### PR TITLE
feat(nodes): add traceroute links section to NodeDetails page

### DIFF
--- a/src/components/nodes/LinkSNRCharts.tsx
+++ b/src/components/nodes/LinkSNRCharts.tsx
@@ -1,0 +1,189 @@
+import * as React from 'react';
+import { Line, LineChart, CartesianGrid, XAxis, YAxis, Tooltip } from 'recharts';
+import { ChartConfig, ChartContainer, ChartTooltipContent } from '@/components/ui/chart';
+import { Button } from '@/components/ui/button';
+import { ChevronDown } from 'lucide-react';
+import type { NodeTracerouteLinkSnrHistory } from '@/hooks/api/useNodeTracerouteLinks';
+import type { Formatter, Payload } from 'recharts/types/component/DefaultTooltipContent';
+import type { NameType, ValueType } from 'recharts/types/component/DefaultTooltipContent';
+
+interface LinkSNRChartsProps {
+  snrHistory: NodeTracerouteLinkSnrHistory[];
+  /** Number of links to show initially (default 3) */
+  initialVisible?: number;
+  /** Max number of links when expanded; omit to show all links on the map */
+  maxLinks?: number;
+}
+
+const chartConfig: ChartConfig = {
+  inbound: { color: '#3b82f6', label: 'SNR In (dB)' },
+  outbound: { color: '#22c55e', label: 'SNR Out (dB)' },
+};
+
+function mergeSnrPoints(
+  inbound: Array<{ triggered_at: string; snr: number }>,
+  outbound: Array<{ triggered_at: string; snr: number }>
+): Array<{ timestamp: number; inbound?: number; outbound?: number }> {
+  const byTime = new Map<number, { inbound?: number; outbound?: number }>();
+  for (const p of inbound) {
+    const t = new Date(p.triggered_at).getTime();
+    const existing = byTime.get(t) ?? {};
+    existing.inbound = p.snr;
+    byTime.set(t, existing);
+  }
+  for (const p of outbound) {
+    const t = new Date(p.triggered_at).getTime();
+    const existing = byTime.get(t) ?? {};
+    existing.outbound = p.snr;
+    byTime.set(t, existing);
+  }
+  return Array.from(byTime.entries())
+    .map(([timestamp, v]) => ({ timestamp, ...v }))
+    .sort((a, b) => a.timestamp - b.timestamp);
+}
+
+function LinkSNRChart({
+  inbound,
+  outbound,
+}: {
+  inbound: Array<{ triggered_at: string; snr: number }>;
+  outbound: Array<{ triggered_at: string; snr: number }>;
+}) {
+  const chartData = React.useMemo(() => mergeSnrPoints(inbound, outbound), [inbound, outbound]);
+
+  const formatter: Formatter<ValueType, NameType> = (value: ValueType, name: NameType) => {
+    const numValue = typeof value === 'string' ? parseFloat(value) : value;
+    if (typeof numValue !== 'number' || isNaN(numValue)) return ['-', name];
+    return [`${numValue.toFixed(1)} dB`, name];
+  };
+
+  if (chartData.length === 0) {
+    return (
+      <div className="flex h-[120px] items-center justify-center rounded border border-dashed text-xs text-muted-foreground">
+        No data
+      </div>
+    );
+  }
+
+  const minTs = Math.min(...chartData.map((d) => d.timestamp));
+  const maxTs = Math.max(...chartData.map((d) => d.timestamp));
+
+  return (
+    <ChartContainer config={chartConfig} className="aspect-auto h-[120px] w-full min-w-0">
+      <LineChart data={chartData} margin={{ top: 4, right: 4, bottom: 4, left: 4 }}>
+        <CartesianGrid vertical={false} strokeDasharray="2 2" className="opacity-50" />
+        <XAxis
+          dataKey="timestamp"
+          tickLine={false}
+          axisLine={false}
+          tickMargin={4}
+          minTickGap={24}
+          domain={[minTs, maxTs]}
+          tickFormatter={(value: number) => {
+            const date = new Date(value);
+            return date.toLocaleString('en-GB', {
+              month: 'short',
+              day: 'numeric',
+              hour: '2-digit',
+              minute: '2-digit',
+            });
+          }}
+          scale="time"
+          type="number"
+          tick={{ fontSize: 10 }}
+        />
+        <YAxis domain={['auto', 'auto']} tickFormatter={(v) => `${v} dB`} tick={{ fontSize: 10 }} width={36} />
+        <Tooltip
+          content={
+            <ChartTooltipContent
+              labelFormatter={(_, payload: Payload<ValueType, NameType>[]) => {
+                if (payload?.[0]?.payload?.timestamp) {
+                  const date = new Date(payload[0].payload.timestamp);
+                  return date.toLocaleString('en-GB', {
+                    month: 'short',
+                    day: 'numeric',
+                    hour: 'numeric',
+                    minute: 'numeric',
+                  });
+                }
+                return '';
+              }}
+              formatter={formatter}
+            />
+          }
+        />
+        <Line
+          type="monotone"
+          dataKey="inbound"
+          stroke="#3b82f6"
+          strokeWidth={1.5}
+          dot={false}
+          connectNulls
+          name="SNR In"
+        />
+        <Line
+          type="monotone"
+          dataKey="outbound"
+          stroke="#22c55e"
+          strokeWidth={1.5}
+          dot={false}
+          connectNulls
+          name="SNR Out"
+        />
+      </LineChart>
+    </ChartContainer>
+  );
+}
+
+export function LinkSNRCharts({ snrHistory, initialVisible = 3, maxLinks }: LinkSNRChartsProps) {
+  const [expanded, setExpanded] = React.useState(false);
+
+  const allLinksSorted = React.useMemo(() => {
+    const sorted = snrHistory
+      .map((h) => {
+        const inboundTs = h.inbound.map((p) => new Date(p.triggered_at).getTime());
+        const outboundTs = h.outbound.map((p) => new Date(p.triggered_at).getTime());
+        const allTs = [...inboundTs, ...outboundTs];
+        return {
+          ...h,
+          totalPoints: h.inbound.length + h.outbound.length,
+          latestTs: allTs.length ? Math.max(...allTs) : 0,
+        };
+      })
+      .sort((a, b) => b.totalPoints - a.totalPoints || b.latestTs - a.latestTs);
+    return maxLinks != null ? sorted.slice(0, maxLinks) : sorted;
+  }, [snrHistory, maxLinks]);
+
+  const linksToShow = expanded ? allLinksSorted : allLinksSorted.slice(0, initialVisible);
+  const hasMore = allLinksSorted.length > initialVisible;
+  const hiddenCount = allLinksSorted.length - initialVisible;
+
+  if (allLinksSorted.length === 0) {
+    return (
+      <div className="flex h-[120px] items-center justify-center rounded border border-dashed text-sm text-muted-foreground">
+        No SNR history for links
+      </div>
+    );
+  }
+
+  return (
+    <div className="space-y-4">
+      <div className="grid gap-4 sm:grid-cols-2 lg:grid-cols-3">
+        {linksToShow.map((link) => (
+          <div key={link.peer_node_id} className="rounded-lg border p-3">
+            <div className="mb-2 text-sm font-medium text-muted-foreground">
+              Link to {link.peer_short_name || `!${link.peer_node_id.toString(16)}`}
+            </div>
+            <LinkSNRChart inbound={link.inbound} outbound={link.outbound} />
+          </div>
+        ))}
+      </div>
+      {hasMore && !expanded && (
+        <Button variant="outline" size="sm" onClick={() => setExpanded(true)} className="w-full sm:w-auto">
+          <ChevronDown className="mr-1 h-4 w-4" />
+          Show all links ({hiddenCount} more)
+        </Button>
+      )}
+    </div>
+  );
+}

