### PR TITLE
feat: add packet source stats pie chart and table

### DIFF
--- a/src/components/NeighbourPieChart.tsx
+++ b/src/components/NeighbourPieChart.tsx
@@ -1,0 +1,226 @@
+'use client';
+
+import * as React from 'react';
+import { Link } from 'react-router-dom';
+import { Cell, Legend, Pie, PieChart } from 'recharts';
+import { useNeighbourStats } from '@/hooks/api/usePacketStats';
+import { subDays } from 'date-fns';
+import { TimeRangeSelect, TimeRangeOption } from '@/components/TimeRangeSelect';
+import { Card, CardContent, CardDescription, CardHeader, CardTitle } from '@/components/ui/card';
+import { ChartConfig, ChartContainer, ChartTooltip, ChartTooltipContent } from '@/components/ui/chart';
+import { NeighbourStatsBySource } from '@/lib/models';
+
+interface NeighbourPieChartProps {
+  nodeId: number;
+  defaultTimeRange?: string;
+  config?: ChartConfig;
+}
+
+const CHART_COLORS = [
+  '#3b82f6', // blue-500
+  '#10b981', // emerald-500
+  '#f59e0b', // amber-500
+  '#8b5cf6', // violet-500
+  '#ec4899', // pink-500
+  '#ef4444', // red-500
+  '#06b6d4', // cyan-500
+  '#84cc16', // lime-500
+  '#6b7280', // gray-500
+];
+
+const TIME_RANGE_OPTIONS: TimeRangeOption[] = [
+  { key: '1h', label: 'Last hour' },
+  { key: '24h', label: 'Last 24 hours' },
+  { key: '7d', label: 'Last 7 days' },
+];
+
+const LSB_EXPLANATION =
+  "For multi-hop packets, the radio header only stores the last byte (LSB) of the relay node's ID to save bandwidth. Several nodes can share the same last byte, so we list all possible matches from nodes we've seen on the mesh.";
+
+const getInitialDateRange = () => {
+  const endDate = new Date();
+  const startDate = subDays(endDate, 1);
+  return { startDate, endDate };
+};
+
+function getLabel(item: NeighbourStatsBySource): string {
+  if (item.source_type === 'full' && item.candidates.length > 0) {
+    const c = item.candidates[0];
+    return c.short_name || c.node_id_str;
+  }
+  if (item.source_type === 'lsb' && item.candidates.length === 1) {
+    const c = item.candidates[0];
+    return c.short_name || c.node_id_str;
+  }
+  if (item.source_type === 'lsb') {
+    return `LSB ${item.source}`;
+  }
+  return item.candidates[0]?.node_id_str ?? `Source ${item.source}`;
+}
+
+export function NeighbourPieChart({
+  nodeId,
+  defaultTimeRange = '24h',
+  config = {
+    value: {
+      theme: {
+        light: 'var(--color-value)',
+        dark: 'var(--color-value)',
+      },
+    },
+  },
+}: NeighbourPieChartProps) {
+  const [timeRange, setTimeRange] = React.useState(defaultTimeRange);
+  const [dateRange, setDateRange] = React.useState(getInitialDateRange);
+
+  const {
+    data: stats,
+    isLoading,
+    error,
+  } = useNeighbourStats({
+    nodeId,
+    startDate: dateRange.startDate,
+    endDate: dateRange.endDate,
+    enabled: true,
+  });
+
+  const chartData = React.useMemo(() => {
+    if (!stats?.by_source?.length) return [];
+    return stats.by_source.map((item, index) => ({
+      ...item,
+      name: getLabel(item),
+      value: item.count,
+      fill: CHART_COLORS[index % CHART_COLORS.length],
+    }));
+  }, [stats]);
+
+  const handleTimeRangeChange = React.useCallback((value: string, newDateRange: { startDate: Date; endDate: Date }) => {
+    setTimeRange(value);
+    setDateRange(newDateRange);
+  }, []);
+
+  const maxCount = chartData.length > 0 ? Math.max(...chartData.map((d) => d.count)) : 0;
+
+  if (isLoading) {
+    return (
+      <Card>
+        <CardHeader>
+          <CardTitle>Packets by source</CardTitle>
+          <CardDescription>Loading…</CardDescription>
+        </CardHeader>
+        <CardContent>
+          <div className="h-[200px] flex items-center justify-center bg-muted rounded-md">
+            <div className="animate-spin rounded-full h-8 w-8 border-t-2 border-b-2 border-teal-500" />
+          </div>
+        </CardContent>
+      </Card>
+    );
+  }
+
+  if (error) {
+    return (
+      <Card>
+        <CardHeader>
+          <CardTitle>Packets by source</CardTitle>
+          <CardDescription>Failed to load</CardDescription>
+        </CardHeader>
+        <CardContent>
+          <p className="text-destructive">{error.message}</p>
+        </CardContent>
+      </Card>
+    );
+  }
+
+  return (
+    <Card className="@container/card">
+      <CardHeader className="relative">
+        <CardTitle>Packets by source</CardTitle>
+        <CardDescription>Packets received from each neighbour (direct or last hop)</CardDescription>
+        <div className="absolute right-4 top-4 flex items-center gap-2">
+          <TimeRangeSelect options={TIME_RANGE_OPTIONS} value={timeRange} onChange={handleTimeRangeChange} />
+        </div>
+      </CardHeader>
+      <CardContent className="px-2 pt-4 sm:px-6 sm:pt-6 space-y-4">
+        {chartData.length > 0 ? (
+          <>
+            <ChartContainer className="aspect-auto h-[250px] w-full" config={config}>
+              <PieChart>
+                <Pie
+                  data={chartData}
+                  dataKey="value"
+                  nameKey="name"
+                  cx="50%"
+                  cy="50%"
+                  innerRadius={50}
+                  outerRadius={80}
+                  paddingAngle={2}
+                  label={({ name, percent }) => `${name} ${(percent * 100).toFixed(0)}%`}
+                >
+                  {chartData.map((entry, index) => (
+                    <Cell key={`cell-${index}`} fill={entry.fill} />
+                  ))}
+                </Pie>
+                <ChartTooltip
+                  content={
+                    <ChartTooltipContent
+                      formatter={(value) => [`${value} packets`, '']}
+                      labelFormatter={(label, payload) => {
+                        const item = payload?.[0]?.payload as (typeof chartData)[0] | undefined;
+                        return item?.candidates?.length ? `${label} (${item.candidates.length} candidate(s))` : label;
+                      }}
+                    />
+                  }
+                />
+                <Legend />
+              </PieChart>
+            </ChartContainer>
+
+            <div className="rounded-md border border-border p-3 bg-muted/30">
+              <p className="text-sm text-muted-foreground mb-3">{LSB_EXPLANATION}</p>
+            </div>
+
+            <div className="space-y-2">
+              <div className="text-sm font-medium">By source</div>
+              <div className="space-y-2">
+                {chartData.map((item, index) => (
+                  <div key={index} className="flex flex-col gap-1">
+                    <div className="flex items-center justify-between gap-2">
+                      <span className="text-sm font-medium shrink-0">{getLabel(item)}</span>
+                      <span className="text-sm text-muted-foreground">{item.count} packets</span>
+                    </div>
+                    <div className="h-2 rounded-full bg-muted overflow-hidden" style={{ width: '100%' }}>
+                      <div
+                        className="h-full rounded-full"
+                        style={{
+                          width: `${maxCount > 0 ? (item.count / maxCount) * 100 : 0}%`,
+                          backgroundColor: item.fill,
+                        }}
+                      />
+                    </div>
+                    {item.candidates.length > 0 && (
+                      <div className="flex flex-wrap gap-1 mt-1">
+                        {item.candidates.map((c) => (
+                          <Link
+                            key={c.node_id}
+                            to={`/nodes/${c.node_id}`}
+                            className="text-xs text-teal-600 dark:text-teal-400 hover:underline px-1.5 py-0.5 rounded bg-muted"
+                          >
+                            {c.short_name || c.node_id_str}
+                          </Link>
+                        ))}
+                      </div>
+                    )}
+                  </div>
+                ))}
+              </div>
+            </div>
+          </>
+        ) : (
+          <div className="flex h-[250px] items-center justify-center rounded-md bg-muted">
+            <p className="text-muted-foreground">No packet data in this time range</p>
+          </div>
+        )}
+      </CardContent>
+    </Card>
+  );
+}

