### PR TITLE
feat: add Mesh stats section with shared time range and aggregation

### DIFF
--- a/src/components/MeshStatsSection.tsx
+++ b/src/components/MeshStatsSection.tsx
@@ -1,0 +1,75 @@
+'use client';
+
+import * as React from 'react';
+import { subDays } from 'date-fns';
+import { Card, CardContent, CardDescription, CardHeader, CardTitle } from '@/components/ui/card';
+import { TimeRangeSelect, TimeRangeOption } from '@/components/TimeRangeSelect';
+import { OnlineNodesChart } from '@/components/OnlineNodesChart';
+import { PacketStatsChartFromSnapshots } from '@/components/PacketStatsChartFromSnapshots';
+import { ChartConfig } from '@/components/ui/chart';
+
+const MESH_STATS_TIME_OPTIONS: TimeRangeOption[] = [
+  { key: '48h', label: 'Last 48 hours' },
+  { key: '1d', label: 'Today' },
+  { key: '2d', label: 'Last 2 days' },
+  { key: '7d', label: 'Last 7 days' },
+  { key: '30d', label: 'Last 30 days' },
+];
+
+const onlineNodesChartConfig = {
+  value: {
+    label: 'Online nodes',
+    color: 'hsl(var(--chart-1))',
+  },
+} satisfies ChartConfig;
+
+const packetChartConfig = {
+  value: {
+    label: 'Packets',
+    color: 'hsl(var(--chart-2))',
+  },
+} satisfies ChartConfig;
+
+export function MeshStatsSection() {
+  const [timeRangeKey, setTimeRangeKey] = React.useState('2d');
+  const [dateRange, setDateRange] = React.useState<{ startDate: Date; endDate: Date }>({
+    startDate: subDays(new Date(), 2),
+    endDate: new Date(),
+  });
+
+  const handleTimeRangeChange = (value: string, timeRange: { startDate: Date; endDate: Date }) => {
+    if (value === timeRangeKey) return;
+    setTimeRangeKey(value);
+    setDateRange(timeRange);
+  };
+
+  return (
+    <Card data-testid="dashboard-mesh-stats">
+      <CardHeader className="relative">
+        <CardTitle>Mesh stats</CardTitle>
+        <CardDescription>
+          Online nodes and packet volume over time. Longer ranges are aggregated into 6-hour or daily windows.
+        </CardDescription>
+        <div className="absolute right-4 top-4">
+          <TimeRangeSelect options={MESH_STATS_TIME_OPTIONS} value={timeRangeKey} onChange={handleTimeRangeChange} />
+        </div>
+      </CardHeader>
+      <CardContent className="flex flex-col gap-6">
+        <OnlineNodesChart
+          title="Online Nodes"
+          description="Online nodes (heard within 2h)"
+          config={onlineNodesChartConfig}
+          embedded
+          dateRange={dateRange}
+        />
+        <PacketStatsChartFromSnapshots
+          title="Mesh Activity"
+          description="Total packets"
+          config={packetChartConfig}
+          embedded
+          dateRange={dateRange}
+        />
+      </CardContent>
+    </Card>
+  );
+}