--- a/src/components/nodes/NodeDetailContent.tsx
+++ b/src/components/nodes/NodeDetailContent.tsx
@@ -1,13 +1,17 @@
 import { Link } from 'react-router-dom';
 import { useNodeSuspense, useNodePositions, useManagedNodesSuspense } from '@/hooks/api/useNodes';
+import { useNodeTracerouteLinks } from '@/hooks/api/useNodeTracerouteLinks';
 import { useRecentNodes } from '@/hooks/useRecentNodes';
 import { formatDistanceToNow } from 'date-fns';
+import { subDays, subHours } from 'date-fns';
 import { formatUptimeSeconds } from '@/lib/utils';
 import { BatteryChartShadcn } from '@/components/BatteryChartShadcn';
 import { NeighbourPieChart } from '@/components/NeighbourPieChart';
 import { PacketTypeChart } from '@/components/PacketTypeChart';
 import { ReceivedPacketTypeChart } from '@/components/ReceivedPacketTypeChart';
 import { NodesMap } from '@/components/nodes/NodesMap';
+import { NodeTracerouteLinksMap } from '@/components/nodes/NodeTracerouteLinksMap';
+import { LinkSNRCharts } from '@/components/nodes/LinkSNRCharts';
 import { BatteryGauge } from '@/components/nodes/BatteryGauge';
 import { PercentGauge } from '@/components/nodes/PercentGauge';
 import { Card, CardHeader, CardTitle, CardContent, CardDescription } from '@/components/ui/card';
