### PR TITLE
feat: add IGNORE_PORTNUMS, TR_HOPS_LIMIT++ to onboarding instructions

### DIFF
--- a/src/components/nodes/BotSetupInstructions.test.tsx
+++ b/src/components/nodes/BotSetupInstructions.test.tsx
@@ -1,0 +1,87 @@
+import { describe, it, expect } from 'vitest';
+import { render } from '@testing-library/react';
+import { BotSetupInstructions } from './BotSetupInstructions';
+
+function getEmbeddedDockerComposeContent(container: HTMLElement): string {
+  const pres = container.querySelectorAll('pre');
+  for (const pre of pres) {
+    const text = pre.textContent || '';
+    if (text.includes('STORAGE_API_TOKEN=test-key') && text.includes('meshtastic-bot:')) {
+      return text;
+    }
+  }
+  return '';
+}
+
+describe('BotSetupInstructions', () => {
+  it('renders docker-compose without bot env vars when botDefaults not provided', () => {
+    const { container } = render(
+      <BotSetupInstructions apiKey="test-key" apiBaseUrl="https://api.example.com" />
+    );
+
+    const embeddedContent = getEmbeddedDockerComposeContent(container);
+    expect(embeddedContent).toBeTruthy();
+    expect(embeddedContent).not.toContain('IGNORE_PORTNUMS');
+    expect(embeddedContent).not.toContain('TR_HOPS_LIMIT');
+    expect(embeddedContent).not.toContain('TEXT_MESSAGE_MAX_HOPS');
+  });
+
+  it('includes IGNORE_PORTNUMS in docker-compose when botDefaults.ignorePortnums provided', () => {
+    const { container } = render(
+      <BotSetupInstructions
+        apiKey="test-key"
+        apiBaseUrl="https://api.example.com"
+        botDefaults={{ ignorePortnums: '345,ROUTING_APP' }}
+      />
+    );
+
+    const embeddedContent = getEmbeddedDockerComposeContent(container);
+    expect(embeddedContent).toContain('IGNORE_PORTNUMS=345,ROUTING_APP');
+  });
+
+  it('includes TR_HOPS_LIMIT and TEXT_MESSAGE_MAX_HOPS when botDefaults.hopLimit provided', () => {
+    const { container } = render(
+      <BotSetupInstructions
+        apiKey="test-key"
+        apiBaseUrl="https://api.example.com"
+        botDefaults={{ hopLimit: 5 }}
+      />
+    );
+
+    const embeddedContent = getEmbeddedDockerComposeContent(container);
+    expect(embeddedContent).toContain('TR_HOPS_LIMIT=5');
+    expect(embeddedContent).toContain('TEXT_MESSAGE_MAX_HOPS=5');
+  });
+
+  it('includes all bot env vars when full botDefaults provided', () => {
+    const { container } = render(
+      <BotSetupInstructions
+        apiKey="test-key"
+        apiBaseUrl="https://api.example.com"
+        botDefaults={{
+          ignorePortnums: '345,ROUTING_APP',
+          hopLimit: 7,
+        }}
+      />
+    );
+
+    const embeddedContent = getEmbeddedDockerComposeContent(container);
+    expect(embeddedContent).toContain('IGNORE_PORTNUMS=345,ROUTING_APP');
+    expect(embeddedContent).toContain('TR_HOPS_LIMIT=7');
+    expect(embeddedContent).toContain('TEXT_MESSAGE_MAX_HOPS=7');
+  });
+
+  it('omits hop limit env vars when hopLimit is out of range', () => {
+    const { container } = render(
+      <BotSetupInstructions
+        apiKey="test-key"
+        apiBaseUrl="https://api.example.com"
+        botDefaults={{ hopLimit: 0 }}
+      />
+    );
+
+    const embeddedContent = getEmbeddedDockerComposeContent(container);
+    expect(embeddedContent).not.toContain('TR_HOPS_LIMIT');
+    expect(embeddedContent).not.toContain('TEXT_MESSAGE_MAX_HOPS');
+  });
+});

--- a/src/components/nodes/BotSetupInstructions.tsx
+++ b/src/components/nodes/BotSetupInstructions.tsx
@@ -3,18 +3,52 @@ import { Button } from '@/components/ui/button';
 import { Tabs, TabsContent, TabsList, TabsTrigger } from '@/components/ui/tabs';
 import { Copy, Download, ExternalLink } from 'lucide-react';
 