--- a/src/components/nodes/NodeDetailContent.tsx
+++ b/src/components/nodes/NodeDetailContent.tsx
@@ -4,6 +4,7 @@ import { useRecentNodes } from '@/hooks/useRecentNodes';
 import { formatDistanceToNow } from 'date-fns';
 import { formatUptimeSeconds } from '@/lib/utils';
 import { BatteryChartShadcn } from '@/components/BatteryChartShadcn';
+import { NeighbourPieChart } from '@/components/NeighbourPieChart';
 import { PacketTypeChart } from '@/components/PacketTypeChart';
 import { ReceivedPacketTypeChart } from '@/components/ReceivedPacketTypeChart';
 import { NodesMap } from '@/components/nodes/NodesMap';
@@ -21,6 +22,34 @@ interface NodeDetailContentProps {
   nodeId: number;
   /** When true, hide the "Back to Nodes" link (e.g. when shown in slide-over) */
   compact?: boolean;
+}
+
+function NeighbourStatsSection({ nodeId }: { nodeId: number }) {
+  const [showChart, setShowChart] = useState(false);
+
+  if (!showChart) {
+    return (
+      <div className="mb-6">
+        <Card>
+          <CardHeader>
+            <CardTitle>Packets by source</CardTitle>
+            <CardDescription>Packets received from each neighbour (direct or last hop). Click to load.</CardDescription>
+          </CardHeader>
+          <CardContent>
+            <Button onClick={() => setShowChart(true)} variant="outline">
+              Load packets by source
+            </Button>
+          </CardContent>
+        </Card>
+      </div>
+    );
+  }
+
+  return (
+    <div className="mb-6">
+      <NeighbourPieChart nodeId={nodeId} defaultTimeRange={'24h'} />
+    </div>
+  );
 }
 
 export function NodeDetailContent({ nodeId, compact = false }: NodeDetailContentProps) {
@@ -325,25 +354,28 @@ export function NodeDetailContent({ nodeId, compact = false }: NodeDetailContent
           </div>
 
           {isManagedNode && (
-            <div className="mb-6">
-              <Suspense
-                fallback={
-                  <Card>
-                    <CardHeader>
-                      <CardTitle>Received Packets</CardTitle>
-                      <CardDescription>Loading chart…</CardDescription>
-                    </CardHeader>
-                    <CardContent>
-                      <div className="h-[200px] flex items-center justify-center bg-muted rounded-md">
-                        <div className="animate-spin rounded-full h-8 w-8 border-t-2 border-b-2 border-teal-500" />
-                      </div>
-                    </CardContent>
-                  </Card>
-                }
-              >
-                <ReceivedPacketTypeChart nodeId={nodeId} defaultTimeRange={'48h'} />
-              </Suspense>
-            </div>
+            <>
+              <div className="mb-6">
+                <Suspense
+                  fallback={
+                    <Card>
+                      <CardHeader>
+                        <CardTitle>Received Packets</CardTitle>
+                        <CardDescription>Loading chart…</CardDescription>
+                      </CardHeader>
+                      <CardContent>
+                        <div className="h-[200px] flex items-center justify-center bg-muted rounded-md">
+                          <div className="animate-spin rounded-full h-8 w-8 border-t-2 border-b-2 border-teal-500" />
+                        </div>
+                      </CardContent>
+                    </Card>
+                  }
+                >
+                  <ReceivedPacketTypeChart nodeId={nodeId} defaultTimeRange={'48h'} />
+                </Suspense>
+              </div>
+              <NeighbourStatsSection nodeId={nodeId} />
+            </>
           )}
         </>
       )}