@@ -15,6 +19,7 @@ import { useState, useEffect, Suspense, useMemo } from 'react';
 import { Button } from '@/components/ui/button';
 import { Pause, Play, CheckCircle, Clock, Copy } from 'lucide-react';
 import { Badge } from '@/components/ui/badge';
+import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from '@/components/ui/select';
 import { authService } from '@/lib/auth/authService';
 import { getRoleLabel } from '@/lib/meshtastic';
 
@@ -22,6 +27,82 @@ interface NodeDetailContentProps {
   nodeId: number;
   /** When true, hide the "Back to Nodes" link (e.g. when shown in slide-over) */
   compact?: boolean;
+}
+
+type TracerouteTimeRange = '24h' | '7d' | '30d';
+
+function TracerouteLinksSection({ nodeId }: { nodeId: number }) {
+  const [timeRange, setTimeRange] = useState<TracerouteTimeRange>('7d');
+  const triggeredAtAfter = useMemo(() => {
+    if (timeRange === '24h') return subHours(new Date(), 24);
+    if (timeRange === '7d') return subDays(new Date(), 7);
+    if (timeRange === '30d') return subDays(new Date(), 30);
+    return undefined;
+  }, [timeRange]);
+
+  const { data, isLoading, error } = useNodeTracerouteLinks(nodeId, { triggeredAtAfter });
+
+  const hasData = data && (data.edges.length > 0 || data.nodes.length > 0);
+
+  return (
+    <div className="mb-6">
+      <Card>
+        <CardHeader className="flex flex-row flex-wrap items-center justify-between gap-4">
+          <div>
+            <CardTitle>Traceroute Links</CardTitle>
+            <CardDescription>
+              Mesh links from traceroutes. Arcs colored by average SNR (green = good, red = poor).
+            </CardDescription>
+          </div>
+          <div className="w-full sm:w-auto sm:min-w-[140px]">
+            <Select value={timeRange} onValueChange={(v) => setTimeRange(v as TracerouteTimeRange)}>
+              <SelectTrigger>
+                <SelectValue />
+              </SelectTrigger>
+              <SelectContent>
+                <SelectItem value="24h">Last 24 hours</SelectItem>
+                <SelectItem value="7d">Last 7 days</SelectItem>
+                <SelectItem value="30d">Last 30 days</SelectItem>
+              </SelectContent>
+            </Select>
+          </div>
+        </CardHeader>
+        <CardContent>
+          {error && (
+            <div className="flex min-h-[200px] items-center justify-center text-destructive text-sm">
+              Failed to load traceroute links: {error instanceof Error ? error.message : 'Unknown error'}
+            </div>
+          )}
+          {isLoading && (
+            <div className="flex min-h-[300px] items-center justify-center text-muted-foreground">
+              <div className="animate-spin rounded-full h-8 w-8 border-t-2 border-b-2 border-teal-500" />
+            </div>
+          )}
+          {!error && !isLoading && !hasData && (
+            <div className="flex min-h-[200px] flex-col items-center justify-center gap-2 text-muted-foreground">
+              <p>No traceroute data for this node</p>
+              <Link to="/traceroutes/heatmap" className="text-sm text-teal-600 dark:text-teal-400 hover:underline">
+                View Traceroute Heatmap
+              </Link>
+            </div>
+          )}
+          {!error && !isLoading && hasData && data && (
+            <>
+              <div className="mb-4 h-[300px] w-full">
+                <NodeTracerouteLinksMap edges={data.edges} nodes={data.nodes} focusNodeId={nodeId} showLabels={true} />
+              </div>
+              {data.snr_history.length > 0 && (
+                <div>
+                  <h4 className="mb-3 text-sm font-medium">SNR over time by link</h4>
+                  <LinkSNRCharts snrHistory={data.snr_history} initialVisible={3} />
+                </div>
+              )}
+            </>
+          )}
+        </CardContent>
+      </Card>
+    </div>
+  );
 }
 
 function NeighbourStatsSection({ nodeId }: { nodeId: number }) {
@@ -313,6 +394,7 @@ export function NodeDetailContent({ nodeId, compact = false }: NodeDetailContent
 
       {!compact && (
         <>
+          <TracerouteLinksSection nodeId={nodeId} />
           <div className="mb-6">
             <Suspense
               fallback={

--- a/src/components/nodes/NodeTracerouteLinksMap.tsx
+++ b/src/components/nodes/NodeTracerouteLinksMap.tsx
@@ -1,0 +1,273 @@
+import { useMemo, useState, useCallback, useEffect } from 'react';
+import { Map, useControl, useMap } from 'react-map-gl';
+import { MapboxOverlay, MapboxOverlayProps } from '@deck.gl/mapbox';
+import { ArcLayer, ScatterplotLayer, TextLayer } from '@deck.gl/layers';
+import type { PickingInfo } from '@deck.gl/core';
+import 'mapbox-gl/dist/mapbox-gl.css';
+import { Link } from 'react-router-dom';
+import { useConfig } from '@/providers/ConfigProvider';
+import { useMapboxStyle } from '@/hooks/useMapboxStyle';
+import { X } from 'lucide-react';
+import type { NodeTracerouteLinkEdge, NodeTracerouteLinkNode } from '@/hooks/api/useNodeTracerouteLinks';
+
+const DEFAULT_CENTER = { longitude: -4.2518, latitude: 55.8642, zoom: 8 };
+const FOCUS_NODE_COLOR: [number, number, number, number] = [34, 197, 94, 255]; // green - focus
+const PEER_NODE_COLOR: [number, number, number, number] = [134, 239, 172, 200]; // light green
+const LOW_SNR_COLOR: [number, number, number, number] = [239, 68, 68, 200]; // red - bad
+const HIGH_SNR_COLOR: [number, number, number, number] = [34, 197, 94, 200]; // green - good
+
+/** Interpolate color by SNR. Higher SNR = greener, lower = redder. */
+function interpolateColorBySnr(snr: number, minSnr: number, maxSnr: number): [number, number, number, number] {
+  if (maxSnr <= minSnr) return LOW_SNR_COLOR;
+  const t = (snr - minSnr) / (maxSnr - minSnr);
+  const r = Math.round(LOW_SNR_COLOR[0] + (HIGH_SNR_COLOR[0] - LOW_SNR_COLOR[0]) * t);
+  const g = Math.round(LOW_SNR_COLOR[1] + (HIGH_SNR_COLOR[1] - LOW_SNR_COLOR[1]) * t);
+  const b = Math.round(LOW_SNR_COLOR[2] + (HIGH_SNR_COLOR[2] - LOW_SNR_COLOR[2]) * t);
+  return [r, g, b, 200];
+}
+
+function DeckGLOverlay(props: MapboxOverlayProps) {
+  const overlay = useControl(() => new MapboxOverlay(props));
+  overlay.setProps(props);
+  return null;
+}
+
+export interface NodeTracerouteLinksMapProps {
+  edges: NodeTracerouteLinkEdge[];
+  nodes: NodeTracerouteLinkNode[];
+  focusNodeId: number;
+  showLabels?: boolean;
+}
+
+function getNodeLabel(node: NodeTracerouteLinkNode): string {
+  return node.short_name || node.long_name || node.node_id_str || `!${node.node_id.toString(16)}`;
+}
+
+function NodePopupOverlay({
+  node,
+  edge,
+  onClose,
+}: {
+  node: NodeTracerouteLinkNode;
+  edge?: NodeTracerouteLinkEdge;
+  onClose: () => void;
+}) {
+  const { current: mapRef } = useMap();
+  const [position, setPosition] = useState<{ x: number; y: number } | null>(null);
+
+  useEffect(() => {
+    const map = mapRef?.getMap?.();
+    if (!map || !mapRef || !node) return;
+
+    const updatePosition = () => {
+      try {
+        const point = mapRef.project([node.lng, node.lat]);
+        setPosition({ x: point.x, y: point.y });
+      } catch {
+        setPosition(null);
+      }
+    };
+
+    updatePosition();
+    map.on('move', updatePosition);
+    map.on('zoom', updatePosition);
+    return () => {
+      map.off('move', updatePosition);
+      map.off('zoom', updatePosition);
+    };
+  }, [mapRef, node?.lng, node?.lat]);
+
+  if (!position) return null;
+
+  return (
+    <div className="pointer-events-none absolute inset-0 z-[10000]" style={{ position: 'absolute' }}>
+      <div
+        className="pointer-events-auto min-w-[140px] rounded border border-slate-600 bg-slate-800 px-3 py-2 text-sm text-slate-100 shadow-lg"
+        style={{
+          position: 'absolute',
+          left: position.x,
+          top: position.y,
+          transform: 'translate(-50%, -100%)',
+          marginTop: -8,
+        }}
+      >
+        <button
+          type="button"
+          onClick={onClose}
+          className="absolute right-1 top-1 rounded p-0.5 text-slate-400 hover:bg-slate-700 hover:text-slate-200"
+          aria-label="Close"
+        >
+          <X className="h-3.5 w-3.5" />
+        </button>
+        <div className="pr-5">
+          <div className="font-semibold">
+            {node.long_name && node.short_name ? `${node.long_name} (${node.short_name})` : getNodeLabel(node)}
+          </div>
+          <div className="mt-0.5 text-xs text-slate-400">{node.node_id_str || `!${node.node_id.toString(16)}`}</div>
+          {edge && (
+            <div className="mt-1 space-y-0.5 text-xs">
+              {edge.avg_snr_in != null && (
+                <div>
+                  <span className="text-slate-400">SNR in:</span> {edge.avg_snr_in.toFixed(1)} dB
+                </div>
+              )}
+              {edge.avg_snr_out != null && (
+                <div>
+                  <span className="text-slate-400">SNR out:</span> {edge.avg_snr_out.toFixed(1)} dB
+                </div>
+              )}
+            </div>
+          )}
+          <Link
+            to={`/nodes/${node.node_id}`}
+            className="mt-1 inline-block text-xs text-emerald-400 hover:text-emerald-300 hover:underline"
+          >
+            Open details
+          </Link>
+        </div>
+      </div>
+    </div>
+  );
+}
+
+export function NodeTracerouteLinksMap({ edges, nodes, focusNodeId, showLabels = true }: NodeTracerouteLinksMapProps) {
+  const config = useConfig();
+  const mapboxToken = config.mapboxToken ?? (import.meta.env.VITE_MAPBOX_TOKEN as string | undefined);
+  const mapStyle = useMapboxStyle();
+  const [selectedNode, setSelectedNode] = useState<NodeTracerouteLinkNode | null>(null);
+  const [selectedEdge, setSelectedEdge] = useState<NodeTracerouteLinkEdge | null>(null);
+
+  const handleClick = useCallback(
+    (info: PickingInfo) => {
+      if (info.object && (info.layer?.id === 'links-nodes' || info.layer?.id === 'links-node-labels')) {
+        const node = info.object as NodeTracerouteLinkNode;
+        setSelectedNode(node);
+        setSelectedEdge(edges.find((e) => e.to_node_id === node.node_id) ?? null);
+      } else {
+        setSelectedNode(null);
+        setSelectedEdge(null);
+      }
+    },
+    [edges]
+  );
+
+  const edgesWithSnr = useMemo(() => {
+    return edges.map((e) => {
+      const avgSnr =
+        e.avg_snr_in != null && e.avg_snr_out != null
+          ? (e.avg_snr_in + e.avg_snr_out) / 2
+          : (e.avg_snr_in ?? e.avg_snr_out ?? -999);
+      return { ...e, _avgSnr: avgSnr };
+    });
+  }, [edges]);
+
+  const arcLayer = useMemo(() => {
+    if (edgesWithSnr.length === 0) return null;
+    const snrValues = edgesWithSnr.map((e) => e._avgSnr).filter((s) => s > -999);
+    const minSnr = snrValues.length ? Math.min(...snrValues) : -20;
+    const maxSnr = snrValues.length ? Math.max(...snrValues) : 10;
+    return new ArcLayer({
+      id: 'links-arcs',
+      data: edgesWithSnr,
+      getSourcePosition: (d) => [d.from_lng, d.from_lat],
+      getTargetPosition: (d) => [d.to_lng, d.to_lat],
+      getSourceColor: (d) => interpolateColorBySnr(d._avgSnr, minSnr, maxSnr),
+      getTargetColor: (d) => interpolateColorBySnr(d._avgSnr, minSnr, maxSnr),
+      getWidth: 2,
+      widthMinPixels: 2,
+      widthMaxPixels: 8,
+      getHeight: 0,
+    });
+  }, [edgesWithSnr]);
+
+  const scatterLayer = useMemo(() => {
+    if (nodes.length === 0) return null;
+    return new ScatterplotLayer({
+      id: 'links-nodes',
+      data: nodes,
+      getPosition: (d) => [d.lng, d.lat],
+      getFillColor: (d) => (d.node_id === focusNodeId ? FOCUS_NODE_COLOR : PEER_NODE_COLOR),
+      getRadius: (d) => (d.node_id === focusNodeId ? 150 : 100),
+      radiusMinPixels: 4,
+      radiusMaxPixels: 12,
+      pickable: true,
+    });
+  }, [nodes, focusNodeId]);
+
+  const textLayer = useMemo(() => {
+    if (nodes.length === 0) return null;
+    return new TextLayer({
+      id: 'links-node-labels',
+      data: showLabels ? nodes : [],
+      getPosition: (d) => [d.lng, d.lat],
+      getText: getNodeLabel,
+      getSize: 11,
+      sizeMinPixels: 9,
+      sizeMaxPixels: 12,
+      getColor: [220, 220, 220, 230],
+      getTextAnchor: 'middle',
+      getAlignmentBaseline: 'bottom',
+      background: true,
+      getBackgroundColor: [25, 25, 35, 200],
+      backgroundPadding: [6, 3],
+      backgroundBorderRadius: 2,
+      pickable: true,
+    });
+  }, [nodes, showLabels]);
+
+  const layers = useMemo(
+    () => [arcLayer, scatterLayer, textLayer].filter(Boolean) as (ArcLayer | ScatterplotLayer | TextLayer)[],
+    [arcLayer, scatterLayer, textLayer]
+  );
+
+  const initialViewState = useMemo(() => {
+    const lats = nodes.map((n) => n.lat).filter((v) => typeof v === 'number');
+    const lngs = nodes.map((n) => n.lng).filter((v) => typeof v === 'number');
+    if (lats.length > 0 && lngs.length > 0) {
+      const padding = 0.02;
+      const bounds: [number, number, number, number] = [
+        Math.min(...lngs) - padding,
+        Math.min(...lats) - padding,
+        Math.max(...lngs) + padding,
+        Math.max(...lats) + padding,
+      ];
+      return { bounds, fitBoundsOptions: { padding: 40, maxZoom: 14 } };
+    }
+    const focusNode = nodes.find((n) => n.node_id === focusNodeId);
+    if (focusNode && focusNode.lat != null && focusNode.lng != null) {
+      return { longitude: focusNode.lng, latitude: focusNode.lat, zoom: 10 };
+    }
+    return DEFAULT_CENTER;
+  }, [nodes, focusNodeId]);
+
+  if (!mapboxToken) {
+    return (
+      <div className="flex min-h-[300px] items-center justify-center rounded-md border bg-muted/30 text-muted-foreground">
+        Mapbox token required. Set VITE_MAPBOX_TOKEN (dev) or MAPBOX_TOKEN (Docker) in your environment.
+      </div>
+    );
+  }
+
+  return (
+    <div className="relative h-full w-full">
+      <Map
+        mapboxAccessToken={mapboxToken}
+        initialViewState={initialViewState}
+        mapStyle={mapStyle}
+        style={{ width: '100%', height: '100%' }}
+      >
+        <DeckGLOverlay interleaved={false} layers={layers} onClick={handleClick} />
+        {selectedNode && (
+          <NodePopupOverlay
+            node={selectedNode}
+            edge={selectedEdge ?? undefined}
+            onClose={() => {
+              setSelectedNode(null);
+              setSelectedEdge(null);
+            }}
+          />
+        )}
+      </Map>
+    </div>
+  );
+}

--- a/src/hooks/api/useNodeTracerouteLinks.ts
+++ b/src/hooks/api/useNodeTracerouteLinks.ts
@@ -1,0 +1,54 @@
+import { useQuery } from '@tanstack/react-query';
+import { useMeshtasticApi } from './useApi';
+
+export interface NodeTracerouteLinkEdge {
+  from_node_id: number;
+  to_node_id: number;
+  from_lat: number;
+  from_lng: number;
+  to_lat: number;
+  to_lng: number;
+  avg_snr_in: number | null;
+  avg_snr_out: number | null;
+  count: number;
+}
+
+export interface NodeTracerouteLinkNode {
+  node_id: number;
+  node_id_str?: string;
+  lat: number;
+  lng: number;
+  short_name?: string;
+  long_name?: string;
+}
+
+export interface NodeTracerouteLinkSnrHistory {
+  peer_node_id: number;
+  peer_short_name: string;
+  inbound: Array<{ triggered_at: string; snr: number }>;
+  outbound: Array<{ triggered_at: string; snr: number }>;
+}
+
+export interface NodeTracerouteLinksData {
+  edges: NodeTracerouteLinkEdge[];
+  nodes: NodeTracerouteLinkNode[];
+  snr_history: NodeTracerouteLinkSnrHistory[];
+}
+
+export interface UseNodeTracerouteLinksParams {
+  triggeredAtAfter?: Date;
+}
+
+export function useNodeTracerouteLinks(nodeId: number, params?: UseNodeTracerouteLinksParams) {
+  const api = useMeshtasticApi();
+  const triggeredAtAfter = params?.triggeredAtAfter?.toISOString();
+
+  return useQuery({
+    queryKey: ['node-traceroute-links', nodeId, { triggeredAtAfter }],
+    queryFn: () =>
+      api.getNodeTracerouteLinks(nodeId, {
+        triggered_at_after: triggeredAtAfter,
+      }),
+    enabled: nodeId > 0,
+  });
+}

--- a/src/lib/api/meshtastic-api.ts
+++ b/src/lib/api/meshtastic-api.ts
@@ -547,4 +547,44 @@ export class MeshtasticApi extends BaseApi {
     }
     return this.get('/traceroutes/heatmap-edges/', searchParams);
   }
+
+  /**
+   * Get traceroute links for a specific node (from Neo4j)
+   */
+  async getNodeTracerouteLinks(
+    nodeId: number,
+    params?: { triggered_at_after?: string }
+  ): Promise<{
+    edges: Array<{
+      from_node_id: number;
+      to_node_id: number;
+      from_lat: number;
+      from_lng: number;
+      to_lat: number;
+      to_lng: number;
+      avg_snr_in: number | null;
+      avg_snr_out: number | null;
+      count: number;
+    }>;
+    nodes: Array<{
+      node_id: number;
+      node_id_str?: string;
+      lat: number;
+      lng: number;
+      short_name?: string;
+      long_name?: string;
+    }>;
+    snr_history: Array<{
+      peer_node_id: number;
+      peer_short_name: string;
+      inbound: Array<{ triggered_at: string; snr: number }>;
+      outbound: Array<{ triggered_at: string; snr: number }>;
+    }>;
+  }> {
+    const searchParams = new URLSearchParams();
+    if (params?.triggered_at_after) {
+      searchParams.append('triggered_at_after', params.triggered_at_after);
+    }
+    return this.get(`/nodes/observed-nodes/${nodeId}/traceroute-links/`, searchParams);
+  }
 }


### PR DESCRIPTION
# Summary

Adds a Traceroute Links section to the NodeDetails page. Shows a map of the node and its links (colored by SNR) plus mini SNR-over-time charts per link.

**Changes:**

- **NodeTracerouteLinksMap** – Mapbox + deck.gl map with arcs between nodes, colored by average SNR; focus node highlighted
- **LinkSNRCharts** – Recharts mini graphs per link showing inbound and outbound SNR over time; 3 shown by default with "Show all links (X more)" to expand
- **useNodeTracerouteLinks** – Hook for `GET /api/nodes/observed-nodes/{node_id}/traceroute-links/`
- **getNodeTracerouteLinks** – API method with `lastHeardAfter` / `lastHeardBefore` params
- **NodeDetailContent** – New "Traceroute Links" section with time range selector (24h, 7d, 30d)

Requires meshflow-api PR with `traceroute-links` endpoint to be merged first (or deployed).

<img width="1076" height="699" alt="image" src="https://github.com/user-attachments/assets/1046d5c3-287c-4460-b9ea-3a1fa3a9ae5f" />


## Testing performed

- Existing unit tests pass
- Manual verification of map and charts on NodeDetails page recommended