+export interface BotDefaults {
+  ignorePortnums?: string | null;
+  hopLimit?: number | null;
+}
+
 interface BotSetupInstructionsProps {
   apiKey: string;
   apiBaseUrl: string;
   nodeShortName?: string;
+  botDefaults?: BotDefaults;
 }
 
 function deriveWsUrl(httpUrl: string): string {
   return httpUrl.replace(/^http:\/\//, 'ws://').replace(/^https:\/\//, 'wss://');
 }
 
-function generateDockerComposeEmbedded(apiBaseUrl: string, apiKey: string): string {
+function buildBotEnvVars(botDefaults?: BotDefaults): string[] {
+  const lines: string[] = [];
+  if (botDefaults?.ignorePortnums?.trim()) {
+    lines.push(`      - IGNORE_PORTNUMS=${botDefaults.ignorePortnums.trim()}`);
+  }
+  const hopLimit = botDefaults?.hopLimit;
+  if (typeof hopLimit === 'number' && hopLimit >= 1 && hopLimit <= 7) {
+    lines.push(`      - TR_HOPS_LIMIT=${hopLimit}`);
+    lines.push(`      - TEXT_MESSAGE_MAX_HOPS=${hopLimit}`);
+  }
+  return lines;
+}
+
+function buildBotEnvVarsForEnvFile(botDefaults?: BotDefaults): string[] {
+  const lines: string[] = [];
+  if (botDefaults?.ignorePortnums?.trim()) {
+    lines.push(`IGNORE_PORTNUMS=${botDefaults.ignorePortnums.trim()}`);
+  }
+  const hopLimit = botDefaults?.hopLimit;
+  if (typeof hopLimit === 'number' && hopLimit >= 1 && hopLimit <= 7) {
+    lines.push(`TR_HOPS_LIMIT=${hopLimit}`);
+    lines.push(`TEXT_MESSAGE_MAX_HOPS=${hopLimit}`);
+  }
+  return lines;
+}
+
+function generateDockerComposeEmbedded(apiBaseUrl: string, apiKey: string, botDefaults?: BotDefaults): string {
   const wsUrl = deriveWsUrl(apiBaseUrl);
+  const botEnvLines = buildBotEnvVars(botDefaults);
+  const botEnvBlock = botEnvLines.length > 0 ? '\n' + botEnvLines.join('\n') : '';
   return `---
 services:
   meshtastic-bot:
@@ -27,7 +61,7 @@ services:
       - STORAGE_API_ROOT=${apiBaseUrl}
       - STORAGE_API_TOKEN=${apiKey}
       - STORAGE_API_VERSION=2
-      - MESHFLOW_WS_URL=${wsUrl}
+      - MESHFLOW_WS_URL=${wsUrl}${botEnvBlock}
     volumes:
       - ./data:/app/data
     depends_on:
@@ -67,8 +101,10 @@ services:
 `;
 }
 
-function generateEnvFile(apiBaseUrl: string, apiKey: string): string {
+function generateEnvFile(apiBaseUrl: string, apiKey: string, botDefaults?: BotDefaults): string {
   const wsUrl = deriveWsUrl(apiBaseUrl);
+  const botEnvLines = buildBotEnvVarsForEnvFile(botDefaults);
+  const botEnvBlock = botEnvLines.length > 0 ? '\n\n' + botEnvLines.join('\n') : '';
   return `# Meshtastic Bot configuration
 # Copy this file to .env in the same directory as docker-compose.yaml
 
@@ -78,7 +114,7 @@ ADMIN_NODES='!xxxxxxxx'
 STORAGE_API_ROOT=${apiBaseUrl}
 STORAGE_API_TOKEN=${apiKey}
 STORAGE_API_VERSION=2
-MESHFLOW_WS_URL=${wsUrl}
+MESHFLOW_WS_URL=${wsUrl}${botEnvBlock}
 `;
 }
 
@@ -92,13 +128,13 @@ function downloadFile(filename: string, content: string) {
   URL.revokeObjectURL(url);
 }
 
-export function BotSetupInstructions({ apiKey, apiBaseUrl }: BotSetupInstructionsProps) {
+export function BotSetupInstructions({ apiKey, apiBaseUrl, botDefaults }: BotSetupInstructionsProps) {
   const [format, setFormat] = useState<'embedded' | 'separate'>('embedded');
   const [copied, setCopied] = useState<'compose' | 'env' | null>(null);
 
-  const dockerComposeEmbedded = generateDockerComposeEmbedded(apiBaseUrl, apiKey);
+  const dockerComposeEmbedded = generateDockerComposeEmbedded(apiBaseUrl, apiKey, botDefaults);
   const dockerComposeSeparate = generateDockerComposeSeparate();
-  const envContent = generateEnvFile(apiBaseUrl, apiKey);
+  const envContent = generateEnvFile(apiBaseUrl, apiKey, botDefaults);
 
   const handleCopy = (text: string, type: 'compose' | 'env') => {
     navigator.clipboard.writeText(text);

--- a/src/components/nodes/SetupManagedNode.tsx
+++ b/src/components/nodes/SetupManagedNode.tsx
@@ -574,6 +574,19 @@ export function SetupManagedNode({ node, isOpen, onClose }: SetupManagedNodeProp
             apiKey={effectiveApiKey}
             apiBaseUrl={config.apis.meshBot.baseUrl}
             nodeShortName={nodeName}
+            botDefaults={
+              selectedConstellation != null
+                ? (() => {
+                    const c = constellations.find((x) => x.id === selectedConstellation);
+                    return c
+                      ? {
+                          ignorePortnums: c.bot_default_ignore_portnums ?? undefined,
+                          hopLimit: c.bot_default_hop_limit ?? undefined,
+                        }
+                      : undefined;
+                  })()
+                : undefined
+            }
           />
         ) : (
           <Alert variant="destructive">

--- a/src/lib/models.ts
+++ b/src/lib/models.ts
@@ -55,6 +55,8 @@ export interface ManagedNode {
     id: number;
     name?: string;
     map_color?: string;
+    bot_default_ignore_portnums?: string | null;
+    bot_default_hop_limit?: number | null;
   };
   allow_auto_traceroute?: boolean;
   position: {
@@ -354,6 +356,8 @@ export interface Constellation {
   created_by: number;
   channels: MessageChannel[];
   map_color: string;
+  bot_default_ignore_portnums?: string | null;
+  bot_default_hop_limit?: number | null;
 }
 
 export interface NodeClaim {
@@ -370,11 +374,21 @@ export interface NodeClaim {
   accepted_at: string | null;
 }
 
+/** Constellation object returned in API key list/detail (includes bot setup defaults) */
+export interface NodeApiKeyConstellation {
+  id: number;
+  name: string;
+  map_color: string;
+  bot_default_ignore_portnums?: string | null;
+  bot_default_hop_limit?: number | null;
+}
+
 export interface NodeApiKey {
   id: string;
   key: string;
   name: string;
-  constellation: number;
+  /** Constellation ID (create response) or object (list/detail response) */
+  constellation: number | NodeApiKeyConstellation;
   created_at: string;
   owner: number;
   last_used: string | null;

--- a/src/pages/nodes/MyNodes.tsx
+++ b/src/pages/nodes/MyNodes.tsx
@@ -6,8 +6,9 @@ import { Button } from '@/components/ui/button';
 import { Alert, AlertDescription, AlertTitle } from '@/components/ui/alert';
 import { Loader2, AlertCircle, Radio, Settings, CheckCircle2 } from 'lucide-react';
 import { useConfig } from '@/providers/ConfigProvider';
-import { BotSetupInstructions } from '@/components/nodes/BotSetupInstructions';
+import { BotSetupInstructions, type BotDefaults } from '@/components/nodes/BotSetupInstructions';
 import { ObservedNode } from '@/lib/models';
+import type { NodeApiKeyConstellation } from '@/lib/models';
 import { Badge } from '@/components/ui/badge';
 import { Table, TableBody, TableCell, TableHead, TableHeader, TableRow } from '@/components/ui/table';
 import { SetupManagedNode } from '@/components/nodes/SetupManagedNode';
@@ -221,6 +222,17 @@ function MyNodesContent() {
                 apiKey={firstApiKey}
                 apiBaseUrl={config.apis.meshBot.baseUrl}
                 nodeShortName={showInstructionsNode.short_name || showInstructionsNode.node_id_str}
+                botDefaults={(() => {
+                  const c = nodeApiKeys[0]?.constellation;
+                  if (c && typeof c === 'object') {
+                    const obj = c as NodeApiKeyConstellation;
+                    return {
+                      ignorePortnums: obj.bot_default_ignore_portnums ?? undefined,
+                      hopLimit: obj.bot_default_hop_limit ?? undefined,
+                    } as BotDefaults;
+                  }
+                  return undefined;
+                })()}
               />
             ) : nodeApiKeys.length === 0 ? (
               <Alert variant="destructive">

--- a/src/pages/user/NodeSettings.tsx
+++ b/src/pages/user/NodeSettings.tsx
@@ -31,9 +31,11 @@ function NodeSettingsContent() {
   const [assignModalOpen, setAssignModalOpen] = useState(false);
   const [selectedAssignNodes, setSelectedAssignNodes] = useState<number[]>([]);
   const [isAssigning, setIsAssigning] = useState(false);
-  const [setupInstructionsKey, setSetupInstructionsKey] = useState<{ apiKey: string; nodeShortName: string } | null>(
-    null
-  );
+  const [setupInstructionsKey, setSetupInstructionsKey] = useState<{
+    apiKey: string;
+    nodeShortName: string;
+    botDefaults?: { ignorePortnums?: string | null; hopLimit?: number | null };
+  } | null>(null);
   const queryClient = useQueryClient();
   const [searchParams, setSearchParams] = useSearchParams();
   const tabParam = searchParams.get('tab');
@@ -388,6 +390,7 @@ function NodeSettingsContent() {
                   apiKey={setupInstructionsKey.apiKey}
                   apiBaseUrl={config.apis.meshBot.baseUrl}
                   nodeShortName={setupInstructionsKey.nodeShortName}
+                  botDefaults={setupInstructionsKey.botDefaults}
                 />
               </DialogContent>
             </Dialog>
@@ -416,7 +419,13 @@ function ManagedNodeSettings({
   isLoadingApiKeys: boolean;
   handleCopyToClipboard: (text: string) => void;
   openAssignModal: (keyId: string, currentNodes: number[]) => void;
-  onShowSetupInstructions: (params: { apiKey: string; nodeShortName: string } | null) => void;
+  onShowSetupInstructions: (
+    params: {
+      apiKey: string;
+      nodeShortName: string;
+      botDefaults?: { ignorePortnums?: string | null; hopLimit?: number | null };
+    } | null
+  ) => void;
 }) {
   return (
     <div className="space-y-4 pt-2">
@@ -465,6 +474,12 @@ function ManagedNodeSettings({
                           onShowSetupInstructions({
                             apiKey: apiKey.key,
                             nodeShortName: node.short_name || node.node_id_str,
+                            botDefaults: node.constellation
+                              ? {
+                                  ignorePortnums: node.constellation.bot_default_ignore_portnums ?? undefined,
+                                  hopLimit: node.constellation.bot_default_hop_limit ?? undefined,
+                                }
+                              : undefined,
                           })
                         }
                         title="Setup instructions"


### PR DESCRIPTION
# Summary

Add `IGNORE_PORTNUMS`, `TR_HOPS_LIMIT`, and `TEXT_MESSAGE_MAX_HOPS` to the generated docker-compose and .env during onboarding. Default values come from the Constellation (via API) when configured by admins.

**Changes:**
- `BotSetupInstructions` accepts optional `botDefaults` prop (`ignorePortnums`, `hopLimit`)
- When present, appends the 3 env vars to embedded docker-compose and .env output
- `SetupManagedNode` passes bot defaults from selected constellation
- `MyNodes` passes bot defaults from API key’s nested constellation object
- `NodeSettings` passes bot defaults from managed node’s constellation
- Extended `Constellation` and `NodeApiKey` types for new API fields

**Dependencies:** Requires meshflow-api PR with Constellation bot default fields and API key constellation nesting.

## Testing performed

- Added `BotSetupInstructions.test.tsx` with 5 tests: no botDefaults, ignorePortnums only, hopLimit only, full botDefaults, and out-of-range hopLimit omitted
- `npm test` passes
