### PR TITLE
build: Mapbox token via docker env vars

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -4,6 +4,8 @@
 # Mapbox access token for the Traceroute Heatmap page.
 # Required for /traceroutes/heatmap. Get a token at https://account.mapbox.com/
 # Scopes: styles:read, fonts:read, tiles:read
+# - VITE_MAPBOX_TOKEN: local dev (build-time)
+# - MAPBOX_TOKEN: Docker runtime (injected into config.json at container startup)
 VITE_MAPBOX_TOKEN=pk.your_mapbox_public_token_here
 
 # API configuration is primarily loaded from public/config.json (or defaults in config.ts).

--- a/config.ts
+++ b/config.ts
@@ -7,6 +7,7 @@ const VERSION = 'development';
 // Default configuration
 const defaultConfig: AppConfig = {
   version: VERSION,
+  mapboxToken: import.meta.env.VITE_MAPBOX_TOKEN as string | undefined,
   apis: {
     meshBot: {
       baseUrl: 'http://localhost:8000',
@@ -40,6 +41,7 @@ async function fetchConfig(): Promise<AppConfig> {
     // Deep merge the configs, with remote config taking precedence
     return {
       version: VERSION,
+      mapboxToken: remoteConfig.mapboxToken ?? defaultConfig.mapboxToken,
       apis: {
         meshBot: {
           ...defaultConfig.apis.meshBot,

--- a/deploy/docker/entrypoint.sh
+++ b/deploy/docker/entrypoint.sh
@@ -3,6 +3,7 @@
 # Create config.json from environment variables
 cat > /usr/share/nginx/html/config.json << EOF
 {
+  "mapboxToken": "${MAPBOX_TOKEN:-}",
   "apis": {
     "meshBot": {
       "baseUrl": "${MESHBOT_API_URL:-http://localhost:8000}",

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -27,6 +27,7 @@ services:
       - MAP_DEFAULT_CENTER_LAT=0
       - MAP_DEFAULT_CENTER_LNG=0
       - MAP_DEFAULT_ZOOM=2
+      - MAPBOX_TOKEN=
       - NODE_ENV=production
     ports:
       - '5175:80'

--- a/src/components/traceroutes/TracerouteHeatmapMap.tsx
+++ b/src/components/traceroutes/TracerouteHeatmapMap.tsx
@@ -5,6 +5,7 @@ import { ArcLayer, ScatterplotLayer, TextLayer } from '@deck.gl/layers';
 import type { PickingInfo } from '@deck.gl/core';
 import 'mapbox-gl/dist/mapbox-gl.css';
 import { Link } from 'react-router-dom';
+import { useConfig } from '@/providers/ConfigProvider';
 import { X } from 'lucide-react';
 import type { HeatmapEdge, HeatmapNode } from '@/hooks/api/useHeatmapEdges';
 
@@ -106,7 +107,8 @@ function NodePopupOverlay({ node, onClose }: { node: HeatmapNode; onClose: () =>
 }
 
 export function TracerouteHeatmapMap({ edges, nodes, intensity = 0.7, showLabels = true }: TracerouteHeatmapMapProps) {
-  const mapboxToken = import.meta.env.VITE_MAPBOX_TOKEN as string | undefined;
+  const config = useConfig();
+  const mapboxToken = config.mapboxToken ?? (import.meta.env.VITE_MAPBOX_TOKEN as string | undefined);
   const [selectedNode, setSelectedNode] = useState<HeatmapNode | null>(null);
 
   const handleClick = useCallback((info: PickingInfo) => {
@@ -183,7 +185,7 @@ export function TracerouteHeatmapMap({ edges, nodes, intensity = 0.7, showLabels
   if (!mapboxToken) {
     return (
       <div className="flex min-h-[400px] items-center justify-center rounded-md border bg-muted/30 text-muted-foreground">
-        Mapbox token required. Set VITE_MAPBOX_TOKEN in your environment.
+        Mapbox token required. Set VITE_MAPBOX_TOKEN (dev) or MAPBOX_TOKEN (Docker) in your environment.
       </div>
     );
   }

--- a/src/lib/types.ts
+++ b/src/lib/types.ts
@@ -40,6 +40,7 @@ export interface ApiConfig {
 
 export interface AppConfig {
   version: string;
+  mapboxToken?: string; // For Mapbox GL; injected at runtime in Docker
   apis: {
     meshBot: ApiConfig;
   };

--- a/src/test/config.test.ts
+++ b/src/test/config.test.ts
@@ -12,6 +12,7 @@ vi.mock('axios', () => ({
 describe('Config', () => {
   const defaultConfig: AppConfig = {
     version: 'development',
+    mapboxToken: undefined,
     apis: {
       meshBot: {
         baseUrl: 'http://localhost:8000',
@@ -37,6 +38,7 @@ describe('Config', () => {
   };
 
   const remoteConfig = {
+    mapboxToken: 'pk.remote-token',
     apis: {
       meshBot: {
         baseUrl: 'https://api.example.com',
@@ -76,6 +78,7 @@ describe('Config', () => {
       // Deep merge the configs, with remote config taking precedence
       return {
         version: 'development',
+        mapboxToken: remoteConfig.mapboxToken ?? defaultConfig.mapboxToken,
         apis: {
           meshBot: {
             ...defaultConfig.apis.meshBot,
@@ -133,6 +136,7 @@ describe('Config', () => {
     expect(config.map.defaultZoom).toBe(5);
     expect(config.refresh.nodesList).toBe(60000);
     expect(config.refresh.nodeDetails).toBe(10000); // From default
+    expect(config.mapboxToken).toBe('pk.remote-token');
   });
 
   it('should handle partial remote config', async () => {
@@ -159,6 +163,7 @@ describe('Config', () => {
     expect(config.map.defaultZoom).toBe(2); // From default
     expect(config.refresh.nodesList).toBe(30000); // From default
     expect(config.refresh.nodeDetails).toBe(10000); // From default
+    expect(config.mapboxToken).toBeUndefined();
   });
 
   it('should cache the config promise', async () => {


### PR DESCRIPTION
# Summary

Add runtime injection of the Mapbox token for Docker deployments. The token can now be passed via the `MAPBOX_TOKEN` environment variable when starting the container, instead of requiring it at build time.

Previously, `VITE_MAPBOX_TOKEN` was baked in at build time, so passing it when running a Docker container had no effect. This change extends the existing `config.json` runtime config pattern: the Docker entrypoint writes `MAPBOX_TOKEN` into `config.json` at container startup, and the Traceroute Heatmap component reads it via `useConfig()`.

## Changes

- **AppConfig** (`src/lib/types.ts`): Added optional `mapboxToken` field
- **config.ts**: Added `mapboxToken` to default config (from `VITE_MAPBOX_TOKEN`) and merge logic for remote `config.json`
- **deploy/docker/entrypoint.sh**: Injects `mapboxToken` from `MAPBOX_TOKEN` env var into generated `config.json`
- **TracerouteHeatmapMap.tsx**: Reads token from `useConfig().mapboxToken` with fallback to `VITE_MAPBOX_TOKEN` for local dev
- **docker-compose.yaml**: Added `MAPBOX_TOKEN` to `app-prod` environment
- **.env.example**: Documented `VITE_MAPBOX_TOKEN` (dev) vs `MAPBOX_TOKEN` (Docker runtime)
- **config.test.ts**: Added `mapboxToken` to test fixtures and assertions

## Testing performed

- `npm test` passes (config tests updated and passing)
- No breaking changes: local dev continues to use `VITE_MAPBOX_TOKEN` in `.env`
