### PR TITLE
feat: add WebSocket support for real-time traceroute updates

### DIFF
--- a/src/hooks/useTraceroutesWithWebSocket.ts
+++ b/src/hooks/useTraceroutesWithWebSocket.ts
@@ -1,0 +1,46 @@
+import { useEffect, useRef } from 'react';
+import { useQueryClient } from '@tanstack/react-query';
+import { useConfig } from '@/providers/ConfigProvider';
+import { authService } from '@/lib/auth/authService';
+import { useTraceroutes, UseTraceroutesParams } from '@/hooks/api/useTraceroutes';
+
+/**
+ * Hook to fetch traceroutes and subscribe to real-time status updates via WebSocket.
+ * Connects to ws/traceroutes/ when mounted; invalidates traceroutes query on status updates.
+ */
+export function useTraceroutesWithWebSocket(params?: UseTraceroutesParams) {
+  const queryClient = useQueryClient();
+  const config = useConfig();
+  const socketRef = useRef<WebSocket | null>(null);
+
+  const result = useTraceroutes(params);
+
+  useEffect(() => {
+    const token = authService.getAccessToken();
+    if (!token || !config.apis.meshBot.baseUrl) return;
+
+    const baseUrl = config.apis.meshBot.baseUrl.replace(/^http/, 'ws');
+    const wsUrl = `${baseUrl}/ws/traceroutes/?token=${token}`;
+
+    const socket = new WebSocket(wsUrl);
+    socketRef.current = socket;
+
+    socket.onmessage = (event) => {
+      try {
+        const data = JSON.parse(event.data) as { id: number; status: string };
+        if (data.id != null && data.status) {
+          queryClient.invalidateQueries({ queryKey: ['traceroutes'] });
+        }
+      } catch {
+        // ignore parse errors
+      }
+    };
+
+    return () => {
+      socket.close();
+      socketRef.current = null;
+    };
+  }, [config.apis.meshBot.baseUrl, queryClient]);
+
+  return result;
+}

--- a/src/pages/traceroutes/TracerouteHistory.tsx
+++ b/src/pages/traceroutes/TracerouteHistory.tsx
@@ -5,7 +5,9 @@ import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card';
 import { Button } from '@/components/ui/button';
 import { Table, TableBody, TableCell, TableHead, TableHeader, TableRow } from '@/components/ui/table';
 import { Badge } from '@/components/ui/badge';
-import { useTraceroutes, useCanTriggerTraceroute, useTriggerTraceroute } from '@/hooks/api/useTraceroutes';
+import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from '@/components/ui/select';
+import { useTraceroutesWithWebSocket } from '@/hooks/useTraceroutesWithWebSocket';
+import { useCanTriggerTraceroute, useTriggerTraceroute } from '@/hooks/api/useTraceroutes';
 import { useManagedNodesSuspense, useNodesSuspense } from '@/hooks/api/useNodes';
 import { TriggerTracerouteModal } from './TriggerTracerouteModal';
 import { TracerouteDetailModal } from './TracerouteDetailModal';