--- a/src/hooks/api/usePacketStats.ts
+++ b/src/hooks/api/usePacketStats.ts
@@ -1,6 +1,6 @@
 import { useQuery, useSuspenseQuery } from '@tanstack/react-query';
 import { useMeshtasticApi } from './useApi';
-import { GlobalStats } from '@/lib/models';
+import { GlobalStats, NeighbourStats } from '@/lib/models';
 import { StatsQueryParams } from '@/lib/types';
 import { getKeyValue, roundDateParams } from './hooks-utils';
 
@@ -95,6 +95,74 @@ export function useReceivedPacketStatsSuspense(params?: StatsQueryParams) {
           },
         };
       }
+    },
+  });
+
+  return {
+    stats: query.data,
+  };
+}
+
+type NeighbourStatsParams = StatsQueryParams & { nodeId: number; enabled?: boolean };
+
+/**
+ * Hook to fetch neighbour stats for a managed node (lazy-loadable via enabled).
+ */
+export function useNeighbourStats(params?: NeighbourStatsParams) {
+  const api = useMeshtasticApi();
+  const enabled = params?.enabled ?? true;
+  const queryParams: (StatsQueryParams & { nodeId: number }) | undefined = params
+    ? { ...params, nodeId: params.nodeId }
+    : undefined;
+  const roundedParams = roundDateParams(queryParams);
+  const nodeId = roundedParams?.nodeId ?? params?.nodeId ?? 0;
+  const keyValue = getKeyValue(roundedParams);
+  const key = ['neighbour-stats', nodeId, keyValue];
+
+  return useQuery<NeighbourStats, Error>({
+    refetchInterval: 5 * 1000 * 60, // 5 minutes
+    queryKey: key,
+    queryFn: async () => {
+      const startDate = roundedParams?.startDate ?? params?.startDate;
+      const endDate = roundedParams?.endDate ?? params?.endDate;
+      if (!nodeId) {
+        return {
+          start_date: null,
+          end_date: null,
+          by_source: [],
+          total_packets: 0,
+        };
+      }
+      return api.getNodeNeighbourStats(nodeId, { startDate, endDate });
+    },
+    enabled: enabled && !!nodeId,
+  });
+}
+
+/**
+ * Suspense-enabled hook to fetch neighbour stats for a managed node
+ * Use inside a <Suspense> boundary. No isLoading or error states are returned.
+ */
+export function useNeighbourStatsSuspense(params?: StatsQueryParams & { nodeId: number }) {
+  const api = useMeshtasticApi();
+  params = roundDateParams(params);
+  const keyValue = getKeyValue(params);
+  const key = ['neighbour-stats', params?.nodeId ?? 0, keyValue];
+
+  const query = useSuspenseQuery<NeighbourStats, Error>({
+    refetchInterval: 5 * 1000 * 60, // 5 minutes
+    queryKey: key,
+    queryFn: async () => {
+      const { startDate, endDate, nodeId } = params || {};
+      if (!nodeId) {
+        return {
+          start_date: null,
+          end_date: null,
+          by_source: [],
+          total_packets: 0,
+        };
+      }
+      return api.getNodeNeighbourStats(nodeId, { startDate, endDate });
     },
   });
 

--- a/src/lib/api/meshtastic-api.ts
+++ b/src/lib/api/meshtastic-api.ts
@@ -8,6 +8,7 @@ import {
   NodeSearchResult,
   PaginatedResponse,
   GlobalStats,
+  NeighbourStats,
   Constellation,
   MessageChannel,
   TextMessage,
@@ -431,5 +432,16 @@ export class MeshtasticApi extends BaseApi {
         end_date: new Date(interval.end_date).toISOString(),
       })),
     };
