### PR TITLE
feat(nodes): display inferred_max_hops on NodeDetails page

### DIFF
--- a/src/components/nodes/NodeDetailContent.tsx
+++ b/src/components/nodes/NodeDetailContent.tsx
@@ -264,6 +264,14 @@ export function NodeDetailContent({ nodeId, compact = false }: NodeDetailContent
                   Last time any packet was received from this node (telemetry, messages, etc.)
                 </span>
               </p>
+              {node.inferred_max_hops != null && (
+                <p>
+                  <span className="font-medium">Inferred Max Hops:</span> {node.inferred_max_hops}
+                  <span className="block text-xs text-muted-foreground mt-0.5">
+                    Inferred from packets; recommended is 7
+                  </span>
+                </p>
+              )}
             </div>
           </CardContent>
         </Card>

--- a/src/lib/models.ts
+++ b/src/lib/models.ts
@@ -29,6 +29,7 @@ export interface ObservedNode {
   role?: number | null;
   is_licensed?: boolean | null;
   is_unmessagable?: boolean | null;
+  inferred_max_hops?: number | null;
   // Additional fields for UI compatibility
   last_heard?: Date | null;
   latest_device_metrics?: DeviceMetrics | null;


### PR DESCRIPTION
## Summary

Displays `inferred_max_hops` on the NodeDetails page, sourced from the API response. Helps identify nodes with suboptimal hop limits (recommended is 7).

- Add inferred_max_hops to ObservedNode interface
- Display in Basic Information card when available

**Depends on:** meshflow-api PR adding inferred_max_hops to ObservedNode API response

## Testing performed

* Manual verification in dev

Closes #68