### PR TITLE
Split new nodes and online nodes into separate charts

### DIFF
--- a/src/components/MeshStatsSection.tsx
+++ b/src/components/MeshStatsSection.tsx
@@ -27,7 +27,7 @@ const onlineNodesOnlyChartConfig = {
 const newNodesOnlyChartConfig = {
   value: {
     label: 'New nodes',
-    color: 'hsl(var(--chart-2))',
+    color: 'hsl(var(--chart-3))',
   },
 } satisfies ChartConfig;
 
@@ -87,6 +87,7 @@ export function MeshStatsSection() {
           config={onlineNodesOnlyChartConfig}
           embedded
           dateRange={dateRange}
+          movingAverage={true}
         />
         <OnlineNodesChart
           title="New Nodes"
@@ -95,6 +96,7 @@ export function MeshStatsSection() {
           config={newNodesOnlyChartConfig}
           embedded
           dateRange={dateRange}
+          movingAverage={false}
         />
         <PacketStatsChartFromSnapshots
           title="Mesh Activity"

--- a/src/components/OnlineNodesChart.tsx
+++ b/src/components/OnlineNodesChart.tsx
@@ -25,6 +25,7 @@ interface OnlineNodesChartProps {
   /** When true, render without Card/TimeRangeSelect; use dateRange from parent */
   embedded?: boolean;
   dateRange?: { startDate: Date; endDate: Date };
+  movingAverage?: boolean;
 }
 
 export function OnlineNodesChart({
@@ -42,6 +43,7 @@ export function OnlineNodesChart({
   defaultTimeRange = '2d',
   embedded = false,
   dateRange: controlledDateRange,
+  movingAverage = true,
 }: OnlineNodesChartProps) {
   const [timeRangeLabel, setTimeRangeLabel] = React.useState(defaultTimeRange);
   const [internalDateRange, setInternalDateRange] = React.useState<{ startDate: Date; endDate: Date }>({
@@ -167,14 +169,16 @@ export function OnlineNodesChart({
           content={<ChartTooltipContent labelFormatter={tooltipLabelFormatter} indicator="dot" />}
         />
         <Bar dataKey="value" fill="var(--color-value)" fillOpacity={0.7} barSize={8} />
-        <Line
-          type="monotone"
-          dataKey="movingAverage"
-          stroke="var(--color-value)"
-          strokeWidth={2}
-          dot={false}
-          name={aggregationWindow === 'hourly' ? '24h Moving Average' : 'Moving Average'}
-        />
+        {movingAverage && (
+          <Line
+            type="monotone"
+            dataKey="movingAverage"
+            stroke="var(--color-value)"
+            strokeWidth={2}
+            dot={false}
+            name={aggregationWindow === 'hourly' ? '24h Moving Average' : 'Moving Average'}
+          />
+        )}
       </ComposedChart>
     </ChartContainer>
   );


### PR DESCRIPTION
# Summary

The Mesh stats dashboard combined online node count (~100+) and new nodes (~few per hour) on one chart with a shared Y-axis, so the new-nodes series was effectively invisible.

- `OnlineNodesChart` now takes a required `metric`: `online_nodes` or `new_nodes`, fetches only that snapshot type, and scales the Y-axis to that series.
- `MeshStatsSection` renders two embedded charts: **Online Nodes** (average + moving average) and **New Nodes** (sum per window + moving average).
- Exported `OnlineNodesChartMetric` for typing.

Closes #113

## Testing performed

- `npm run build`
- `npm run lint` (existing warnings only)
- `npm test -- --run`