### PR TITLE
refactor: remove node.sw_version field globally

### DIFF
--- a/src/components/nodes/NodeDetailContent.tsx
+++ b/src/components/nodes/NodeDetailContent.tsx
@@ -134,9 +134,6 @@ export function NodeDetailContent({ nodeId, compact = false }: NodeDetailContent
               <p>
                 <span className="font-medium">Hardware Model:</span> {node.hw_model ?? '—'}
               </p>
-              <p>
-                <span className="font-medium">Meshtastic Version:</span> {node.sw_version ?? '—'}
-              </p>
               {roleLabel && (
                 <p>
                   <span className="font-medium">Role:</span> {roleLabel}

--- a/src/lib/models.ts
+++ b/src/lib/models.ts
@@ -25,7 +25,6 @@ export interface ObservedNode {
   long_name: string | null;
   short_name: string | null;
   hw_model: string | null;
-  sw_version: string | null;
   public_key: string | null;
   role?: number | null;
   is_licensed?: boolean | null;


### PR DESCRIPTION
# Summary

Remove the `sw_version` field from the UI. Aligns with the meshflow-api change that removes this field from the API, since it has never been used and is not part of the Meshtastic spec.

Changes:
- Remove `sw_version` from `ObservedNode` interface in `models.ts`
- Remove the "Meshtastic Version:" row from the node detail Basic Information card in `NodeDetailContent.tsx`

## Testing performed

* UI build verified (`npm run build`)