--- a/src/components/OnlineNodesChart.tsx
+++ b/src/components/OnlineNodesChart.tsx
@@ -1,0 +1,197 @@
+'use client';
+
+import * as React from 'react';
+import { CartesianGrid, XAxis, YAxis, Bar, Line, ComposedChart } from 'recharts';
+
+import { Card, CardContent, CardDescription, CardHeader, CardTitle } from '@/components/ui/card';
+import { ChartConfig, ChartContainer, ChartTooltip, ChartTooltipContent } from '@/components/ui/chart';
+import { TimeRangeSelect, TimeRangeOption } from '@/components/TimeRangeSelect';
+import { useStatsSnapshotsSuspense } from '@/hooks/api/useStatsSnapshots';
+import { subDays } from 'date-fns';
+import { Payload, ValueType, NameType } from 'recharts/types/component/DefaultTooltipContent';
+import { getAggregationWindow, aggregateStats } from '@/lib/stats-aggregation';
+
+interface OnlineNodesChartProps {
+  title: string;
+  description?: string;
+  config: ChartConfig;
+  timeRangeOptions?: TimeRangeOption[];
+  defaultTimeRange?: string;
+  /** When true, render without Card/TimeRangeSelect; use dateRange from parent */
+  embedded?: boolean;
+  dateRange?: { startDate: Date; endDate: Date };
+}
+
+export function OnlineNodesChart({
+  title,
+  description,
+  config,
+  timeRangeOptions = [
+    { key: '48h', label: 'Last 48 hours' },
+    { key: '1d', label: 'Today' },
+    { key: '2d', label: 'Last 2 days' },
+    { key: '7d', label: 'Last 7 days' },
+    { key: '30d', label: 'Last 30 days' },
+  ],
+  defaultTimeRange = '2d',
+  embedded = false,
+  dateRange: controlledDateRange,
+}: OnlineNodesChartProps) {
+  const [timeRangeLabel, setTimeRangeLabel] = React.useState(defaultTimeRange);
+  const [internalDateRange, setInternalDateRange] = React.useState<{ startDate: Date; endDate: Date }>({
+    startDate: subDays(new Date(), 2),
+    endDate: new Date(),
+  });
+
+  const dateRange = embedded && controlledDateRange ? controlledDateRange : internalDateRange;
+
+  const params = React.useMemo(
+    () => ({
+      statType: 'online_nodes' as const,
+      constellationId: -1,
+      recordedAtAfter: dateRange.startDate,
+      recordedAtBefore: dateRange.endDate,
+      page_size: 1000,
+    }),
+    [dateRange.startDate, dateRange.endDate]
+  );
+
+  const { snapshots } = useStatsSnapshotsSuspense(params);
+
+  const handleTimeRangeChange = (value: string, timeRange: { startDate: Date; endDate: Date }) => {
+    if (value === timeRangeLabel) return;
+    setTimeRangeLabel(value);
+    setInternalDateRange(timeRange);
+  };
+
+  const aggregationWindow = React.useMemo(
+    () => getAggregationWindow(dateRange.startDate, dateRange.endDate),
+    [dateRange.startDate, dateRange.endDate]
+  );
+
+  // Filter to global only, sort, optionally aggregate, then add moving average
+  const chartData = React.useMemo(() => {
+    if (!snapshots?.results) return [];
+
+    const globalOnly = snapshots.results.filter((s) => s.constellation_id === null);
+    const sorted = [...globalOnly].sort(
+      (a, b) => new Date(a.recorded_at).getTime() - new Date(b.recorded_at).getTime()
+    );
+
+    let stats = sorted.map((s) => ({
+      timestamp: new Date(s.recorded_at).getTime(),
+      value: s.value?.count ?? 0,
+    }));
+
+    stats = aggregateStats(stats, aggregationWindow, 'average');
+
+    // Add moving average (window size depends on aggregation)
+    const windowSize = aggregationWindow === 'hourly' ? Math.min(24, stats.length) : Math.min(4, stats.length);
+    return stats.map((stat, index) => {
+      const startIdx = Math.max(0, index - windowSize + 1);
+      const window = stats.slice(startIdx, index + 1);
+      const avg = window.length > 0 ? window.reduce((acc, i) => acc + i.value, 0) / window.length : 0;
+      return { ...stat, movingAverage: avg };
+    });
+  }, [snapshots, aggregationWindow]);
+
+  const yAxisDomain = React.useMemo(() => {
+    if (!chartData.length) return [0, 'auto'] as [number, 'auto'];
+    const values = chartData.map((item) => item.value);
+    const maxVal = Math.max(...values, 1);
+    return [0, maxVal] as [number, number];
+  }, [chartData]);
+
+  const tickFormatter = (value: number) => {
+    const date = new Date(value);
+    if (aggregationWindow === 'daily') {
+      return date.toLocaleDateString('en-GB', { month: 'short', day: 'numeric' });
+    }
+    if (aggregationWindow === '6h') {
+      return date.toLocaleDateString('en-GB', { month: 'short', day: 'numeric', hour: 'numeric' });
+    }
+    return date.toLocaleDateString('en-GB', {
+      month: 'short',
+      day: 'numeric',
+      hour: 'numeric',
+      minute: 'numeric',
+    });
+  };
+
+  const tooltipLabelFormatter = (_: unknown, payload: Payload<ValueType, NameType>[]) => {
+    if (payload?.[0]?.payload?.timestamp != null) {
+      return tickFormatter(payload[0].payload.timestamp);
+    }
+    return 'Unknown time';
+  };
+
+  const chartContent = (
+    <ChartContainer config={config} className="aspect-auto h-[250px] w-full">
+      <ComposedChart data={chartData}>
+        <defs>
+          <linearGradient id="fillOnlineNodes" x1="0" y1="0" x2="0" y2="1">
+            <stop offset="5%" stopColor="var(--color-value)" stopOpacity={1.0} />
+            <stop offset="95%" stopColor="var(--color-value)" stopOpacity={0.1} />
+          </linearGradient>
+        </defs>
+        <CartesianGrid vertical={false} />
+        <XAxis
+          dataKey="timestamp"
+          tickLine={false}
+          axisLine={false}
+          tickMargin={8}
+          minTickGap={80}
+          tickCount={6}
+          scale="time"
+          type="number"
+          domain={[dateRange.startDate.getTime(), dateRange.endDate.getTime()]}
+          tickFormatter={tickFormatter}
+        />
+        <YAxis domain={yAxisDomain} tickLine={false} axisLine={false} tickMargin={8} />
+        <ChartTooltip
+          cursor={false}
+          content={<ChartTooltipContent labelFormatter={tooltipLabelFormatter} indicator="dot" />}
+        />
+        <Bar dataKey="value" fill="var(--color-value)" fillOpacity={0.7} barSize={8} />
+        <Line
+          type="monotone"
+          dataKey="movingAverage"
+          stroke="var(--color-value)"
+          strokeWidth={2}
+          dot={false}
+          name={aggregationWindow === 'hourly' ? '24h Moving Average' : 'Moving Average'}
+        />
+      </ComposedChart>
+    </ChartContainer>
+  );
+
+  if (embedded) {
+    return (
+      <div>
+        <h3 className="text-sm font-medium mb-1">{title}</h3>
+        {description && <p className="text-xs text-muted-foreground mb-2">{description}</p>}
+        {chartContent}
+      </div>
+    );
+  }
+
+  return (
+    <Card className="@container/card">
+      <CardHeader className="relative">
+        <CardTitle>{title}</CardTitle>
+        {description && (
+          <CardDescription>
+            <span className="@[540px]/card:block hidden">{description}</span>
+            <span className="@[540px]/card:hidden">
+              {timeRangeOptions.find((option) => option.key === timeRangeLabel)?.label}
+            </span>
+          </CardDescription>
+        )}
+        <div className="absolute right-4 top-4">
+          <TimeRangeSelect options={timeRangeOptions} value={timeRangeLabel} onChange={handleTimeRangeChange} />
+        </div>
+      </CardHeader>
+      <CardContent className="px-2 pt-4 sm:px-6 sm:pt-6">{chartContent}</CardContent>
+    </Card>
+  );
+}

