### PR TITLE
feat: add Weather page with map and mini charts

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -9,6 +9,7 @@ import { WebSocketProvider } from '@/providers/WebSocketProvider';
 
 import { NodesList } from '@/pages/nodes/NodesList';
 import { MeshInfrastructure } from '@/pages/nodes/MeshInfrastructure';
+import { Weather } from '@/pages/Weather';
 import { NodeMap } from '@/pages/map/NodeMap';
 import { MessageHistory } from '@/pages/messages/MessageHistory';
 import { Dashboard } from '@/pages/Dashboard';
@@ -48,6 +49,7 @@ function App() {
                   <Route path="/" element={<Dashboard />} />
                   <Route path="/nodes" element={<NodesList />} />
                   <Route path="/nodes/infrastructure" element={<MeshInfrastructure />} />
+                  <Route path="/weather" element={<Weather />} />
                   <Route path="/nodes/my-nodes" element={<MyNodes />} />
                   <Route path="/nodes/monitor" element={<MonitorNodes />} />
                   <Route path="/nodes/:id/claim" element={<ClaimNode />} />

--- a/src/components/SiteBreadcrumb.tsx
+++ b/src/components/SiteBreadcrumb.tsx
@@ -28,6 +28,8 @@ function getBreadcrumbSegments(pathname: string): { path: string; label: string 
         segments.push({ path: `/nodes/${parts[1]}/claim`, label: 'Claim' });
       }
     }
