### PR TITLE
fix: default chart timespan is 2d, but label says 7d

### DIFF
--- a/src/pages/nodes/MeshInfrastructure.tsx
+++ b/src/pages/nodes/MeshInfrastructure.tsx
@@ -82,7 +82,7 @@ function MeshInfrastructureContent() {
   const [includeClientBase, setIncludeClientBase] = useState(false);
   const [chartTimeRangeLabel, setChartTimeRangeLabel] = useState('7d');
   const [chartDateRange, setChartDateRange] = useState<{ startDate: Date; endDate: Date }>({
-    startDate: new Date(Date.now() - 48 * 60 * 60 * 1000),
+    startDate: new Date(Date.now() - 7 * 24 * 60 * 60 * 1000), // 7 days ago
     endDate: new Date(),
   });
 


### PR DESCRIPTION
# Summary
Fix the default time range of the charts on the Mesh Infrastructure page. Previously they were actually showing 48h of data, but the label was saying 7d

## Testing performed

* Manual inspection