+  }
+
+  /**
+   * Get neighbour stats (packets received by source node) for a managed node
+   */
+  async getNodeNeighbourStats(nodeId: number, params?: DateRangeParams): Promise<NeighbourStats> {
+    const searchParams = new URLSearchParams();
+    if (params?.startDate) searchParams.append('start_date', params.startDate.toISOString());
+    if (params?.endDate) searchParams.append('end_date', params.endDate.toISOString());
+
+    return this.get(`/stats/nodes/${nodeId}/neighbours/`, searchParams);
   }
 }

--- a/src/lib/models.ts
+++ b/src/lib/models.ts
@@ -201,6 +201,26 @@ export interface PacketStats {
   intervals: PacketStatsInterval[];
 }
 
+export interface NeighbourStatsCandidate {
+  node_id: number;
+  node_id_str: string;
+  short_name: string | null;
+}
+
+export interface NeighbourStatsBySource {
+  source: number;
+  source_type: 'lsb' | 'full';
+  count: number;
+  candidates: NeighbourStatsCandidate[];
+}
+
+export interface NeighbourStats {
+  start_date: string | null;
+  end_date: string | null;
+  by_source: NeighbourStatsBySource[];
+  total_packets: number;
+}
+
 export interface MessageChannel {
   id: number;
   name: string;


### PR DESCRIPTION
# Summary

Add "Packets by source" section to the Node Details page for managed nodes. Shows a pie chart and bar table of packets received from each neighbour (direct sender or last-hop relay). Lazy-loaded behind a "Load" button to avoid heavy API calls until the user requests them.

**Features**:
- **Lazy load**: "Packets by source" card with Load button; chart and table load only after click
- **Pie chart + bar table**: Packets grouped by source with horizontal bars and clickable candidate links
- **LSB explanation**: Plain-English note explaining why some sources show multiple candidate nodes (1-byte header ambiguity)
- **Candidates**: For LSB sources, lists all possible nodes; each candidate links to Node Details

**Components**:
- `NeighbourPieChart`: Uses `useNeighbourStats` with `enabled`; time range selector (1h, 24h, 7d)
- `NodeDetailContent`: Collapsible "Packets by source" section with Load button
- `useNeighbourStats`: Non-Suspense hook with `enabled` for lazy loading

## Background

The API returns `source_type` ("lsb" | "full") and `candidates` for each source. LSB sources can have multiple candidates because the radio header stores only the last byte of the relay node ID. The UI explains this and shows all candidates with links to their node pages.

## Testing performed

* UI build verified (`npm run build`)
* Manually verified lazy load and chart rendering on Node Details page