+  } else if (parts[0] === 'weather') {
+    segments.push({ path: '/weather', label: 'Weather' });
   } else if (parts[0] === 'map') {
     segments.push({ path: '/map', label: 'Map' });
   } else if (parts[0] === 'messages') {

--- a/src/components/nav-main.tsx
+++ b/src/components/nav-main.tsx
@@ -1,5 +1,6 @@
 import {
   BarChartIcon,
+  CloudRainIcon,
   NetworkIcon,
   RadioIcon,
   ActivityIcon,
@@ -61,6 +62,14 @@ export function NavMain() {
               <Link to="/nodes/infrastructure">
                 <ServerIcon />
                 <span>Mesh Infrastructure</span>
+              </Link>
+            </SidebarMenuButton>
+          </SidebarMenuItem>
+          <SidebarMenuItem key="Weather">
+            <SidebarMenuButton asChild tooltip="Weather">
+              <Link to="/weather">
+                <CloudRainIcon />
+                <span>Weather</span>
               </Link>
             </SidebarMenuButton>
           </SidebarMenuItem>

--- a/src/components/nodes/EnvironmentMetricsMiniChart.tsx
+++ b/src/components/nodes/EnvironmentMetricsMiniChart.tsx
@@ -1,0 +1,179 @@
+import * as React from 'react';
+import { Line, LineChart, CartesianGrid, XAxis, YAxis, Tooltip, Text } from 'recharts';
+import { EnvironmentMetrics } from '@/lib/models';
+import { ChartConfig, ChartContainer, ChartTooltipContent } from '@/components/ui/chart';
+import { Formatter, NameType, ValueType, Payload } from 'recharts/types/component/DefaultTooltipContent';
+
+const MINI_SERIES: Array<{
+  dataKey: keyof EnvironmentMetrics;
+  label: string;
+  unit: string;
+  color: string;
+}> = [
+  { dataKey: 'temperature', label: 'Temp', unit: '°C', color: '#ff7b72' },
+  { dataKey: 'relative_humidity', label: 'RH', unit: '%', color: '#79c0ff' },
+  { dataKey: 'barometric_pressure', label: 'Pressure', unit: 'hPa', color: '#d0a8ff' },
+];
+
+const X_AXIS_TICK_COUNT = 4;
+
+interface EnvironmentMetricsMiniChartProps {
+  metrics: EnvironmentMetrics[];
+  dateRange: { startDate: Date; endDate: Date };
+}
+
+function SingleMetricChart({
+  dataKey,
+  label,
+  unit,
+  color,
+  chartData,
+  dateRange,
+}: {
+  dataKey: string;
+  label: string;
+  unit: string;
+  color: string;
+  chartData: Array<Record<string, number | null>>;
+  dateRange: { startDate: Date; endDate: Date };
+}) {
+  const chartConfig: ChartConfig = { [dataKey]: { color, label } };
+
+  const xTicks = React.useMemo(() => {
+    const start = dateRange.startDate.getTime();
+    const end = dateRange.endDate.getTime();
+    const ticks: number[] = [];
+    for (let i = 0; i <= X_AXIS_TICK_COUNT; i++) {
+      ticks.push(start + (end - start) * (i / X_AXIS_TICK_COUNT));
+    }
+    return ticks;
+  }, [dateRange.startDate, dateRange.endDate]);
+
+  const renderXAxisTick = React.useCallback(
+    (props: { x: number; y: number; payload: { value: number }; tickFormatter?: (v: number, i: number) => string }) => {
+      const { x, y, payload, tickFormatter } = props;
+      const isOurTick = xTicks.some((t) => Math.abs(t - payload.value) < 60_000);
+      if (!isOurTick) return <g />;
+      const value = tickFormatter ? tickFormatter(payload.value, 0) : String(payload.value);
+      return (
+        <Text
+          x={x}
+          y={y}
+          textAnchor="end"
+          verticalAnchor="start"
+          angle={-35}
+          className="recharts-cartesian-axis-tick-value"
+        >
+          {value}
+        </Text>
+      );
+    },
+    [xTicks]
+  );
+
+  const formatter: Formatter<ValueType, NameType> = (value: ValueType) => {
+    const numValue = typeof value === 'string' ? parseFloat(value) : value;
+    if (typeof numValue !== 'number' || isNaN(numValue)) return ['-', label];
+    const formatted = numValue.toFixed(1);
+    return [unit ? `${formatted} ${unit}` : formatted, label];
+  };
+
+  return (
+    <ChartContainer config={chartConfig} className="aspect-auto h-[100px] w-full min-w-0">
+      <LineChart data={chartData} margin={{ top: 4, right: 4, bottom: 28, left: 4 }}>
+        <CartesianGrid vertical={false} strokeDasharray="2 2" className="opacity-50" />
+        <XAxis
+          dataKey="timestamp"
+          tickLine={false}
+          axisLine={false}
+          tickMargin={12}
+          ticks={xTicks}
+          tick={renderXAxisTick}
+          interval={0}
+          domain={[dateRange.startDate.getTime(), dateRange.endDate.getTime()]}
+          tickFormatter={(value: number) => {
+            const date = new Date(value);
+            return date.toLocaleString('en-GB', {
+              month: 'short',
+              day: 'numeric',
+              hour: '2-digit',
+              minute: '2-digit',
+            });
+          }}
+          scale="time"
+          type="number"
+        />
+        <YAxis tickLine={false} axisLine={false} tick={{ fontSize: 9 }} width={28} domain={['auto', 'auto']} />
+        <Tooltip
+          content={
+            <ChartTooltipContent
+              labelFormatter={(_, payload: Payload<ValueType, NameType>[]) => {
+                if (payload?.[0]?.payload?.timestamp) {
+                  const date = new Date(payload[0].payload.timestamp);
+                  return date.toLocaleString('en-GB', {
+                    month: 'short',
+                    day: 'numeric',
+                    hour: 'numeric',
+                    minute: 'numeric',
+                  });
+                }
+                return '';
+              }}
+              formatter={formatter}
+            />
+          }
+        />
+        <Line type="monotone" dataKey={dataKey} stroke={color} strokeWidth={1.5} dot={false} connectNulls />
+      </LineChart>
+    </ChartContainer>
+  );
+}
+
+export function EnvironmentMetricsMiniChart({ metrics, dateRange }: EnvironmentMetricsMiniChartProps) {
+  const chartData = React.useMemo(() => {
+    return metrics
+      .filter((m) => m.reported_time != null)
+      .map((m) => {
+        const row: Record<string, number | null> = {
+          timestamp: new Date(m.reported_time!).getTime(),
+        };
+        for (const s of MINI_SERIES) {
+          const val = (m as unknown as Record<string, unknown>)[s.dataKey];
+          row[s.dataKey] = typeof val === 'number' ? val : null;
+        }
+        return row;
+      })
+      .sort((a, b) => (a.timestamp ?? 0) - (b.timestamp ?? 0));
+  }, [metrics]);
+
+  const seriesWithData = React.useMemo(
+    () => MINI_SERIES.filter((s) => chartData.some((d) => d[s.dataKey] != null)),
+    [chartData]
+  );
+
+  if (chartData.length === 0 || seriesWithData.length === 0) {
+    return (
+      <div className="h-[120px] flex items-center justify-center text-xs text-muted-foreground rounded border border-dashed">
+        No data
+      </div>
+    );
+  }
+
+  return (
+    <div className="grid grid-cols-1 sm:grid-cols-2 gap-4">
+      {seriesWithData.map((s) => (
+        <div key={s.dataKey} className="min-w-0">
+          <p className="text-xs font-medium text-muted-foreground mb-1">{s.label}</p>
+          <SingleMetricChart
+            dataKey={s.dataKey}
+            label={s.label}
+            unit={s.unit}
+            color={s.color}
+            chartData={chartData}
+            dateRange={dateRange}
+          />
+        </div>
+      ))}
+    </div>
+  );
+}

--- a/src/components/nodes/NodesAndConstellationsMap.tsx
+++ b/src/components/nodes/NodesAndConstellationsMap.tsx
@@ -8,6 +8,7 @@ import type { Feature, Point, Polygon, Position as GeoPosition } from 'geojson';
 import { useMapTileUrl } from '@/hooks/useMapTileUrl';
 import {
   createNodeIcon,
+  createWeatherNodeIcon,
   getRoleColor,
   boundaryPolygonFromPoints,
   precisionBitsToMeters,
@@ -54,6 +55,12 @@ export interface NodesAndConstellationsMapProps {
   onNodeSelect?: (node: MapNode | null) => boolean;
   /** When provided, highlights this node (e.g. selection from external source like search) */
   selectedNodeId?: number | null;
+  /** Optional custom label for observed node markers (e.g. weather metrics) */
+  getMarkerLabel?: (node: ObservedNode) => string;
+  /** Optional opacity 0-1 for observed node markers (e.g. age-based fading) */
+  getMarkerOpacity?: (node: ObservedNode) => number;
+  /** Optional grayscale 0-1 for observed node markers (e.g. 24h = 100% gray) */
+  getMarkerGrayscale?: (node: ObservedNode) => number;
 }
 
 export function NodesAndConstellationsMap({
@@ -70,6 +77,9 @@ export function NodesAndConstellationsMap({
   onMapMove,
   onNodeSelect,
   selectedNodeId: selectedNodeIdProp,
+  getMarkerLabel,
+  getMarkerOpacity,
+  getMarkerGrayscale,
 }: NodesAndConstellationsMapProps) {
   const mapRef = useRef<HTMLDivElement>(null);
   const mapInstanceRef = useRef<L.Map | null>(null);
@@ -151,6 +161,29 @@ export function NodesAndConstellationsMap({
           font-weight: bold;
           font-size: 12px;
           text-shadow: 1px 1px 2px rgba(0,0,0,0.5);
+        }
+        .weather-marker-container {
+          display: flex;
+          justify-content: center;
+          align-items: flex-end;
+        }
+        .weather-marker-pill {
+          padding: 8px 14px;
+          border-radius: 12px;
+          min-width: 60px;
+          max-width: 160px;
+          text-align: center;
+          box-shadow: 0 2px 6px rgba(0,0,0,0.35);
+          white-space: nowrap;
+          overflow: hidden;
+          text-overflow: ellipsis;
+        }
+        .weather-marker-text {
+          color: white;
+          font-size: 12px;
+          font-weight: 600;
+          text-shadow: 1px 1px 2px rgba(0,0,0,0.5);
+          line-height: 1.2;
         }
         .leaflet-container { z-index: 1; }
         .leaflet-pane, .leaflet-tile, .leaflet-marker-icon, .leaflet-marker-shadow,
@@ -366,13 +399,15 @@ export function NodesAndConstellationsMap({
       if (!pos) return;
       const position: L.LatLngExpression = [pos.lat, pos.lng];
       const isSelected = selectedNodeId === node.node_id;
+      const label = getMarkerLabel
+        ? getMarkerLabel(node as ObservedNode)
+        : node.short_name || node.node_id_str?.toString().slice(-4) || '?';
+      const opacity = getMarkerOpacity?.(node as ObservedNode);
+      const grayscale = getMarkerGrayscale?.(node as ObservedNode);
+      const color = getRoleColor('role' in node ? node.role : undefined);
+      const iconFn = getMarkerLabel ? createWeatherNodeIcon : createNodeIcon;
       const marker = L.marker(position, {
-        icon: createNodeIcon(
-          node.short_name || node.node_id_str?.toString().slice(-4) || '?',
-          getRoleColor('role' in node ? node.role : undefined),
-          isSelected,
-          hasSelection && !isSelected
-        ),
+        icon: iconFn(label, color, isSelected, hasSelection && !isSelected, opacity, grayscale),
       });
       marker.on('click', () => handleMarkerClick(node));
       if (enableBubbles) {
@@ -430,6 +465,9 @@ export function NodesAndConstellationsMap({
     enableBubbles,
     selectedNodeId,
     handleMarkerClick,
+    getMarkerLabel,
+    getMarkerOpacity,
+    getMarkerGrayscale,
   ]);
 
   return (

--- a/src/components/nodes/WeatherNodeCard.tsx
+++ b/src/components/nodes/WeatherNodeCard.tsx
@@ -1,0 +1,63 @@
+import { Link } from 'react-router-dom';
+import { formatDistanceToNow } from 'date-fns';
+import { EnvironmentMetrics, ObservedNode } from '@/lib/models';
+import { EnvironmentMetricsMiniChart } from './EnvironmentMetricsMiniChart';
+import { ChevronRight } from 'lucide-react';
+import { memo } from 'react';
+
+interface WeatherNodeCardProps {
+  node: ObservedNode;
+  /** Environment metrics history for mini chart */
+  metrics?: EnvironmentMetrics[];
+  dateRange?: { startDate: Date; endDate: Date };
+}
+
+function WeatherNodeCardInner({ node, metrics, dateRange }: WeatherNodeCardProps) {
+  const env = node.latest_environment_metrics;
+  const envReportedTime = env?.reported_time ? new Date(env.reported_time) : null;
+
+  return (
+    <div className="flex flex-col h-full p-6 bg-white dark:bg-slate-800 rounded-lg shadow-md hover:shadow-lg transition-shadow duration-200 border border-slate-200 dark:border-slate-700">
+      <div className="flex justify-between items-start mb-4">
+        <div>
+          <h2 className="text-xl font-semibold text-slate-900 dark:text-slate-100">{node.short_name}</h2>
+          <p className="text-slate-600 dark:text-slate-400">{node.long_name}</p>
+        </div>
+        <div className="flex flex-col items-end gap-1">
+          <span className="text-sm text-slate-500 dark:text-slate-400">
+            {envReportedTime ? formatDistanceToNow(envReportedTime, { addSuffix: true }) : 'No env data'}
+          </span>
+        </div>
+      </div>
+      <div className="flex-1 space-y-2">
+        <p className="text-slate-600 dark:text-slate-400">ID: {node.node_id_str}</p>
+        {node.owner && <p className="text-slate-600 dark:text-slate-400">Owner: {node.owner.username}</p>}
+        {env && (
+          <div className="flex flex-wrap gap-3 text-sm">
+            {env.temperature != null && <span>Temp: {env.temperature.toFixed(1)}°C</span>}
+            {env.barometric_pressure != null && <span>Pressure: {Math.round(env.barometric_pressure)} hPa</span>}
+            {env.relative_humidity != null && <span>RH: {Math.round(env.relative_humidity)}%</span>}
+            {env.iaq != null && <span>IAQ: {env.iaq}</span>}
+            {env.lux != null && <span>Lux: {env.lux.toFixed(0)} lx</span>}
+          </div>
+        )}
+        {metrics != null && metrics.length > 0 && dateRange && (
+          <div className="mt-3 -mx-2">
+            <EnvironmentMetricsMiniChart metrics={metrics} dateRange={dateRange} />
+          </div>
+        )}
+      </div>
+      <div className="mt-auto flex justify-end pt-3">
+        <Link
+          to={`/nodes/${node.node_id}`}
+          className="inline-flex items-center gap-1.5 text-sm text-primary hover:underline"
+        >
+          Open node details
+          <ChevronRight className="h-3.5 w-3.5" />
+        </Link>
+      </div>
+    </div>
+  );
+}
+
+export const WeatherNodeCard = memo(WeatherNodeCardInner);

--- a/src/components/nodes/WeatherNodesMap.tsx
+++ b/src/components/nodes/WeatherNodesMap.tsx
@@ -1,0 +1,86 @@
+import { useMemo } from 'react';
+import { subHours } from 'date-fns';
+import { ObservedNode } from '@/lib/models';
+import { NodesAndConstellationsMap } from './NodesAndConstellationsMap';
+import { LatestEnvironmentMetrics } from '@/lib/models';
+
+const MAP_CUTOFF_HOURS = 24;
+
+function hasRecentLocation(node: ObservedNode): boolean {
+  const pos = node.latest_position as {
+    latitude?: number;
+    longitude?: number;
+    reported_time?: Date | string;
+  } | null;
+  if (!pos) return false;
+  const lat = pos.latitude;
+  const lon = pos.longitude;
+  if (lat == null || lon == null || lat === 0 || lon === 0) return false;
+  return true;
+}
+
+function getEnvironmentReportedTime(node: ObservedNode): Date | null {
+  const env = node.latest_environment_metrics as LatestEnvironmentMetrics | null;
+  if (!env?.reported_time) return null;
+  return new Date(env.reported_time);
+}
+
+function formatWeatherLabel(env: LatestEnvironmentMetrics | null | undefined): string {
+  if (!env) return '—';
+  const parts: string[] = [];
+  if (env.temperature != null) parts.push(`${env.temperature.toFixed(1)}°C`);
+  // if (env.barometric_pressure != null) parts.push(`${Math.round(env.barometric_pressure)} hPa`);
+  // if (env.relative_humidity != null) parts.push(`${Math.round(env.relative_humidity)}%`);
+  return parts.length > 0 ? parts.join(' | ') : '—';
+}
+
+export interface WeatherNodesMapProps {
+  nodes: ObservedNode[];
+  /** Nodes with env reported after this are shown on map. Older are hidden. Default 24h. */
+  cutoffHours?: number;
+}
+
+/**
+ * Map of weather nodes with temp/pressure/RH labels and age-based grayscale fading.
+ * Nodes with env readings > cutoffHours ago are hidden.
+ */
+export function WeatherNodesMap({ nodes, cutoffHours = MAP_CUTOFF_HOURS }: WeatherNodesMapProps) {
+  const cutoff = useMemo(() => subHours(new Date(), cutoffHours), [cutoffHours]);
+
+  const nodesForMap = useMemo(() => {
+    return nodes.filter((node) => {
+      if (!hasRecentLocation(node)) return false;
+      const reported = getEnvironmentReportedTime(node);
+      if (!reported) return false;
+      return reported >= cutoff;
+    });
+  }, [nodes, cutoff]);
+
+  const getMarkerLabel = useMemo(() => (node: ObservedNode) => formatWeatherLabel(node.latest_environment_metrics), []);
+
+  const getMarkerGrayscale = useMemo(
+    () => (node: ObservedNode) => {
+      const reported = getEnvironmentReportedTime(node);
+      if (!reported) return 1;
+      const ageMs = Date.now() - reported.getTime();
+      const ageHours = ageMs / (1000 * 60 * 60);
+      if (ageHours >= MAP_CUTOFF_HOURS) return 1;
+      return ageHours / MAP_CUTOFF_HOURS;
+    },
+    []
+  );
+
+  return (
+    <NodesAndConstellationsMap
+      observedNodes={nodesForMap}
+      managedNodes={[]}
+      showConstellation={false}
+      showUnmanagedNodes={true}
+      drawBoundingBox={false}
+      drawPositionUncertainty={false}
+      enableBubbles={true}
+      getMarkerLabel={getMarkerLabel}
+      getMarkerGrayscale={getMarkerGrayscale}
+    />
+  );
+}

--- a/src/components/nodes/map-utils.ts
+++ b/src/components/nodes/map-utils.ts
@@ -57,18 +57,35 @@ function escapeHtml(s: string): string {
   return div.innerHTML;
 }
 
+function escapeHtmlForMarker(s: string): string {
+  return s.replace(/&/g, '&amp;').replace(/</g, '&lt;').replace(/>/g, '&gt;').replace(/"/g, '&quot;');
+}
+
 /**
  * Create a custom marker icon with bottom-centre anchor.
  * The teardrop tip aligns with the map point.
  * @param dimmed - When true, applies opacity 0.5 (for unselected nodes when one is selected)
+ * @param opacity - Optional 0-1 opacity override
+ * @param grayscale - Optional 0-1 grayscale (CSS filter, 0=full color, 1=100% gray)
  */
-export function createNodeIcon(text: string, color: string, highlighted = false, dimmed = false): L.DivIcon {
+export function createNodeIcon(
+  text: string,
+  color: string,
+  highlighted = false,
+  dimmed = false,
+  opacity?: number,
+  grayscale?: number
+): L.DivIcon {
   const highlightClass = highlighted ? ' marker-pin-highlighted' : '';
-  const dimmedStyle = dimmed ? 'opacity: 0.5;' : '';
+  const styles: string[] = [];
+  if (opacity != null) styles.push(`opacity: ${opacity}`);
+  else if (dimmed) styles.push('opacity: 0.5');
+  if (grayscale != null && grayscale > 0) styles.push(`filter: grayscale(${grayscale * 100}%)`);
+  const containerStyle = styles.length > 0 ? styles.join('; ') + ';' : '';
   return L.divIcon({
     className: 'custom-node-marker',
     html: `
-      <div class="marker-container" style="${dimmedStyle}">
+      <div class="marker-container" style="${containerStyle}">
         <div class="marker-pin${highlightClass}" style="background: ${color};"></div>
         <span class="marker-text">${text}</span>
       </div>
@@ -76,6 +93,48 @@ export function createNodeIcon(text: string, color: string, highlighted = false,
     iconSize: [40, 40],
     iconAnchor: [20, 40],
     popupAnchor: [0, -40],
+  });
+}
+
+const WEATHER_MARKER_WIDTH = 130;
+const WEATHER_MARKER_HEIGHT = 56;
+
+/**
+ * Create a larger rounded-rectangle marker for weather nodes.
+ * Better readability for multi-line labels (temp | pressure | RH).
+ * @param text - Label content (e.g. "9.5°C | 955 hPa | 68%")
+ * @param color - Background color
+ * @param highlighted - When true, adds highlight ring
+ * @param dimmed - When true, applies opacity 0.5
+ * @param opacity - Optional 0-1 opacity override
+ * @param grayscale - Optional 0-1 grayscale (0=full color, 1=100% gray)
+ */
+export function createWeatherNodeIcon(
+  text: string,
+  color: string,
+  highlighted = false,
+  dimmed = false,
+  opacity?: number,
+  grayscale?: number
+): L.DivIcon {
+  const styles: string[] = [];
+  if (opacity != null) styles.push(`opacity: ${opacity}`);
+  else if (dimmed) styles.push('opacity: 0.5');
+  if (grayscale != null && grayscale > 0) styles.push(`filter: grayscale(${grayscale * 100}%)`);
+  const containerStyle = styles.length > 0 ? styles.join('; ') + ';' : '';
+  const highlightStyle = highlighted ? 'box-shadow: 0 0 0 3px rgba(226, 153, 6, 0.9);' : '';
+  return L.divIcon({
+    className: 'custom-node-marker weather-node-marker',
+    html: `
+      <div class="weather-marker-container" style="${containerStyle}">
+        <div class="weather-marker-pill" style="background: ${color}; ${highlightStyle}">
+          <span class="weather-marker-text">${escapeHtmlForMarker(text)}</span>
+        </div>
+      </div>
+    `,
+    iconSize: [WEATHER_MARKER_WIDTH, WEATHER_MARKER_HEIGHT],
+    iconAnchor: [WEATHER_MARKER_WIDTH / 2, WEATHER_MARKER_HEIGHT],
+    popupAnchor: [0, -WEATHER_MARKER_HEIGHT],
   });
 }
 

--- a/src/hooks/api/useMultiNodeEnvironmentMetrics.ts
+++ b/src/hooks/api/useMultiNodeEnvironmentMetrics.ts
@@ -1,0 +1,86 @@
+import { useQuery, useSuspenseQuery } from '@tanstack/react-query';
+import { useMeshtasticApi } from './useApi';
+import { EnvironmentMetrics, ObservedNode } from '@/lib/models';
+import { DateRangeParams } from '@/lib/types';
+import { getKeyValue, roundDateParams } from './hooks-utils';
+
+/**
+ * Transform flat bulk response into metricsMap keyed by node_id.
+ * Strips node_id, node_id_str, short_name from each item for EnvironmentMetrics shape.
+ */
+function bulkResultsToMetricsMap(
+  results: Array<EnvironmentMetrics & { node_id: number; node_id_str?: string; short_name?: string | null }>
+): Record<number, EnvironmentMetrics[]> {
+  const map: Record<number, EnvironmentMetrics[]> = {};
+  for (const item of results) {
+    const { node_id, ...metric } = item;
+    if (!map[node_id]) map[node_id] = [];
+    map[node_id].push(metric as EnvironmentMetrics);
+  }
+  // Sort each node's metrics by reported_time ascending (for chart ordering)
+  for (const nodeId of Object.keys(map)) {
+    map[Number(nodeId)].sort((a, b) => {
+      const ta = a.reported_time != null ? new Date(a.reported_time).getTime() : 0;
+      const tb = b.reported_time != null ? new Date(b.reported_time).getTime() : 0;
+      return ta - tb;
+    });
+  }
+  return map;
+}
+
+/**
+ * Hook to fetch environment metrics for multiple nodes via bulk endpoint (single request).
+ * @param nodes Array of nodes to fetch metrics for
+ * @param dateRange Optional date range to filter metrics
+ * @returns Object with metricsMap and loading/error states
+ */
+export function useMultiNodeEnvironmentMetrics(nodes: ObservedNode[], dateRange?: DateRangeParams) {
+  const api = useMeshtasticApi();
+  const nodeIds = nodes.map((n) => n.node_id);
+  const params = roundDateParams(dateRange);
+  const keyValue = getKeyValue(params);
+  const queryKey = ['nodes', 'environment-metrics-bulk', nodeIds.sort().join(','), keyValue];
+
+  const query = useQuery({
+    queryKey,
+    queryFn: async () => {
+      const results = await api.getEnvironmentMetricsBulk(nodeIds, params);
+      return bulkResultsToMetricsMap(results);
+    },
+    enabled: nodeIds.length > 0,
+  });
+
+  const metricsMap = query.data ?? Object.fromEntries(nodeIds.map((id) => [id, []]));
+
+  return {
+    metricsMap,
+    isLoading: query.isLoading,
+    isError: query.isError,
+    errors: query.error ? [query.error] : [],
+  };
+}
+
+/**
+ * Suspense-enabled hook to fetch environment metrics for multiple nodes via bulk endpoint.
+ * Use inside a <Suspense> boundary. No isLoading or error states are returned.
+ */
+export function useMultiNodeEnvironmentMetricsSuspense(nodes: ObservedNode[], params?: DateRangeParams) {
+  const api = useMeshtasticApi();
+  const roundedParams = roundDateParams(params);
+  const nodeIds = nodes.map((n) => n.node_id);
+  const keyValue = getKeyValue(roundedParams);
+  const queryKey = ['nodes', 'environment-metrics-bulk', nodeIds.sort().join(','), keyValue];
+
+  const query = useSuspenseQuery({
+    queryKey,
+    queryFn: async () => {
+      if (nodeIds.length === 0) return {};
+      const results = await api.getEnvironmentMetricsBulk(nodeIds, roundedParams);
+      return bulkResultsToMetricsMap(results);
+    },
+  });
+
+  return {
+    metricsMap: (query.data ?? {}) as Record<number, EnvironmentMetrics[]>,
+  };
+}

--- a/src/hooks/api/useNodes.ts
+++ b/src/hooks/api/useNodes.ts
@@ -367,6 +367,53 @@ export function useInfrastructureNodesSuspense(options?: UseInfrastructureNodesO
   };
 }
 
+export interface UseWeatherNodesOptions {
+  pageSize?: number;
+  environmentReportedAfter?: Date;
+}
+
+/**
+ * Suspense-enabled hook to fetch weather nodes (nodes with environment metrics within cutoff).
+ */
+export function useWeatherNodesSuspense(options?: UseWeatherNodesOptions) {
+  const api = useMeshtasticApi();
+  const pageSize = options?.pageSize || 100;
+  const environmentReportedAfterKey = options?.environmentReportedAfter
+    ? roundToFiveMinutes(options.environmentReportedAfter)
+    : null;
+
+  const nodesQuery = useSuspenseInfiniteQuery<PaginatedResponse<ObservedNode>, Error>({
+    refetchInterval: 1000 * 60, // 1 minute
+    queryKey: ['nodes', 'weather', pageSize, environmentReportedAfterKey],
+    queryFn: async ({ pageParam = 1 }) =>
+      api.getWeatherNodes({
+        page: pageParam as number,
+        pageSize,
+        environmentReportedAfter: options?.environmentReportedAfter,
+      }),
+    initialPageParam: 1,
+    getNextPageParam: (lastPage, allPages) => (lastPage.next ? allPages.length + 1 : undefined),
+  });
+
+  if (!nodesQuery.data) {
+    return {
+      nodes: [],
+      totalNodes: 0,
+      fetchNextPage: nodesQuery.fetchNextPage,
+      hasNextPage: false,
+    };
+  }
+
+  const allNodes = nodesQuery.data.pages.flatMap((page) => page.results);
+
+  return {
+    nodes: allNodes,
+    totalNodes: nodesQuery.data.pages[0]?.count || 0,
+    fetchNextPage: nodesQuery.fetchNextPage,
+    hasNextPage: nodesQuery.hasNextPage,
+  };
+}
+
 /**
  * Suspense-enabled hook to fetch managed nodes with pagination
  */

--- a/src/lib/api/meshtastic-api.ts
+++ b/src/lib/api/meshtastic-api.ts
@@ -117,6 +117,28 @@ export class MeshtasticApi extends BaseApi {
   }
 
   /**
+   * Get weather nodes (nodes with environment metrics within cutoff).
+   */
+  async getWeatherNodes(params?: {
+    environmentReportedAfter?: Date;
+    page?: number;
+    pageSize?: number;
+  }): Promise<PaginatedResponse<ObservedNode>> {
+    const searchParams = new URLSearchParams();
+    if (params?.page) searchParams.append('page', params.page.toString());
+    if (params?.pageSize) searchParams.append('page_size', params.pageSize.toString());
+    if (params?.environmentReportedAfter) {
+      searchParams.append('environment_reported_after', params.environmentReportedAfter.toISOString());
+    }
+
+    const response = await this.get<PaginatedResponse<ObservedNode>>('/nodes/observed-nodes/weather/', searchParams);
+    return {
+      ...response,
+      results: response.results.map((node) => parseObservedNodeFromAPI(node)),
+    };
+  }
+
+  /**
    * Search for observed nodes
    */
   async searchNodes(query: string): Promise<NodeSearchResult[]> {
@@ -160,6 +182,30 @@ export class MeshtasticApi extends BaseApi {
 
     const metrics = await this.get<DeviceMetrics[]>(`/nodes/observed-nodes/${id}/device_metrics/`, searchParams);
     return metrics.map((metric) => ({
+      ...metric,
+      logged_time: metric.logged_time != null ? new Date(metric.logged_time) : null,
+      reported_time: metric.reported_time != null ? new Date(metric.reported_time) : null,
+    }));
+  }
+
+  /**
+   * Get environment metrics for multiple nodes in one request (bulk).
+   * Returns flat list; frontend groups by node_id for per-node charts.
+   */
+  async getEnvironmentMetricsBulk(
+    nodeIds: number[],
+    params?: DateRangeParams
+  ): Promise<Array<EnvironmentMetrics & { node_id: number; node_id_str: string; short_name: string | null }>> {
+    if (nodeIds.length === 0) return [];
+    const searchParams = new URLSearchParams();
+    searchParams.append('node_ids', nodeIds.join(','));
+    if (params?.startDate) searchParams.append('start_date', params.startDate.toISOString());
+    if (params?.endDate) searchParams.append('end_date', params.endDate.toISOString());
+
+    const response = await this.get<{
+      results: Array<EnvironmentMetrics & { node_id: number; node_id_str: string; short_name: string | null }>;
+    }>('/nodes/environment-metrics-bulk/', searchParams);
+    return (response.results || []).map((metric) => ({
       ...metric,
       logged_time: metric.logged_time != null ? new Date(metric.logged_time) : null,
       reported_time: metric.reported_time != null ? new Date(metric.reported_time) : null,

--- a/src/pages/Weather.tsx
+++ b/src/pages/Weather.tsx
@@ -1,0 +1,181 @@
+import { useMemo, useState, Suspense } from 'react';
+import { subHours } from 'date-fns';
+import { useWeatherNodesSuspense } from '@/hooks/api/useNodes';
+import { useMultiNodeEnvironmentMetricsSuspense } from '@/hooks/api/useMultiNodeEnvironmentMetrics';
+import { WeatherNodeCard } from '@/components/nodes/WeatherNodeCard';
+import { WeatherNodesMap } from '@/components/nodes/WeatherNodesMap';
+import { TimeRangeSelect } from '@/components/TimeRangeSelect';
+import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from '@/components/ui/select';
+import { Card, CardHeader, CardTitle, CardContent } from '@/components/ui/card';
+import { Button } from '@/components/ui/button';
+
+const CHART_TIME_RANGE_OPTIONS = [
+  { key: '24h', label: '24 hours' },
+  { key: '48h', label: '48 hours' },
+  { key: '7d', label: '7 days' },
+  { key: '14d', label: '14 days' },
+];
+
+type EnvCutoffRange = '2h' | '6h' | '12h' | '24h';
+
+const ENV_CUTOFF_OPTIONS: { value: EnvCutoffRange; label: string }[] = [
+  { value: '2h', label: '2 hours' },
+  { value: '6h', label: '6 hours' },
+  { value: '12h', label: '12 hours' },
+  { value: '24h', label: '24 hours' },
+];
+
+function getEnvironmentReportedAfter(cutoff: EnvCutoffRange): Date {
+  const now = new Date();
+  switch (cutoff) {
+    case '2h':
+      return subHours(now, 2);
+    case '6h':
+      return subHours(now, 6);
+    case '12h':
+      return subHours(now, 12);
+    case '24h':
+    default:
+      return subHours(now, 24);
+  }
+}
+
+function getChartDateRange(key: string): { startDate: Date; endDate: Date } {
+  const now = new Date();
+  const hours = key.endsWith('h') ? parseInt(key) || 48 : 0;
+  const days = key.endsWith('d') ? parseInt(key) || 7 : 0;
+  const startDate =
+    days > 0 ? new Date(now.getTime() - days * 24 * 60 * 60 * 1000) : new Date(now.getTime() - hours * 60 * 60 * 1000);
+  return { startDate, endDate: now };
+}
+
+function WeatherContent() {
+  const [envCutoff, setEnvCutoff] = useState<EnvCutoffRange>('24h');
+  const [chartTimeRangeLabel, setChartTimeRangeLabel] = useState('48h');
+  const [chartDateRange, setChartDateRange] = useState<{ startDate: Date; endDate: Date }>(() =>
+    getChartDateRange('48h')
+  );
+
+  const environmentReportedAfter = useMemo(() => getEnvironmentReportedAfter(envCutoff), [envCutoff]);
+
+  const { nodes, totalNodes, fetchNextPage, hasNextPage } = useWeatherNodesSuspense({
+    environmentReportedAfter,
+    pageSize: 100,
+  });
+
+  const { metricsMap } = useMultiNodeEnvironmentMetricsSuspense(nodes, chartDateRange);
+
+  const sortedNodes = useMemo(
+    () =>
+      [...nodes].sort((a, b) => {
+        const aTime = a.latest_environment_metrics?.reported_time;
+        const bTime = b.latest_environment_metrics?.reported_time;
+        if (!aTime) return 1;
+        if (!bTime) return -1;
+        return new Date(bTime).getTime() - new Date(aTime).getTime();
+      }),
+    [nodes]
+  );
+
+  const handleChartTimeRangeChange = (value: string, timeRange: { startDate: Date; endDate: Date }) => {
+    setChartTimeRangeLabel(value);
+    setChartDateRange(timeRange);
+  };
+
+  return (
+    <div className="container mx-auto px-4 py-8">
+      <div className="mb-6">
+        <h1 className="text-3xl font-bold">Weather</h1>
+        <p className="mt-1 text-muted-foreground">
+          Nodes reporting environment metrics (temperature, pressure, humidity)
+        </p>
+      </div>
+
+      <div className="flex flex-col sm:flex-row flex-wrap justify-between items-start sm:items-center gap-4 mb-8">
+        <div className="flex items-center gap-2">
+          <label htmlFor="env-cutoff" className="text-sm text-muted-foreground">
+            Show nodes with env data from:
+          </label>
+          <Select value={envCutoff} onValueChange={(v) => setEnvCutoff(v as EnvCutoffRange)}>
+            <SelectTrigger className="w-[180px]" id="env-cutoff" aria-label="Select env cutoff">
+              <SelectValue placeholder="Select cutoff" />
+            </SelectTrigger>
+            <SelectContent>
+              {ENV_CUTOFF_OPTIONS.map((opt) => (
+                <SelectItem key={opt.value} value={opt.value}>
+                  {opt.label}
+                </SelectItem>
+              ))}
+            </SelectContent>
+          </Select>
+        </div>
+        <div className="flex items-center gap-2">
+          <label htmlFor="chart-time-range" className="text-sm text-muted-foreground">
+            Chart time range:
+          </label>
+          <TimeRangeSelect
+            options={CHART_TIME_RANGE_OPTIONS}
+            value={chartTimeRangeLabel}
+            onChange={handleChartTimeRangeChange}
+          />
+        </div>
+      </div>
+
+      <div className="mb-8">
+        <Card>
+          <CardHeader>
+            <CardTitle>Weather Node Locations</CardTitle>
+            <p className="text-sm text-muted-foreground">
+              Nodes fade to gray based on reading age (24h ago = 100% gray). Nodes with readings &gt;24h ago are hidden.
+            </p>
+          </CardHeader>
+          <CardContent>
+            <div className="h-[600px] w-full">
+              <WeatherNodesMap nodes={nodes} cutoffHours={24} />
+            </div>
+          </CardContent>
+        </Card>
+      </div>
+
+      <div className="space-y-4">
+        <div className="flex items-center justify-between">
+          <h2 className="text-xl font-semibold">
+            All Weather Nodes ({sortedNodes.length}
+            {totalNodes > sortedNodes.length ? ` of ${totalNodes}` : ''})
+          </h2>
+        </div>
+        <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-6">
+          {sortedNodes.map((node) => (
+            <WeatherNodeCard
+              key={node.internal_id}
+              node={node}
+              metrics={metricsMap[node.node_id] ?? []}
+              dateRange={chartDateRange}
+            />
+          ))}
+        </div>
+        {hasNextPage && (
+          <div className="flex justify-center pt-4">
+            <Button variant="outline" onClick={() => fetchNextPage()}>
+              Load more
+            </Button>
+          </div>
+        )}
+      </div>
+    </div>
+  );
+}
+
+export function Weather() {
+  return (
+    <Suspense
+      fallback={
+        <div className="flex justify-center min-h-screen items-center">
+          <div className="animate-spin rounded-full h-12 w-12 border-t-2 border-b-2 border-primary"></div>
+        </div>
+      }
+    >
+      <WeatherContent />
+    </Suspense>
+  );
+}


### PR DESCRIPTION
# Summary

Add Weather page: displays nodes with environment metrics on a map with temp/pressure/RH labels, age-based grayscale fading, and per-node mini charts. Mirrors Infrastructure page structure.

**Changes:**
- **Weather page** (`/weather`): Header, env cutoff filter (2h, 6h, 12h, 24h), chart time range, map card, node cards grid
- **Map markers**: Larger rounded-rectangle markers for weather nodes (130×56px) with clear temp | pressure | RH labels. Nodes fade to gray by reading age (24h = 100% gray, >24h hidden)
- **API client**: `getWeatherNodes()`, `getEnvironmentMetricsBulk()`
- **Hooks**: `useWeatherNodesSuspense()`, `useMultiNodeEnvironmentMetricsSuspense()`
- **Components**: `WeatherNodesMap`, `WeatherNodeCard`, `EnvironmentMetricsMiniChart`
- **EnvironmentMetricsMiniChart**: Individual charts per metric (Temp, RH, Pressure), max 2 per row. Explicit X-axis ticks (4) with slanted labels to prevent overlap; increased bottom margin for tick clearance
- **Map utils**: `createWeatherNodeIcon()` for rounded-rectangle markers; extended `NodesAndConstellationsMap` with `getMarkerLabel`, `getMarkerOpacity`, `getMarkerGrayscale` for custom weather markers
- **Navigation**: Weather nav item (CloudRain icon), route `/weather`, breadcrumb

## Testing performed

- `npm run build` succeeds
- `npm run lint` passes