--- a/src/components/PacketStatsChart.tsx
+++ b/src/components/PacketStatsChart.tsx
@@ -43,7 +43,7 @@ export function PacketStatsChart({
     () => ({
       startDate: dateRange.startDate,
       endDate: dateRange.endDate,
-      nodeId,
+      ...(nodeId != null && { nodeId }),
     }),
     [dateRange.startDate, dateRange.endDate, nodeId]
   );
@@ -56,34 +56,20 @@ export function PacketStatsChart({
     setDateRange(timeRange);
   };
 
-  // Transform the data for the chart
+  // Transform the data for the chart from live stats API
   const chartData = React.useMemo(() => {
     if (!packetStats?.intervals) return [];
-
-    // Calculate 24-hour moving average
     const stats = packetStats.intervals.map((stat) => ({
       timestamp: new Date(stat.start_date).getTime(),
       value: stat.packets >= 0 ? stat.packets : 0,
     }));
-
-    // Add moving average
-    const windowSize = 24; // 24-hour window
-    const withMovingAverage = stats.map((stat, index) => {
-      // Get the window of data points
+    const windowSize = 24;
+    return stats.map((stat, index) => {
       const startIdx = Math.max(0, index - windowSize + 1);
       const window = stats.slice(startIdx, index + 1);
-
-      // Calculate average
-      const sum = window.reduce((acc, item) => acc + item.value, 0);
-      const avg = window.length > 0 ? sum / window.length : 0;
-
-      return {
-        ...stat,
-        movingAverage: avg,
-      };
+      const avg = window.length > 0 ? window.reduce((acc, i) => acc + i.value, 0) / window.length : 0;
+      return { ...stat, movingAverage: avg };
     });
-
-    return withMovingAverage;
   }, [packetStats]);
 
   // Calculate y-axis domain with 5 std dev clamp

--- a/src/components/PacketStatsChartFromSnapshots.tsx
+++ b/src/components/PacketStatsChartFromSnapshots.tsx
@@ -1,0 +1,201 @@
+'use client';
+
+import * as React from 'react';
+import { CartesianGrid, XAxis, YAxis, Bar, Line, ComposedChart } from 'recharts';
+
+import { Card, CardContent, CardDescription, CardHeader, CardTitle } from '@/components/ui/card';
+import { ChartConfig, ChartContainer, ChartTooltip, ChartTooltipContent } from '@/components/ui/chart';
+import { TimeRangeSelect, TimeRangeOption } from '@/components/TimeRangeSelect';
+import { useStatsSnapshotsSuspense } from '@/hooks/api/useStatsSnapshots';
+import { subDays } from 'date-fns';
+import { Payload, ValueType, NameType } from 'recharts/types/component/DefaultTooltipContent';
+import { getAggregationWindow, aggregateStats } from '@/lib/stats-aggregation';
+
+interface PacketStatsChartFromSnapshotsProps {
+  title: string;
+  description?: string;
+  config: ChartConfig;
+  timeRangeOptions?: TimeRangeOption[];
+  defaultTimeRange?: string;
+  /** When true, render without Card/TimeRangeSelect; use dateRange from parent */
+  embedded?: boolean;
+  dateRange?: { startDate: Date; endDate: Date };
+}
+
+/**
+ * Packet stats chart that uses collected stats snapshots (packet_volume) instead of
+ * the on-demand stats/global endpoint. Use for global dashboard views.
+ */
+export function PacketStatsChartFromSnapshots({
+  title,
+  description,
+  config,
+  timeRangeOptions = [
+    { key: '48h', label: 'Last 48 hours' },
+    { key: '1d', label: 'Today' },
+    { key: '2d', label: 'Last 2 days' },
+    { key: '7d', label: 'Last 7 days' },
+    { key: '30d', label: 'Last 30 days' },
+  ],
+  defaultTimeRange = '2d',
+  embedded = false,
+  dateRange: controlledDateRange,
+}: PacketStatsChartFromSnapshotsProps) {
+  const [timeRangeLabel, setTimeRangeLabel] = React.useState(defaultTimeRange);
+  const [internalDateRange, setInternalDateRange] = React.useState<{ startDate: Date; endDate: Date }>({
+    startDate: subDays(new Date(), 2),
+    endDate: new Date(),
+  });
+
+  const dateRange = embedded && controlledDateRange ? controlledDateRange : internalDateRange;
+
+  const params = React.useMemo(
+    () => ({
+      statType: 'packet_volume' as const,
+      recordedAtAfter: dateRange.startDate,
+      recordedAtBefore: dateRange.endDate,
+      page_size: 1000,
+    }),
+    [dateRange.startDate, dateRange.endDate]
+  );
+
+  const { snapshots } = useStatsSnapshotsSuspense(params);
+
+  const handleTimeRangeChange = (value: string, timeRange: { startDate: Date; endDate: Date }) => {
+    if (value === timeRangeLabel) return;
+    setTimeRangeLabel(value);
+    setInternalDateRange(timeRange);
+  };
+
+  const aggregationWindow = React.useMemo(
+    () => getAggregationWindow(dateRange.startDate, dateRange.endDate),
+    [dateRange.startDate, dateRange.endDate]
+  );
+
+  const chartData = React.useMemo(() => {
+    if (!snapshots?.results) return [];
+
+    const globalOnly = snapshots.results.filter((s) => s.constellation_id === null);
+    const sorted = [...globalOnly].sort(
+      (a, b) => new Date(a.recorded_at).getTime() - new Date(b.recorded_at).getTime()
+    );
+    let stats = sorted.map((s) => ({
+      timestamp: new Date(s.recorded_at).getTime(),
+      value: s.value?.count ?? 0,
+    }));
+
+    stats = aggregateStats(stats, aggregationWindow, 'sum');
+
+    const windowSize = aggregationWindow === 'hourly' ? Math.min(24, stats.length) : Math.min(4, stats.length);
+    return stats.map((stat, index) => {
+      const startIdx = Math.max(0, index - windowSize + 1);
+      const window = stats.slice(startIdx, index + 1);
+      const avg = window.length > 0 ? window.reduce((acc, i) => acc + i.value, 0) / window.length : 0;
+      return { ...stat, movingAverage: avg };
+    });
+  }, [snapshots, aggregationWindow]);
+
+  const yAxisDomain = React.useMemo(() => {
+    if (!chartData.length) return [0, 'auto'] as [number, 'auto'];
+    const values = chartData.map((item) => item.value);
+    const mean = values.reduce((sum, val) => sum + val, 0) / values.length;
+    const squaredDiffs = values.map((val) => Math.pow(val - mean, 2));
+    const variance = squaredDiffs.reduce((sum, val) => sum + val, 0) / values.length;
+    const stdDev = Math.sqrt(variance);
+    const maxValue = Math.max(mean + 5 * stdDev, Math.max(...values));
+    return [0, maxValue] as [number, number];
+  }, [chartData]);
+
+  const tickFormatter = (value: number) => {
+    const date = new Date(value);
+    if (aggregationWindow === 'daily') {
+      return date.toLocaleDateString('en-GB', { month: 'short', day: 'numeric' });
+    }
+    if (aggregationWindow === '6h') {
+      return date.toLocaleDateString('en-GB', { month: 'short', day: 'numeric', hour: 'numeric' });
+    }
+    return date.toLocaleDateString('en-GB', {
+      month: 'short',
+      day: 'numeric',
+      hour: 'numeric',
+      minute: 'numeric',
+    });
+  };
+
+  const tooltipLabelFormatter = (_: unknown, payload: Payload<ValueType, NameType>[]) => {
+    if (payload?.[0]?.payload?.timestamp != null) {
+      return tickFormatter(payload[0].payload.timestamp);
+    }
+    return 'Unknown time';
+  };
+
+  const chartContent = (
+    <ChartContainer config={config} className="aspect-auto h-[250px] w-full">
+      <ComposedChart data={chartData}>
+        <defs>
+          <linearGradient id="fillPacketValue" x1="0" y1="0" x2="0" y2="1">
+            <stop offset="5%" stopColor="var(--color-value)" stopOpacity={1.0} />
+            <stop offset="95%" stopColor="var(--color-value)" stopOpacity={0.1} />
+          </linearGradient>
+        </defs>
+        <CartesianGrid vertical={false} />
+        <XAxis
+          dataKey="timestamp"
+          tickLine={false}
+          axisLine={false}
+          tickMargin={8}
+          minTickGap={80}
+          tickCount={6}
+          scale="time"
+          type="number"
+          domain={[dateRange.startDate.getTime(), dateRange.endDate.getTime()]}
+          tickFormatter={tickFormatter}
+        />
+        <YAxis domain={yAxisDomain} tickLine={false} axisLine={false} tickMargin={8} />
+        <ChartTooltip
+          cursor={false}
+          content={<ChartTooltipContent labelFormatter={tooltipLabelFormatter} indicator="dot" />}
+        />
+        <Bar dataKey="value" fill="var(--color-value)" fillOpacity={0.7} barSize={8} />
+        <Line
+          type="monotone"
+          dataKey="movingAverage"
+          stroke="var(--color-value)"
+          strokeWidth={2}
+          dot={false}
+          name={aggregationWindow === 'hourly' ? '24h Moving Average' : 'Moving Average'}
+        />
+      </ComposedChart>
+    </ChartContainer>
+  );
+
+  if (embedded) {
+    return (
+      <div>
+        <h3 className="text-sm font-medium mb-1">{title}</h3>
+        {description && <p className="text-xs text-muted-foreground mb-2">{description}</p>}
+        {chartContent}
+      </div>
+    );
+  }
+
+  return (
+    <Card className="@container/card">
+      <CardHeader className="relative">
+        <CardTitle>{title}</CardTitle>
+        {description && (
+          <CardDescription>
+            <span className="@[540px]/card:block hidden">{description}</span>
+            <span className="@[540px]/card:hidden">
+              {timeRangeOptions.find((option) => option.key === timeRangeLabel)?.label}
+            </span>
+          </CardDescription>
+        )}
+        <div className="absolute right-4 top-4">
+          <TimeRangeSelect options={timeRangeOptions} value={timeRangeLabel} onChange={handleTimeRangeChange} />
+        </div>
+      </CardHeader>
+      <CardContent className="px-2 pt-4 sm:px-6 sm:pt-6">{chartContent}</CardContent>
+    </Card>
+  );
+}

--- a/src/hooks/api/useStatsSnapshots.ts
+++ b/src/hooks/api/useStatsSnapshots.ts
@@ -1,0 +1,53 @@
+import { useQuery, useSuspenseQuery } from '@tanstack/react-query';
+import { useMeshtasticApi } from './useApi';
+import { PaginatedResponse, StatsSnapshot } from '@/lib/models';
+import { StatsSnapshotsParams } from '@/lib/types';
+import { roundToNearestMinutes } from 'date-fns';
+
+function getStatsSnapshotsKey(params?: StatsSnapshotsParams): string {
+  if (!params) return 'default';
+  const parts: string[] = [params.statType ?? '', params.constellationId?.toString() ?? ''];
+  if (params.recordedAtAfter) {
+    const rounded = roundToNearestMinutes(params.recordedAtAfter, { nearestTo: 5 });
+    parts.push(rounded.toISOString());
+  }
+  if (params.recordedAtBefore) {
+    const rounded = roundToNearestMinutes(params.recordedAtBefore, { nearestTo: 5 });
+    parts.push(rounded.toISOString());
+  }
+  parts.push(params.page?.toString() ?? '', params.page_size?.toString() ?? '');
+  return parts.join('-');
+}
+
+/**
+ * Hook to fetch stats snapshots
+ */
+export function useStatsSnapshots(params?: StatsSnapshotsParams) {
+  const api = useMeshtasticApi();
+  const key = ['stats-snapshots', getStatsSnapshotsKey(params)];
+
+  return useQuery<PaginatedResponse<StatsSnapshot>, Error>({
+    refetchInterval: 5 * 1000 * 60, // 5 minutes
+    queryKey: key,
+    queryFn: () => api.getStatsSnapshots(params),
+  });
+}
+
+/**
+ * Suspense-enabled hook to fetch stats snapshots
+ * Use inside a <Suspense> boundary.
+ */
+export function useStatsSnapshotsSuspense(params?: StatsSnapshotsParams) {
+  const api = useMeshtasticApi();
+  const key = ['stats-snapshots', getStatsSnapshotsKey(params)];
+
+  const query = useSuspenseQuery<PaginatedResponse<StatsSnapshot>, Error>({
+    refetchInterval: 5 * 1000 * 60, // 5 minutes
+    queryKey: key,
+    queryFn: () => api.getStatsSnapshots(params),
+  });
+
+  return {
+    snapshots: query.data,
+  };
+}

--- a/src/lib/api/meshtastic-api.ts
+++ b/src/lib/api/meshtastic-api.ts
@@ -9,6 +9,7 @@ import {
   PaginatedResponse,
   GlobalStats,
   NeighbourStats,
+  StatsSnapshot,
   Constellation,
   MessageChannel,
   TextMessage,
@@ -19,7 +20,13 @@ import {
   CreateNodeApiKey,
   AutoTraceRoute,
 } from '../models';
-import { ApiConfig, DateRangeParams, DateRangeIntervalParams, PaginationParams } from '@/lib/types';
+import {
+  ApiConfig,
+  DateRangeParams,
+  DateRangeIntervalParams,
+  PaginationParams,
+  StatsSnapshotsParams,
+} from '@/lib/types';
 import { parseObservedNodeFromAPI } from './api-utils';
 
 export class MeshtasticApi extends BaseApi {
@@ -433,6 +440,21 @@ export class MeshtasticApi extends BaseApi {
         end_date: new Date(interval.end_date).toISOString(),
       })),
     };
+  }
+
+  /**
+   * Get stored stats snapshots with optional filters
+   */
+  async getStatsSnapshots(params?: StatsSnapshotsParams): Promise<PaginatedResponse<StatsSnapshot>> {
+    const searchParams = new URLSearchParams();
+    if (params?.statType) searchParams.append('stat_type', params.statType);
+    if (params?.constellationId != null) searchParams.append('constellation_id', params.constellationId.toString());
+    if (params?.recordedAtAfter) searchParams.append('recorded_at_after', params.recordedAtAfter.toISOString());
+    if (params?.recordedAtBefore) searchParams.append('recorded_at_before', params.recordedAtBefore.toISOString());
+    if (params?.page) searchParams.append('page', params.page.toString());
+    if (params?.page_size) searchParams.append('page_size', params.page_size.toString());
+
+    return this.get<PaginatedResponse<StatsSnapshot>>('/stats/snapshots/', searchParams);
   }
 
   /**

--- a/src/lib/models.ts
+++ b/src/lib/models.ts
@@ -251,6 +251,14 @@ export interface NeighbourStats {
   total_packets: number;
 }
 
+export interface StatsSnapshot {
+  id: number;
+  recorded_at: string;
+  stat_type: 'online_nodes' | 'new_nodes' | 'packet_volume';
+  constellation_id: number | null;
+  value: { count: number; window_hours?: number };
+}
+
 export interface MessageChannel {
   id: number;
   name: string;

--- a/src/lib/stats-aggregation.ts
+++ b/src/lib/stats-aggregation.ts
@@ -1,0 +1,72 @@
+import { startOfDay } from 'date-fns';
+
+export type AggregationWindow = 'hourly' | '6h' | 'daily';
+
+/**
+ * Determine aggregation window based on time range span.
+ * - <= 2 days: hourly (no aggregation)
+ * - > 2 days and <= 7 days: 6-hour windows
+ * - > 7 days: daily (local midnight)
+ */
+export function getAggregationWindow(startDate: Date, endDate: Date): AggregationWindow {
+  const spanHours = (endDate.getTime() - startDate.getTime()) / (1000 * 60 * 60);
+  if (spanHours <= 48) return 'hourly';
+  if (spanHours <= 168) return '6h';
+  return 'daily';
+}
+
+/**
+ * Get the bucket start (local midnight or 6h boundary) for a given date.
+ * For 6h: 00:00, 06:00, 12:00, 18:00
+ * For daily: 00:00 (start of day)
+ */
+export function getBucketStart(date: Date, window: '6h' | 'daily'): Date {
+  const d = new Date(date);
+  if (window === 'daily') {
+    return startOfDay(d);
+  }
+  // 6h: floor hour to 0, 6, 12, 18
+  const hours = d.getHours();
+  const bucketHour = Math.floor(hours / 6) * 6;
+  d.setHours(bucketHour, 0, 0, 0);
+  return d;
+}
+
+export interface RawDataPoint {
+  timestamp: number;
+  value: number;
+}
+
+/**
+ * Aggregate raw hourly data into larger windows.
+ * - packet_volume: SUM (cumulative over window)
+ * - online_nodes: AVERAGE (point-in-time counts)
+ */
+export function aggregateStats(
+  points: RawDataPoint[],
+  window: AggregationWindow,
+  mode: 'sum' | 'average'
+): RawDataPoint[] {
+  if (window === 'hourly' || points.length === 0) return points;
+
+  const bucketKey = (ts: number) => {
+    const d = getBucketStart(new Date(ts), window === '6h' ? '6h' : 'daily');
+    return d.getTime();
+  };
+
+  const buckets = new Map<number, { sum: number; count: number }>();
+  for (const p of points) {
+    const key = bucketKey(p.timestamp);
+    const existing = buckets.get(key) ?? { sum: 0, count: 0 };
+    existing.sum += p.value;
+    existing.count += 1;
+    buckets.set(key, existing);
+  }
+
+  return Array.from(buckets.entries())
+    .map(([ts, { sum, count }]) => ({
+      timestamp: ts,
+      value: mode === 'sum' ? sum : sum / count,
+    }))
+    .sort((a, b) => a.timestamp - b.timestamp);
+}

--- a/src/lib/types.ts
+++ b/src/lib/types.ts
@@ -13,6 +13,15 @@ export interface StatsQueryParams extends DateRangeIntervalParams {
   nodeId?: number;
 }
 
+export interface StatsSnapshotsParams {
+  statType?: 'online_nodes' | 'new_nodes' | 'packet_volume';
+  constellationId?: number;
+  recordedAtAfter?: Date;
+  recordedAtBefore?: Date;
+  page?: number;
+  page_size?: number;
+}
+
 export interface PaginationParams {
   page?: number;
   page_size?: number;

--- a/src/pages/Dashboard.tsx
+++ b/src/pages/Dashboard.tsx
@@ -2,18 +2,10 @@ import { NodeActivityTable } from '@/components/NodeActivityTable';
 import { NodesAndConstellationsMap } from '@/components/nodes/NodesAndConstellationsMap';
 import { useNodesSuspense, useManagedNodesSuspense, useRecentNodeCountsSuspense } from '@/hooks/api/useNodes';
 import { Card, CardHeader, CardTitle, CardDescription, CardContent } from '@/components/ui/card';
-import { ChartConfig } from '@/components/ui/chart';
 import { Suspense } from 'react';
-import { PacketStatsChart } from '@/components/PacketStatsChart';
+import { MeshStatsSection } from '@/components/MeshStatsSection';
 import { Table, TableBody, TableCell, TableHead, TableHeader, TableRow } from '@/components/ui/table';
 import { Link } from 'react-router-dom';
-
-const packetChartConfig = {
-  value: {
-    label: 'Packets',
-    color: 'hsl(var(--chart-1))',
-  },
-} satisfies ChartConfig;
 
 const COUNT_COLUMNS = [
   { key: '2', label: '2 hours' },
@@ -85,8 +77,8 @@ function DashboardContent() {
           </CardContent>
         </Card>
       </div>
-      <div className="px-4 lg:px-6" data-testid="dashboard-mesh-activity">
-        <PacketStatsChart title="Mesh Activity" description="Total packets per hour" config={packetChartConfig} />
+      <div className="px-4 lg:px-6">
+        <MeshStatsSection />
       </div>
       <div className="px-4 lg:px-6" data-testid="dashboard-node-activity">
         <NodeActivityTable nodes={nodes || []} />

--- a/tests/browser/api-mock.ts
+++ b/tests/browser/api-mock.ts
@@ -36,6 +36,18 @@ const DEFAULT_HANDLERS: Array<{ pattern: string | RegExp; handler: RouteHandler 
   ['**/api/nodes/managed-nodes/**', createJsonHandler(loadFixture('managed-nodes.json'))],
   ['**/api/constellations/**', createJsonHandler(loadFixture('constellations.json'))],
   ['**/api/stats/global/**', createJsonHandler(loadFixture('stats-global.json'))],
+  [
+    '**/api/stats/snapshots/**',
+    (route: Route) => {
+      const url = route.request().url();
+      const fixture = url.includes('packet_volume') ? 'stats-snapshots-packet-volume.json' : 'stats-snapshots.json';
+      return route.fulfill({
+        status: 200,
+        contentType: 'application/json',
+        body: JSON.stringify(loadFixture(fixture)),
+      });
+    },
+  ],
   ['**/ws/**', (route) => route.abort()],
 ].map(([pattern, handler]) => ({ pattern: pattern as string | RegExp, handler: handler as RouteHandler }));
 

--- a/tests/browser/fixtures/stats-snapshots-packet-volume.json
+++ b/tests/browser/fixtures/stats-snapshots-packet-volume.json
@@ -1,0 +1,77 @@
+{
+  "results": [
+    {
+      "id": 101,
+      "recorded_at": "2025-03-15T00:00:00.000Z",
+      "stat_type": "packet_volume",
+      "constellation_id": null,
+      "value": { "count": 150 }
+    },
+    {
+      "id": 102,
+      "recorded_at": "2025-03-15T01:00:00.000Z",
+      "stat_type": "packet_volume",
+      "constellation_id": null,
+      "value": { "count": 180 }
+    },
+    {
+      "id": 103,
+      "recorded_at": "2025-03-15T02:00:00.000Z",
+      "stat_type": "packet_volume",
+      "constellation_id": null,
+      "value": { "count": 120 }
+    },
+    {
+      "id": 104,
+      "recorded_at": "2025-03-15T03:00:00.000Z",
+      "stat_type": "packet_volume",
+      "constellation_id": null,
+      "value": { "count": 200 }
+    },
+    {
+      "id": 105,
+      "recorded_at": "2025-03-15T04:00:00.000Z",
+      "stat_type": "packet_volume",
+      "constellation_id": null,
+      "value": { "count": 250 }
+    },
+    {
+      "id": 106,
+      "recorded_at": "2025-03-15T05:00:00.000Z",
+      "stat_type": "packet_volume",
+      "constellation_id": null,
+      "value": { "count": 320 }
+    },
+    {
+      "id": 107,
+      "recorded_at": "2025-03-15T06:00:00.000Z",
+      "stat_type": "packet_volume",
+      "constellation_id": null,
+      "value": { "count": 410 }
+    },
+    {
+      "id": 108,
+      "recorded_at": "2025-03-15T07:00:00.000Z",
+      "stat_type": "packet_volume",
+      "constellation_id": null,
+      "value": { "count": 380 }
+    },
+    {
+      "id": 109,
+      "recorded_at": "2025-03-15T08:00:00.000Z",
+      "stat_type": "packet_volume",
+      "constellation_id": null,
+      "value": { "count": 450 }
+    },
+    {
+      "id": 110,
+      "recorded_at": "2025-03-15T09:00:00.000Z",
+      "stat_type": "packet_volume",
+      "constellation_id": null,
+      "value": { "count": 520 }
+    }
+  ],
+  "count": 10,
+  "next": null,
+  "previous": null
+}

--- a/tests/browser/fixtures/stats-snapshots.json
+++ b/tests/browser/fixtures/stats-snapshots.json
@@ -1,0 +1,77 @@
+{
+  "results": [
+    {
+      "id": 1,
+      "recorded_at": "2025-03-15T00:00:00.000Z",
+      "stat_type": "online_nodes",
+      "constellation_id": null,
+      "value": { "count": 12, "window_hours": 2 }
+    },
+    {
+      "id": 2,
+      "recorded_at": "2025-03-15T01:00:00.000Z",
+      "stat_type": "online_nodes",
+      "constellation_id": null,
+      "value": { "count": 14, "window_hours": 2 }
+    },
+    {
+      "id": 3,
+      "recorded_at": "2025-03-15T02:00:00.000Z",
+      "stat_type": "online_nodes",
+      "constellation_id": null,
+      "value": { "count": 11, "window_hours": 2 }
+    },
+    {
+      "id": 4,
+      "recorded_at": "2025-03-15T03:00:00.000Z",
+      "stat_type": "online_nodes",
+      "constellation_id": null,
+      "value": { "count": 15, "window_hours": 2 }
+    },
+    {
+      "id": 5,
+      "recorded_at": "2025-03-15T04:00:00.000Z",
+      "stat_type": "online_nodes",
+      "constellation_id": null,
+      "value": { "count": 18, "window_hours": 2 }
+    },
+    {
+      "id": 6,
+      "recorded_at": "2025-03-15T05:00:00.000Z",
+      "stat_type": "online_nodes",
+      "constellation_id": null,
+      "value": { "count": 22, "window_hours": 2 }
+    },
+    {
+      "id": 7,
+      "recorded_at": "2025-03-15T06:00:00.000Z",
+      "stat_type": "online_nodes",
+      "constellation_id": null,
+      "value": { "count": 25, "window_hours": 2 }
+    },
+    {
+      "id": 8,
+      "recorded_at": "2025-03-15T07:00:00.000Z",
+      "stat_type": "online_nodes",
+      "constellation_id": null,
+      "value": { "count": 28, "window_hours": 2 }
+    },
+    {
+      "id": 9,
+      "recorded_at": "2025-03-15T08:00:00.000Z",
+      "stat_type": "online_nodes",
+      "constellation_id": null,
+      "value": { "count": 30, "window_hours": 2 }
+    },
+    {
+      "id": 10,
+      "recorded_at": "2025-03-15T09:00:00.000Z",
+      "stat_type": "online_nodes",
+      "constellation_id": null,
+      "value": { "count": 32, "window_hours": 2 }
+    }
+  ],
+  "count": 10,
+  "next": null,
+  "previous": null
+}


### PR DESCRIPTION
# Summary

Add Mesh stats section to Dashboard with shared time range picker and aggregation for online nodes and packet volume charts. Uses the new stats snapshots API instead of on-demand stats endpoint.

## Changes

- **MeshStatsSection**: New card with "Mesh stats" title, single time range picker (48h, 1d, 2d, 7d, 30d), and both charts sharing the same range.
- **OnlineNodesChart**: Fetches `online_nodes` snapshots; supports embedded mode (no card/picker when used in MeshStatsSection).
- **PacketStatsChartFromSnapshots**: Fetches `packet_volume` snapshots; supports embedded mode.
- **Aggregation**: When time range > 2 days, aggregates to 6-hour windows. When > 7 days, aggregates to daily (local midnight). Online nodes: average; packet volume: sum.
- **useStatsSnapshots / useStatsSnapshotsSuspense**: Hooks for `GET /api/stats/snapshots/`.
- **stats-aggregation.ts**: Utility for window selection and aggregation.
- **Dashboard**: Replaces separate chart cards with MeshStatsSection.
- **Browser mocks**: stats-snapshots.json, stats-snapshots-packet-volume.json for API mock.

## Testing performed

- Unit tests pass.
- Browser fixtures for stats snapshots API.
