### PR TITLE
feat: respect allow_auto_tr field

### DIFF
--- a/src/lib/models.ts
+++ b/src/lib/models.ts
@@ -54,6 +54,7 @@ export interface ManagedNode {
     name?: string;
     map_color?: string;
   };
+  allow_auto_traceroute?: boolean;
   position: {
     latitude: number | null;
     longitude: number | null;

--- a/src/pages/traceroutes/TracerouteHistory.tsx
+++ b/src/pages/traceroutes/TracerouteHistory.tsx
@@ -51,6 +51,7 @@ export function TracerouteHistory() {
   const { data: canTriggerData } = useCanTriggerTraceroute();
   const canTrigger = canTriggerData?.can_trigger ?? false;
   const { managedNodes } = useManagedNodesSuspense(500);
+  const tracerouteEligibleNodes = managedNodes.filter((n) => n.allow_auto_traceroute === true);
   const { nodes: observedNodes } = useNodesSuspense({
     lastHeardAfter: subDays(new Date(), 7),
     pageSize: 500,
@@ -163,7 +164,7 @@ export function TracerouteHistory() {
                               targetNodeId: tr.target_node.node_id,
                             })
                           }
-                          disabled={triggerMutation.isPending}
+                          disabled={triggerMutation.isPending || tr.source_node.allow_auto_traceroute === false}
                           title="Repeat this traceroute"
                           aria-label="Repeat traceroute"
                         >
@@ -189,7 +190,7 @@ export function TracerouteHistory() {
         open={triggerModalOpen}
         onOpenChange={setTriggerModalOpen}
         mode={triggerMode}
-        managedNodes={managedNodes}
+        managedNodes={tracerouteEligibleNodes}
         observedNodes={observedNodes}
         onTrigger={async (managedNodeId, targetNodeId) => {
           await triggerMutation.mutateAsync({ managedNodeId, targetNodeId });


### PR DESCRIPTION
# Summary

Support `allow_auto_traceroute` on managed nodes so the traceroute trigger UI only shows and allows triggering from eligible devices.

**Changes:**
- `ManagedNode` model: added optional `allow_auto_traceroute?: boolean`
- Traceroute history page: filters managed nodes to `allow_auto_traceroute === true` before passing to `TriggerTracerouteModal`
- Repeat traceroute button: disabled when `source_node.allow_auto_traceroute === false`

**Requires:** API changes in meshflow-api (managed nodes API returns `allow_auto_traceroute`).

## Testing performed

- Manual verification: trigger modal shows only nodes with `allow_auto_traceroute` enabled
- Repeat button disabled for traceroutes whose source node has `allow_auto_traceroute=false`
