### PR TITLE
hack: effectively disable pagination with suspense

### DIFF
--- a/src/hooks/api/useConstellations.ts
+++ b/src/hooks/api/useConstellations.ts
@@ -42,7 +42,7 @@ export function useConstellations(pageSize = 25, enabled = true) {
  * Use inside a <Suspense> boundary. No isLoading or error states are returned.
  * Note: Suspense hooks do not support the 'enabled' option.
  */
-export function useConstellationsSuspense(pageSize = 25) {
+export function useConstellationsSuspense(pageSize = 500) {
   const api = useMeshtasticApi();
 
   const query = useSuspenseInfiniteQuery<PaginatedResponse<Constellation>, Error>({

--- a/src/hooks/api/useMessages.ts
+++ b/src/hooks/api/useMessages.ts
@@ -82,7 +82,7 @@ export function useMessage(id: string, enabled = true) {
  */
 export function useMessagesSuspense(options?: UseMessagesOptions) {
   const api = useMeshtasticApi();
-  const pageSize = options?.pageSize || 25;
+  const pageSize = options?.pageSize || 250;
 
   const messagesQuery = useSuspenseInfiniteQuery<TextMessageResponse, Error>({
     queryKey: ['messages', options?.channelId, options?.constellationId, pageSize],

--- a/src/hooks/api/useNodes.ts
+++ b/src/hooks/api/useNodes.ts
@@ -250,7 +250,7 @@ export function useNodeSearch() {
  */
 export function useNodesSuspense(options?: UseNodesOptions) {
   const api = useMeshtasticApi();
-  const pageSize = options?.pageSize || 25;
+  const pageSize = options?.pageSize || 500;
 
   const nodesQuery = useSuspenseInfiniteQuery<PaginatedResponse<ObservedNode>, Error>({
     refetchInterval: 1000 * 60, // 1 minute
@@ -282,7 +282,7 @@ export function useNodesSuspense(options?: UseNodesOptions) {
 /**
  * Suspense-enabled hook to fetch managed nodes with pagination
  */
-export function useManagedNodesSuspense(pageSize = 25) {
+export function useManagedNodesSuspense(pageSize = 500) {
   const api = useMeshtasticApi();
   const managedNodesQuery = useSuspenseInfiniteQuery<PaginatedResponse<ManagedNode>, Error>({
     refetchInterval: 1000 * 60, // 1 minute
@@ -311,7 +311,7 @@ export function useManagedNodesSuspense(pageSize = 25) {
 /**
  * Suspense-enabled hook to fetch user's managed nodes with pagination
  */
-export function useMyManagedNodesSuspense(pageSize = 25) {
+export function useMyManagedNodesSuspense(pageSize = 500) {
   const api = useMeshtasticApi();
   const myManagedNodesQuery = useSuspenseInfiniteQuery<PaginatedResponse<OwnedManagedNode>, Error>({
     refetchInterval: 1000 * 60, // 1 minute
@@ -340,7 +340,7 @@ export function useMyManagedNodesSuspense(pageSize = 25) {
 /**
  * Suspense-enabled hook to fetch user's claimed nodes with pagination
  */
-export function useMyClaimedNodesSuspense(pageSize = 25) {
+export function useMyClaimedNodesSuspense(pageSize = 500) {
   const api = useMeshtasticApi();
   const myClaimedNodesQuery = useSuspenseInfiniteQuery<PaginatedResponse<ObservedNode>, Error>({
     refetchInterval: 1000 * 60, // 1 minute


### PR DESCRIPTION
This is a hack until I can revert some of the suspense stuff

suspense was loading page 1 of data, then rendering the screen, then loading more data, but the ui was never being updated