@@ -39,13 +41,17 @@ function StatusBadge({ status }: { status: string }) {
 }
 
 export function TracerouteHistory() {
-  const [successFilter, setSuccessFilter] = useState<boolean | null>(true);
+  const [tabFilter, setTabFilter] = useState<'success' | 'all'>('success');
+  const [sourceNodeId, setSourceNodeId] = useState<number | null>(null);
+  const [targetNodeId, setTargetNodeId] = useState<number | null>(null);
   const [triggerModalOpen, setTriggerModalOpen] = useState(false);
   const [triggerMode, setTriggerMode] = useState<'user' | 'auto'>('user');
   const [selectedTracerouteId, setSelectedTracerouteId] = useState<number | null>(null);
 
-  const { data, isLoading, error } = useTraceroutes({
-    status: successFilter === true ? 'completed' : successFilter === false ? 'failed' : undefined,
+  const { data, isLoading, error } = useTraceroutesWithWebSocket({
+    status: tabFilter === 'success' ? 'completed,pending,sent' : undefined,
+    source_node: sourceNodeId ?? undefined,
+    target_node: targetNodeId ?? undefined,
     page_size: 50,
   });
   const { data: canTriggerData } = useCanTriggerTraceroute();
@@ -85,28 +91,49 @@ export function TracerouteHistory() {
           )}
         </CardHeader>
         <CardContent>
-          <div className="mb-4 flex gap-2">
+          <div className="mb-4 flex flex-wrap gap-2 items-center">
             <Button
-              variant={successFilter === true ? 'default' : 'outline'}
+              variant={tabFilter === 'success' ? 'default' : 'outline'}
               size="sm"
-              onClick={() => setSuccessFilter(true)}
+              onClick={() => setTabFilter('success')}
             >
               Success
             </Button>
-            <Button
-              variant={successFilter === false ? 'default' : 'outline'}
-              size="sm"
-              onClick={() => setSuccessFilter(false)}
-            >
-              Failed
-            </Button>
-            <Button
-              variant={successFilter === null ? 'default' : 'outline'}
-              size="sm"
-              onClick={() => setSuccessFilter(null)}
-            >
+            <Button variant={tabFilter === 'all' ? 'default' : 'outline'} size="sm" onClick={() => setTabFilter('all')}>
               All
             </Button>
+            <Select
+              value={sourceNodeId != null ? String(sourceNodeId) : 'all'}
+              onValueChange={(v) => setSourceNodeId(v === 'all' ? null : parseInt(v, 10))}
+            >
+              <SelectTrigger className="w-[180px]">
+                <SelectValue placeholder="Source (sender)" />
+              </SelectTrigger>
+              <SelectContent>
+                <SelectItem value="all">All sources</SelectItem>
+                {tracerouteEligibleNodes.map((n) => (
+                  <SelectItem key={n.node_id} value={String(n.node_id)}>
+                    {n.short_name ?? n.node_id_str ?? String(n.node_id)}
+                  </SelectItem>
+                ))}
+              </SelectContent>
+            </Select>
+            <Select
+              value={targetNodeId != null ? String(targetNodeId) : 'all'}
+              onValueChange={(v) => setTargetNodeId(v === 'all' ? null : parseInt(v, 10))}
+            >
+              <SelectTrigger className="w-[180px]">
+                <SelectValue placeholder="Target (recipient)" />
+              </SelectTrigger>
+              <SelectContent>
+                <SelectItem value="all">All targets</SelectItem>
+                {observedNodes.map((n) => (
+                  <SelectItem key={n.node_id} value={String(n.node_id)}>
+                    {n.short_name ?? n.node_id_str ?? String(n.node_id)}
+                  </SelectItem>
+                ))}
+              </SelectContent>
+            </Select>
           </div>
 
           {isLoading && <div className="py-8 text-center text-muted-foreground">Loading...</div>}


### PR DESCRIPTION
# Summary

Traceroute page improvements: tabs, filters, and real-time status updates.

**Tabs:**
- Success: `status=completed,pending,sent` (completed + in-flight)
- All: no status filter
- Removed Failed tab

**Filters:**
- Source (sender): dropdown of managed nodes with `allow_auto_traceroute`
- Target (recipient): dropdown of observed nodes (last 7 days)

**Real-time refresh:**
- New `useTraceroutesWithWebSocket` hook connects to `ws/traceroutes/` when page mounts
- Invalidates traceroutes query when TR status changes (completed or failed)
- Page updates automatically when TRs finish or time out

**Requires:** API changes in meshflow-api (comma-separated status, `ws/traceroutes/` WebSocket, `allow_auto_traceroute` on managed nodes).

## Testing performed

- Manual verification: tabs, filters, real-time refresh when TR completes or times out
- Build passes
