### PR TITLE
Traceroute heatmap UI: TR stats + split metric routes (heat vs snr)

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -57,7 +57,9 @@ function App() {
                   <Route path="/map" element={<NodeMap />} />
                   <Route path="/messages" element={<MessageHistory />} />
                   <Route path="/traceroutes" element={<TracerouteHistory />} />
-                  <Route path="/traceroutes/heatmap" element={<TracerouteHeatmapPage />} />
+                  <Route path="/traceroutes/heatmap" element={<Navigate to="/traceroutes/map/heat" replace />} />
+                  <Route path="/traceroutes/map/heat" element={<TracerouteHeatmapPage edgeMetric="packets" />} />
+                  <Route path="/traceroutes/map/snr" element={<TracerouteHeatmapPage edgeMetric="snr" />} />
                   <Route path="/user/nodes" element={<NodeSettings />} />
                   <Route path="/user/settings" element={<SettingsPage />} />
                   <Route path="/user/api-keys" element={<ApiKeysPage />} />

--- a/src/components/nav-main.tsx
+++ b/src/components/nav-main.tsx
@@ -8,6 +8,7 @@ import {
   ServerIcon,
   RouteIcon,
   MapIcon,
+  SignalIcon,
 } from 'lucide-react';
 import { Link, useNavigate } from 'react-router-dom';
 
@@ -91,9 +92,17 @@ export function NavMain() {
           </SidebarMenuItem>
           <SidebarMenuItem key="Traceroute Heatmap">
             <SidebarMenuButton asChild tooltip="Traceroute Heatmap">
-              <Link to="/traceroutes/heatmap">
+              <Link to="/traceroutes/map/heat">
                 <MapIcon />
                 <span>Traceroute Heatmap</span>
+              </Link>
+            </SidebarMenuButton>
+          </SidebarMenuItem>
+          <SidebarMenuItem key="Traceroute Link Quality">
+            <SidebarMenuButton asChild tooltip="Traceroute Link Quality">
+              <Link to="/traceroutes/map/snr">
+                <SignalIcon />
+                <span>Traceroute Link Quality</span>
               </Link>
             </SidebarMenuButton>
           </SidebarMenuItem>

--- a/src/components/nodes/NodeDetailContent.tsx
+++ b/src/components/nodes/NodeDetailContent.tsx
@@ -79,7 +79,7 @@ function TracerouteLinksSection({ nodeId }: { nodeId: number }) {
           {!error && !isLoading && !hasData && (
             <div className="flex min-h-[200px] flex-col items-center justify-center gap-2 text-muted-foreground">
               <p>No traceroute data for this node</p>
-              <Link to="/traceroutes/heatmap" className="text-sm text-teal-600 dark:text-teal-400 hover:underline">
+              <Link to="/traceroutes/map/heat" className="text-sm text-teal-600 dark:text-teal-400 hover:underline">
                 View Traceroute Heatmap
               </Link>
             </div>

--- a/src/components/traceroutes/TracerouteHeatmapMap.tsx
+++ b/src/components/traceroutes/TracerouteHeatmapMap.tsx
@@ -12,15 +12,28 @@ import type { HeatmapEdge, HeatmapNode } from '@/hooks/api/useHeatmapEdges';
 
 const DEFAULT_CENTER = { longitude: -4.2518, latitude: 55.8642, zoom: 8 };
 const NODE_COLOR: [number, number, number, number] = [134, 239, 172, 200]; // light green
-const LOW_COLOR: [number, number, number, number] = [59, 130, 246, 200]; // blue
-const HIGH_COLOR: [number, number, number, number] = [239, 68, 68, 200]; // red
+// Packets: quiet = blue, busy = orange
+const PACKETS_QUIET_COLOR: [number, number, number, number] = [59, 130, 246, 200]; // blue
+const PACKETS_BUSY_COLOR: [number, number, number, number] = [249, 115, 22, 200]; // orange
+// Link quality (SNR): unhealthy = red, healthy = green
+const SNR_BAD_COLOR: [number, number, number, number] = [239, 68, 68, 200]; // red
+const SNR_GOOD_COLOR: [number, number, number, number] = [34, 197, 94, 200]; // green
 
-function interpolateColor(weight: number, minW: number, maxW: number): [number, number, number, number] {
-  if (maxW <= minW) return LOW_COLOR;
+function interpolatePacketsColor(weight: number, minW: number, maxW: number): [number, number, number, number] {
+  if (maxW <= minW) return PACKETS_QUIET_COLOR;
   const t = (weight - minW) / (maxW - minW);
-  const r = Math.round(LOW_COLOR[0] + (HIGH_COLOR[0] - LOW_COLOR[0]) * t);
-  const g = Math.round(LOW_COLOR[1] + (HIGH_COLOR[1] - LOW_COLOR[1]) * t);
-  const b = Math.round(LOW_COLOR[2] + (HIGH_COLOR[2] - LOW_COLOR[2]) * t);
+  const r = Math.round(PACKETS_QUIET_COLOR[0] + (PACKETS_BUSY_COLOR[0] - PACKETS_QUIET_COLOR[0]) * t);
+  const g = Math.round(PACKETS_QUIET_COLOR[1] + (PACKETS_BUSY_COLOR[1] - PACKETS_QUIET_COLOR[1]) * t);
+  const b = Math.round(PACKETS_QUIET_COLOR[2] + (PACKETS_BUSY_COLOR[2] - PACKETS_QUIET_COLOR[2]) * t);
+  return [r, g, b, 200];
+}
+
+function interpolateSnrColor(snr: number, minS: number, maxS: number): [number, number, number, number] {
+  if (maxS <= minS) return SNR_GOOD_COLOR;
+  const t = (snr - minS) / (maxS - minS);
+  const r = Math.round(SNR_BAD_COLOR[0] + (SNR_GOOD_COLOR[0] - SNR_BAD_COLOR[0]) * t);
+  const g = Math.round(SNR_BAD_COLOR[1] + (SNR_GOOD_COLOR[1] - SNR_BAD_COLOR[1]) * t);
+  const b = Math.round(SNR_BAD_COLOR[2] + (SNR_GOOD_COLOR[2] - SNR_BAD_COLOR[2]) * t);
   return [r, g, b, 200];
 }
 
@@ -34,7 +47,7 @@ export interface TracerouteHeatmapMapProps {
   edges: HeatmapEdge[];
   nodes: HeatmapNode[];
   intensity?: number;
-  showLabels?: boolean;
+  edgeMetric?: 'packets' | 'snr';
 }
 
 function getNodeLabel(node: HeatmapNode): string {
@@ -42,13 +55,17 @@ function getNodeLabel(node: HeatmapNode): string {
 }
 
 /** Custom popup overlay - avoids Mapbox Popup which can interfere with deck.gl layers */
-function NodePopupOverlay({ node, onClose }: { node: HeatmapNode; onClose: () => void }) {
+function NodePopupOverlay({ node, onClose }: { node: HeatmapNode | null; onClose: () => void }) {
   const { current: mapRef } = useMap();
   const [position, setPosition] = useState<{ x: number; y: number } | null>(null);
 
   useEffect(() => {
-    const map = mapRef?.getMap?.();
-    if (!map || !mapRef || !node) return;
+    if (!node || !mapRef) {
+      setPosition(null);
+      return;
+    }
+    const map = mapRef.getMap?.();
+    if (!map) return;
 
     const updatePosition = () => {
       try {
@@ -66,9 +83,9 @@ function NodePopupOverlay({ node, onClose }: { node: HeatmapNode; onClose: () =>
       map.off('move', updatePosition);
       map.off('zoom', updatePosition);
     };
-  }, [mapRef, node?.lng, node?.lat]);
+  }, [mapRef, node?.lng, node?.lat, node]);
 
-  if (!position) return null;
+  if (!node || !position) return null;
 
   return (
     <div
@@ -111,7 +128,12 @@ function NodePopupOverlay({ node, onClose }: { node: HeatmapNode; onClose: () =>
   );
 }
 
-export function TracerouteHeatmapMap({ edges, nodes, intensity = 0.7, showLabels = true }: TracerouteHeatmapMapProps) {
+export function TracerouteHeatmapMap({
+  edges,
+  nodes,
+  intensity = 0.7,
+  edgeMetric = 'packets',
+}: TracerouteHeatmapMapProps) {
   const config = useConfig();
   const mapboxToken = config.mapboxToken ?? (import.meta.env.VITE_MAPBOX_TOKEN as string | undefined);
   const mapStyle = useMapboxStyle();
@@ -125,26 +147,40 @@ export function TracerouteHeatmapMap({ edges, nodes, intensity = 0.7, showLabels
     }
   }, []);
 
-  // Memoize layers separately so toggling showLabels doesn't recreate arc/scatter instances.
-  // Recreating all layers when only showLabels changes can cause deck.gl to lose arc/scatter layers.
   const arcLayer = useMemo(() => {
     if (edges.length === 0) return null;
-    const minWeight = Math.min(...edges.map((e) => e.weight));
-    const maxWeight = Math.max(...edges.map((e) => e.weight));
+    const preferSnr = edgeMetric === 'snr';
+    const snrValues = edges.map((e) => e.avg_snr ?? -999).filter((v) => v > -999);
+    const hasSnrData = snrValues.length > 0;
+    const useSnrColors = preferSnr;
+    const values = hasSnrData ? snrValues : edges.map((e) => e.weight);
+    const valueKey = hasSnrData ? 'avg_snr' : 'weight';
+    if (values.length === 0) return null;
+    const minVal = Math.min(...values);
+    const maxVal = Math.max(...values);
     const baseWidth = 1 + intensity * 4;
     return new ArcLayer({
-      id: 'heatmap-arcs',
+      id: `heatmap-arcs-${edgeMetric}`,
       data: edges,
       getSourcePosition: (d) => [d.from_lng, d.from_lat],
       getTargetPosition: (d) => [d.to_lng, d.to_lat],
-      getSourceColor: (d) => interpolateColor(d.weight, minWeight, maxWeight),
-      getTargetColor: (d) => interpolateColor(d.weight, minWeight, maxWeight),
-      getWidth: (d) => baseWidth * (0.5 + (d.weight - minWeight) / Math.max(maxWeight - minWeight, 1)),
+      getSourceColor: (d) => {
+        const v = valueKey === 'avg_snr' ? (d.avg_snr ?? minVal) : d.weight;
+        return useSnrColors ? interpolateSnrColor(v, minVal, maxVal) : interpolatePacketsColor(v, minVal, maxVal);
+      },
+      getTargetColor: (d) => {
+        const v = valueKey === 'avg_snr' ? (d.avg_snr ?? minVal) : d.weight;
+        return useSnrColors ? interpolateSnrColor(v, minVal, maxVal) : interpolatePacketsColor(v, minVal, maxVal);
+      },
+      getWidth: (d) => {
+        const v = valueKey === 'avg_snr' ? (d.avg_snr ?? minVal) : d.weight;
+        return baseWidth * (0.5 + (v - minVal) / Math.max(maxVal - minVal, 0.001));
+      },
       widthMinPixels: 1,
       widthMaxPixels: 20,
       getHeight: 0,
     });
-  }, [edges, intensity]);
+  }, [edges, intensity, edgeMetric]);
 
   const scatterLayer = useMemo(() => {
     if (nodes.length === 0) return null;
@@ -160,13 +196,11 @@ export function TracerouteHeatmapMap({ edges, nodes, intensity = 0.7, showLabels
     });
   }, [nodes]);
 
-  // Always include TextLayer with data: showLabels ? nodes : [] so we never change the
-  // layers array length. Removing a layer causes deck.gl/MapboxOverlay to stop rendering arcs.
   const textLayer = useMemo(() => {
     if (nodes.length === 0) return null;
     return new TextLayer({
       id: 'heatmap-node-labels',
-      data: showLabels ? nodes : [],
+      data: nodes,
       getPosition: (d) => [d.lng, d.lat],
       getText: getNodeLabel,
       getSize: 11,
@@ -181,7 +215,7 @@ export function TracerouteHeatmapMap({ edges, nodes, intensity = 0.7, showLabels
       backgroundBorderRadius: 2,
       pickable: true,
     });
-  }, [nodes, showLabels]);
+  }, [nodes]);
 
   const layers = useMemo(
     () => [arcLayer, scatterLayer, textLayer].filter(Boolean) as (ArcLayer | ScatterplotLayer | TextLayer)[],
@@ -204,8 +238,8 @@ export function TracerouteHeatmapMap({ edges, nodes, intensity = 0.7, showLabels
         mapStyle={mapStyle}
         style={{ width: '100%', height: '100%' }}
       >
-        <DeckGLOverlay interleaved={true} layers={layers} onClick={handleClick} />
-        {selectedNode && <NodePopupOverlay node={selectedNode} onClose={() => setSelectedNode(null)} />}
+        <DeckGLOverlay interleaved={false} layers={layers} onClick={handleClick} />
+        <NodePopupOverlay node={selectedNode} onClose={() => setSelectedNode(null)} />
       </Map>
     </div>
   );

--- a/src/components/traceroutes/TracerouteStatsSection.tsx
+++ b/src/components/traceroutes/TracerouteStatsSection.tsx
@@ -1,0 +1,242 @@
+import { useMemo, useState } from 'react';
+import { subHours, subDays } from 'date-fns';
+import { Cell, Legend, Line, LineChart, Pie, PieChart, XAxis, YAxis, Tooltip } from 'recharts';
+import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card';
+import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from '@/components/ui/select';
+import { ChartConfig, ChartContainer, ChartTooltipContent } from '@/components/ui/chart';
+import { useTracerouteStats } from '@/hooks/api/useTraceroutes';
+
+const TR_STATS_TIMEFRAME_OPTIONS = [
+  { key: '24h', label: '24 hours' },
+  { key: '48h', label: '48 hours' },
+  { key: '7d', label: '7 days' },
+  { key: '14d', label: '14 days' },
+  { key: '30d', label: '30 days' },
+] as const;
+
+type TimeframeKey = (typeof TR_STATS_TIMEFRAME_OPTIONS)[number]['key'];
+
+function getTriggeredAtAfter(timeframe: TimeframeKey): Date {
+  if (timeframe === '24h') return subHours(new Date(), 24);
+  if (timeframe === '48h') return subHours(new Date(), 48);
+  if (timeframe === '7d') return subDays(new Date(), 7);
+  if (timeframe === '14d') return subDays(new Date(), 14);
+  if (timeframe === '30d') return subDays(new Date(), 30);
+  return subDays(new Date(), 7);
+}
+
+const CHART_COLORS = ['#3b82f6', '#10b981', '#f59e0b', '#8b5cf6', '#ec4899', '#ef4444', '#06b6d4', '#84cc16'];
+
+const SOURCE_LABELS: Record<string, string> = {
+  auto: 'Auto',
+  user: 'User',
+  external: 'External',
+};
+
+export function TracerouteStatsSection() {
+  const [timeframe, setTimeframe] = useState<TimeframeKey>('7d');
+  const triggeredAtAfter = useMemo(() => getTriggeredAtAfter(timeframe), [timeframe]);
+
+  const { data, isLoading, error } = useTracerouteStats({ triggeredAtAfter });
+
+  const sourcesChartData = useMemo(() => {
+    if (!data?.sources?.length) return [];
+    return data.sources.map((s, idx) => ({
+      name: SOURCE_LABELS[s.trigger_type] ?? s.trigger_type,
+      value: s.count,
+      fill: CHART_COLORS[idx % CHART_COLORS.length],
+    }));
+  }, [data?.sources]);
+
+  const successFailureChartData = useMemo(() => {
+    if (!data?.success_failure?.length) return [];
+    return data.success_failure.map((s) => ({
+      name: s.status === 'completed' ? 'Success' : 'Failed',
+      value: s.count,
+      fill: s.status === 'completed' ? '#22c55e' : '#ef4444',
+    }));
+  }, [data?.success_failure]);
+
+  const lineChartConfig: ChartConfig = {
+    completed: { color: '#22c55e', label: 'Completed' },
+    failed: { color: '#ef4444', label: 'Failed' },
+  };
+
+  if (error) {
+    return (
+      <Card>
+        <CardContent className="py-6">
+          <p className="text-destructive">
+            Failed to load traceroute stats: {error instanceof Error ? error.message : 'Unknown error'}
+          </p>
+        </CardContent>
+      </Card>
+    );
+  }
+
+  return (
+    <div className="space-y-4">
+      <div className="flex flex-wrap items-center justify-between gap-4">
+        <h2 className="text-lg font-semibold">Traceroute Statistics</h2>
+        <Select value={timeframe} onValueChange={(v) => setTimeframe(v as TimeframeKey)}>
+          <SelectTrigger className="w-[140px]">
+            <SelectValue />
+          </SelectTrigger>
+          <SelectContent>
+            {TR_STATS_TIMEFRAME_OPTIONS.map((opt) => (
+              <SelectItem key={opt.key} value={opt.key}>
+                {opt.label}
+              </SelectItem>
+            ))}
+          </SelectContent>
+        </Select>
+      </div>
+
+      <div className="grid gap-4 md:grid-cols-2 lg:grid-cols-4">
+        {/* TR sources pie */}
+        <Card>
+          <CardHeader className="pb-2">
+            <CardTitle className="text-sm">TR Sources</CardTitle>
+          </CardHeader>
+          <CardContent>
+            {isLoading ? (
+              <div className="h-[180px] flex items-center justify-center text-muted-foreground text-sm">Loading…</div>
+            ) : sourcesChartData.length > 0 ? (
+              <ChartContainer config={{}} className="aspect-auto h-[180px] w-full">
+                <PieChart>
+                  <Pie
+                    data={sourcesChartData}
+                    dataKey="value"
+                    nameKey="name"
+                    cx="50%"
+                    cy="50%"
+                    innerRadius={40}
+                    outerRadius={65}
+                    paddingAngle={2}
+                    label={({ name, percent }) => `${name} ${(percent * 100).toFixed(0)}%`}
+                  >
+                    {sourcesChartData.map((entry, idx) => (
+                      <Cell key={idx} fill={entry.fill} />
+                    ))}
+                  </Pie>
+                  <Tooltip content={<ChartTooltipContent formatter={(v) => [v, '']} />} />
+                </PieChart>
+              </ChartContainer>
+            ) : (
+              <div className="h-[180px] flex items-center justify-center text-muted-foreground text-sm">No data</div>
+            )}
+          </CardContent>
+        </Card>
+
+        {/* Success/failure pie */}
+        <Card>
+          <CardHeader className="pb-2">
+            <CardTitle className="text-sm">Success / Failure</CardTitle>
+          </CardHeader>
+          <CardContent>
+            {isLoading ? (
+              <div className="h-[180px] flex items-center justify-center text-muted-foreground text-sm">Loading…</div>
+            ) : successFailureChartData.length > 0 ? (
+              <ChartContainer config={{}} className="aspect-auto h-[180px] w-full">
+                <PieChart>
+                  <Pie
+                    data={successFailureChartData}
+                    dataKey="value"
+                    nameKey="name"
+                    cx="50%"
+                    cy="50%"
+                    innerRadius={40}
+                    outerRadius={65}
+                    paddingAngle={2}
+                    label={({ name, percent }) => `${name} ${(percent * 100).toFixed(0)}%`}
+                  >
+                    {successFailureChartData.map((entry, idx) => (
+                      <Cell key={idx} fill={entry.fill} />
+                    ))}
+                  </Pie>
+                  <Tooltip content={<ChartTooltipContent formatter={(v) => [v, '']} />} />
+                </PieChart>
+              </ChartContainer>
+            ) : (
+              <div className="h-[180px] flex items-center justify-center text-muted-foreground text-sm">No data</div>
+            )}
+          </CardContent>
+        </Card>
+
+        {/* Top routers */}
+        <Card>
+          <CardHeader className="pb-2">
+            <CardTitle className="text-sm">Top Routers</CardTitle>
+          </CardHeader>
+          <CardContent>
+            {isLoading ? (
+              <div className="h-[180px] flex items-center justify-center text-muted-foreground text-sm">Loading…</div>
+            ) : data?.top_routers?.length ? (
+              <div className="space-y-2 max-h-[180px] overflow-y-auto">
+                {data.top_routers.slice(0, 8).map((r) => (
+                  <div key={r.node_id} className="flex justify-between items-center gap-2 text-sm">
+                    <span className="truncate font-mono" title={r.short_name}>
+                      {r.short_name || r.node_id_str}
+                    </span>
+                    <span className="text-muted-foreground tabular-nums">{r.count}</span>
+                  </div>
+                ))}
+              </div>
+            ) : (
+              <div className="h-[180px] flex items-center justify-center text-muted-foreground text-sm">No data</div>
+            )}
+          </CardContent>
+        </Card>
+
+        {/* Success over time (14d line) */}
+        <Card className="md:col-span-2 lg:col-span-1">
+          <CardHeader className="pb-2">
+            <CardTitle className="text-sm">Success Over Time (14d)</CardTitle>
+          </CardHeader>
+          <CardContent>
+            {isLoading ? (
+              <div className="h-[180px] flex items-center justify-center text-muted-foreground text-sm">Loading…</div>
+            ) : data?.success_over_time?.length ? (
+              <ChartContainer config={lineChartConfig} className="aspect-auto h-[180px] w-full">
+                <LineChart data={data.success_over_time} margin={{ top: 4, right: 4, bottom: 20, left: 4 }}>
+                  <XAxis
+                    dataKey="date"
+                    tickLine={false}
+                    axisLine={false}
+                    tickMargin={4}
+                    tickFormatter={(v: string) => {
+                      const d = new Date(v);
+                      return d.toLocaleDateString('en-GB', { month: 'short', day: 'numeric' });
+                    }}
+                    tick={{ fontSize: 10 }}
+                  />
+                  <YAxis tickLine={false} axisLine={false} width={28} tick={{ fontSize: 10 }} />
+                  <Tooltip
+                    content={
+                      <ChartTooltipContent
+                        formatter={(v) => [v, '']}
+                        labelFormatter={(l) => new Date(l).toLocaleDateString()}
+                      />
+                    }
+                  />
+                  <Line
+                    type="monotone"
+                    dataKey="completed"
+                    stroke="#22c55e"
+                    strokeWidth={2}
+                    dot={{ r: 2 }}
+                    connectNulls
+                  />
+                  <Line type="monotone" dataKey="failed" stroke="#ef4444" strokeWidth={2} dot={{ r: 2 }} connectNulls />
+                  <Legend />
+                </LineChart>
+              </ChartContainer>
+            ) : (
+              <div className="h-[180px] flex items-center justify-center text-muted-foreground text-sm">No data</div>
+            )}
+          </CardContent>
+        </Card>
+      </div>
+    </div>
+  );
+}

--- a/src/hooks/api/useHeatmapEdges.ts
+++ b/src/hooks/api/useHeatmapEdges.ts
@@ -1,4 +1,4 @@
-import { useQuery } from '@tanstack/react-query';
+import { keepPreviousData, useQuery } from '@tanstack/react-query';
 import { useMeshtasticApi } from './useApi';
 
 export interface HeatmapEdge {
@@ -9,6 +9,7 @@ export interface HeatmapEdge {
   to_lat: number;
   to_lng: number;
   weight: number;
+  avg_snr?: number;
 }
 
 export interface HeatmapNode {
@@ -33,6 +34,7 @@ export interface UseHeatmapEdgesParams {
   triggeredAtAfter?: Date;
   constellationId?: number;
   bbox?: [number, number, number, number];
+  edgeMetric?: 'packets' | 'snr';
 }
 
 export function useHeatmapEdges(params?: UseHeatmapEdgesParams) {
@@ -40,12 +42,22 @@ export function useHeatmapEdges(params?: UseHeatmapEdgesParams) {
   const triggeredAtAfter = params?.triggeredAtAfter?.toISOString();
 
   return useQuery({
-    queryKey: ['heatmap-edges', { triggeredAtAfter, constellationId: params?.constellationId, bbox: params?.bbox }],
+    queryKey: [
+      'heatmap-edges',
+      {
+        triggeredAtAfter,
+        constellationId: params?.constellationId,
+        bbox: params?.bbox,
+        edgeMetric: params?.edgeMetric,
+      },
+    ],
+    placeholderData: keepPreviousData,
     queryFn: () =>
       api.getHeatmapEdges({
         triggered_at_after: triggeredAtAfter,
         constellation_id: params?.constellationId,
         bbox: params?.bbox,
+        edge_metric: params?.edgeMetric,
       }),
   });
 }

--- a/src/hooks/api/useTraceroutes.ts
+++ b/src/hooks/api/useTraceroutes.ts
@@ -46,6 +46,22 @@ export function useTracerouteTriggerableNodes() {
   });
 }
 
+export interface UseTracerouteStatsParams {
+  triggeredAtAfter?: Date;
+}
+
+export function useTracerouteStats(params?: UseTracerouteStatsParams) {
+  const api = useMeshtasticApi();
+  const triggeredAtAfter = params?.triggeredAtAfter?.toISOString();
+  return useQuery({
+    queryKey: ['traceroutes', 'stats', { triggeredAtAfter }],
+    queryFn: () =>
+      api.getTracerouteStats({
+        triggered_at_after: triggeredAtAfter,
+      }),
+  });
+}
+
 export function useTracerouteTriggerableNodesSuspense() {
   const api = useMeshtasticApi();
   const { data } = useSuspenseQuery({

--- a/src/lib/api/meshtastic-api.ts
+++ b/src/lib/api/meshtastic-api.ts
@@ -613,12 +613,29 @@ export class MeshtasticApi extends BaseApi {
   }
 
   /**
+   * Get traceroute statistics (sources, success/failure, top routers, success over time)
+   */
+  async getTracerouteStats(params?: { triggered_at_after?: string }): Promise<{
+    sources: Array<{ trigger_type: string; count: number }>;
+    success_failure: Array<{ status: string; count: number }>;
+    top_routers: Array<{ node_id: number; node_id_str: string; short_name: string; count: number }>;
+    success_over_time: Array<{ date: string; completed: number; failed: number }>;
+  }> {
+    const searchParams = new URLSearchParams();
+    if (params?.triggered_at_after) {
+      searchParams.append('triggered_at_after', params.triggered_at_after);
+    }
+    return this.get('/traceroutes/stats/', searchParams);
+  }
+
+  /**
    * Get aggregated heatmap edges and nodes for traceroute visualization
    */
   async getHeatmapEdges(params?: {
     triggered_at_after?: string;
     constellation_id?: number;
     bbox?: [number, number, number, number];
+    edge_metric?: 'packets' | 'snr';
   }): Promise<{
     edges: Array<{
       from_node_id: number;
@@ -628,6 +645,7 @@ export class MeshtasticApi extends BaseApi {
       to_lat: number;
       to_lng: number;
       weight: number;
+      avg_snr?: number;
     }>;
     nodes: Array<{
       node_id: number;
@@ -651,6 +669,9 @@ export class MeshtasticApi extends BaseApi {
     }
     if (params?.bbox && params.bbox.length >= 4) {
       searchParams.append('bbox', params.bbox.join(','));
+    }
+    if (params?.edge_metric) {
+      searchParams.append('edge_metric', params.edge_metric);
     }
     return this.get('/traceroutes/heatmap-edges/', searchParams);
   }

--- a/src/pages/traceroutes/TracerouteHeatmapPage.tsx
+++ b/src/pages/traceroutes/TracerouteHeatmapPage.tsx
@@ -1,14 +1,15 @@
 import { useState, useMemo } from 'react';
+import { Link } from 'react-router-dom';
 import { subHours, subDays } from 'date-fns';
 import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card';
 import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from '@/components/ui/select';
-import { Switch } from '@/components/ui/switch';
-import { Label } from '@/components/ui/label';
 import { useHeatmapEdges } from '@/hooks/api/useHeatmapEdges';
 import { TracerouteHeatmapMap } from '@/components/traceroutes/TracerouteHeatmapMap';
 import { RouteIcon } from 'lucide-react';
+import { cn } from '@/lib/utils';
 
 type TimeRange = '24h' | '7d' | '30d' | 'custom';
+export type EdgeMetric = 'packets' | 'snr';
 
 function NetworkStatsCard({
   meta,
@@ -26,16 +27,27 @@ function NetworkStatsCard({
         <div>Active Nodes: {meta.active_nodes_count.toLocaleString()}</div>
         <div>Total Trace Routes: {meta.total_trace_routes_count.toLocaleString()}</div>
         <div className="pt-2">
-          <div className="mb-1 text-xs text-muted-foreground">Traffic</div>
+          <div className="mb-1 text-xs text-muted-foreground">Packets: Quiet → Busy</div>
           <div
             className="h-2 w-full rounded"
             style={{
-              background: 'linear-gradient(to right, #3b82f6, #f97316, #ef4444)',
+              background: 'linear-gradient(to right, #3b82f6, #f97316)',
             }}
           />
           <div className="mt-1 flex justify-between text-xs text-muted-foreground">
-            <span>Low (Cool)</span>
-            <span>High (Hot)</span>
+            <span>Quiet (blue)</span>
+            <span>Busy (orange)</span>
+          </div>
+          <div className="mb-1 mt-2 text-xs text-muted-foreground">Link quality: Unhealthy → Healthy</div>
+          <div
+            className="h-2 w-full rounded"
+            style={{
+              background: 'linear-gradient(to right, #ef4444, #22c55e)',
+            }}
+          />
+          <div className="mt-1 flex justify-between text-xs text-muted-foreground">
+            <span>Unhealthy (red)</span>
+            <span>Healthy (green)</span>
           </div>
         </div>
       </CardContent>
@@ -43,9 +55,8 @@ function NetworkStatsCard({
   );
 }
 
-export function TracerouteHeatmapPage() {
+export function TracerouteHeatmapPage({ edgeMetric }: { edgeMetric: EdgeMetric }) {
   const [timeRange, setTimeRange] = useState<TimeRange>('7d');
-  const [showLabels, setShowLabels] = useState(true);
 
   const triggeredAtAfter = useMemo(() => {
     if (timeRange === '24h') return subHours(new Date(), 24);
@@ -56,6 +67,7 @@ export function TracerouteHeatmapPage() {
 
   const { data, isLoading, error } = useHeatmapEdges({
     triggeredAtAfter,
+    edgeMetric,
   });
 
   const edges = data?.edges ?? [];
@@ -71,16 +83,29 @@ export function TracerouteHeatmapPage() {
           <h1 className="text-xl font-semibold sm:text-2xl">Traceroute Heatmap</h1>
         </div>
         <div className="flex flex-wrap items-center gap-4" data-testid="heatmap-filters">
-          <div className="flex items-center gap-2">
-            <Switch
-              id="heatmap-node-labels"
-              checked={showLabels}
-              onCheckedChange={setShowLabels}
-              aria-label="Node labels"
-            />
-            <Label htmlFor="heatmap-node-labels" className="text-sm cursor-pointer">
-              Node labels
-            </Label>
+          <div className="flex rounded-md border border-input bg-muted/50 p-0.5">
+            <Link
+              to="/traceroutes/map/heat"
+              className={cn(
+                'rounded px-3 py-1.5 text-sm font-medium transition-colors',
+                edgeMetric === 'packets'
+                  ? 'bg-background text-foreground shadow-sm'
+                  : 'text-muted-foreground hover:text-foreground'
+              )}
+            >
+              Packets
+            </Link>
+            <Link
+              to="/traceroutes/map/snr"
+              className={cn(
+                'rounded px-3 py-1.5 text-sm font-medium transition-colors',
+                edgeMetric === 'snr'
+                  ? 'bg-background text-foreground shadow-sm'
+                  : 'text-muted-foreground hover:text-foreground'
+              )}
+            >
+              Link quality (SNR)
+            </Link>
           </div>
           <div className="w-full sm:w-auto sm:min-w-[180px]">
             <Select value={timeRange} onValueChange={(v) => setTimeRange(v as TimeRange)}>
@@ -117,7 +142,7 @@ export function TracerouteHeatmapPage() {
                 Loading heatmap data...
               </div>
             )}
-            {!error && !isLoading && <TracerouteHeatmapMap edges={edges} nodes={nodes} showLabels={showLabels} />}
+            {!error && !isLoading && <TracerouteHeatmapMap edges={edges} nodes={nodes} edgeMetric={edgeMetric} />}
           </CardContent>
         </Card>
 

--- a/src/pages/traceroutes/TracerouteHistory.tsx
+++ b/src/pages/traceroutes/TracerouteHistory.tsx
@@ -13,6 +13,7 @@ import { useTracerouteTriggerableNodesSuspense, useTriggerTraceroute } from '@/h
 import { useNodesSuspense } from '@/hooks/api/useNodes';
 import { TriggerTracerouteModal } from './TriggerTracerouteModal';
 import { TracerouteDetailModal } from './TracerouteDetailModal';
+import { TracerouteStatsSection } from '@/components/traceroutes/TracerouteStatsSection';
 import { AutoTraceRoute } from '@/lib/models';
 import { RouteIcon, RotateCw } from 'lucide-react';
 
@@ -93,7 +94,8 @@ export function TracerouteHistory() {
   const traceroutes = data?.results ?? [];
 
   return (
-    <div className="container mx-auto py-6">
+    <div className="container mx-auto py-6 space-y-6">
+      <TracerouteStatsSection />
       <Card>
         <CardHeader className="flex flex-row items-center justify-between">
           <CardTitle className="flex items-center gap-2">


### PR DESCRIPTION
# Summary

Traceroute heatmap + stats UI improvements:

1. **TR stats UI** – Adds stats section powered by the new `/api/traceroutes/stats/` endpoint (pie charts, top routers, success-over-time).
2. **Heatmap edge metric pages** – Splits UI into stable routes:
   - `/traceroutes/map/heat` (Packets)
   - `/traceroutes/map/snr` (Link quality / SNR)
3. **Heatmap updates** – Removes the old in-page metric selector to avoid map flicker/disappearing layers while switching metrics.

## Testing performed

- `vitest run` (via the UI pre-commit hook) passes.
