### PR TITLE
feat(weather): Weather page, node env settings, and map legend

### DIFF
--- a/.cursor/skills/meshflow-git-workflow/SKILL.md
+++ b/.cursor/skills/meshflow-git-workflow/SKILL.md
@@ -13,6 +13,20 @@ description: >-
 
 When working on a feature across meshflow-api, meshtastic-bot, or meshtastic-bot-ui, follow this workflow: plan → issue → branch → commit → PR.
 
+Use the `github-personal` MCP for all MeshFlow work.
+
+We start by documenting and refining a plan collaboratively. After agreeing upon the plan, create tickets in applicable repositories. If necessary add a parent ticket and create linked children. Add the plan to the single or parent ticket, and exerpts of the plan to any children. Update the plan with links to any relevant tickets.
+
+It's also possible that we start with a lightweight ticket (i.e. a feature request from a user), then generate the plan. In that situation, the ticket should be updated with full details from the plan, instead of creating a new one
+
+When executing the plan:
+
+1. Create our git branches from origin/main
+2. Do the work
+3. Commit as appropriate
+4. Push and open a pull request for applicable repositories. Link relevant tickets.
+5. Done
+
 ---
 
 ## 1. Planning and Issues

--- a/package-lock.json
+++ b/package-lock.json
@@ -115,7 +115,6 @@
       "resolved": "https://registry.npmjs.org/@amcharts/amcharts5/-/amcharts5-5.14.4.tgz",
       "integrity": "sha512-Tl7wQLWvsvyWVtlCIm1yhZtJviSDYjuNTnlUkO0D49GyByoK0nb9fr0DK4rUw4DVgyLcySxWBsb2lzTJm5Rd9Q==",
       "license": "SEE LICENSE IN LICENSE",
-      "peer": true,
       "dependencies": {
         "@types/d3": "^7.0.0",
         "@types/d3-chord": "^3.0.0",
@@ -148,15 +147,13 @@
       "version": "3.1.1",
       "resolved": "https://registry.npmjs.org/@types/d3-hierarchy/-/d3-hierarchy-3.1.1.tgz",
       "integrity": "sha512-QwjxA3+YCKH3N1Rs3uSiSy1bdxlLB1uUiENXeJudBoAFvtDuswUxLcanoOaR2JYn1melDTuIXR8VhnVyI3yG/A==",
-      "license": "MIT",
-      "peer": true
+      "license": "MIT"
     },
     "node_modules/@amcharts/amcharts5/node_modules/d3-geo": {
       "version": "3.1.1",
       "resolved": "https://registry.npmjs.org/d3-geo/-/d3-geo-3.1.1.tgz",
       "integrity": "sha512-637ln3gXKXOwhalDzinUgY83KzNWZRKbYubaG+fGVuc/dxO64RRljtCTnf5ecMyE1RIdtqpkVcq0IbtU2S8j2Q==",
       "license": "ISC",
-      "peer": true,
       "dependencies": {
         "d3-array": "2.5.0 - 3"
       },
@@ -201,7 +198,6 @@
       "resolved": "https://registry.npmjs.org/@arcgis/lumina/-/lumina-4.34.9.tgz",
       "integrity": "sha512-efqO+SwR+1IYf29AATh1l2FUeypRyRINTBNkaJY+KkaFe+8gqSJ45qOmputhyzF5WTRDb7WhOYgnChjp6VYPpA==",
       "license": "SEE LICENSE IN LICENSE.md",
-      "peer": true,
       "dependencies": {
         "@arcgis/toolkit": "~4.34.9",
         "csstype": "^3.1.3",
@@ -222,7 +218,6 @@
       "resolved": "https://registry.npmjs.org/@arcgis/toolkit/-/toolkit-4.34.9.tgz",
       "integrity": "sha512-wFST+eVnCwmg9NyICVyn9bsBnR+TlWklsGqG3L7xqSTgfXo6TuCThE7wtTb8xWxsTBkGvImqMUgpgLuwQuTQ1g==",
       "license": "SEE LICENSE IN LICENSE.md",
-      "peer": true,
       "dependencies": {
         "tslib": "^2.8.1"
       }
@@ -279,6 +274,7 @@
       "integrity": "sha512-IaaGWsQqfsQWVLqMn9OB92MNN7zukfVA4s7KKAI0KfrrDsZ0yhi5uV4baBuLuN7n3vsZpwP8asPPcVwApxvjBQ==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@ampproject/remapping": "^2.2.0",
         "@babel/code-frame": "^7.27.1",
@@ -929,6 +925,7 @@
         }
       ],
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=18"
       },
@@ -952,6 +949,7 @@
         }
       ],
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -961,6 +959,7 @@
       "resolved": "https://registry.npmjs.org/@deck.gl/aggregation-layers/-/aggregation-layers-9.2.11.tgz",
       "integrity": "sha512-MRFbBHtMcDkOthxXnMPm6nF08DjFDACaIQsJSyHkdWtLUTSLHsWnOTn/8QbB4ka86WyNyfJy3dibLu/m3ei2ow==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@luma.gl/constants": "~9.2.6",
         "@luma.gl/shadertools": "~9.2.6",
@@ -1058,6 +1057,7 @@
       "resolved": "https://registry.npmjs.org/@deck.gl/core/-/core-9.2.11.tgz",
       "integrity": "sha512-lpdxXQuFSkd6ET7M6QxPI8QMhsLRY6vzLyk83sPGFb7JSb4OhrNHYt9sfIhcA/hxJW7bdBSMWWphf2GvQetVuA==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@loaders.gl/core": "~4.3.4",
         "@loaders.gl/images": "~4.3.4",
@@ -1083,6 +1083,7 @@
       "resolved": "https://registry.npmjs.org/@deck.gl/extensions/-/extensions-9.2.11.tgz",
       "integrity": "sha512-zlpM4Bg1ifBziW1Juiii9NY5gyW2rEhyVTWnhagH/bpTCZ2E73OhnToYt1ouqmoxL6lMtIjhRXz6LPb7tJbHHQ==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@luma.gl/constants": "~9.2.6",
         "@luma.gl/shadertools": "~9.2.6",
@@ -1099,6 +1100,7 @@
       "resolved": "https://registry.npmjs.org/@deck.gl/geo-layers/-/geo-layers-9.2.11.tgz",
       "integrity": "sha512-Mr3yvKyZMPmQ3ho0hSqcJu1p7a881RqQaq/dRaPs2VP56UAkfk1e10zxXnrZ9/Dmo2MR5PH0j8tkOoGR3zKbfA==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@loaders.gl/3d-tiles": "~4.3.4",
         "@loaders.gl/gis": "~4.3.4",
@@ -1172,6 +1174,7 @@
       "resolved": "https://registry.npmjs.org/@deck.gl/layers/-/layers-9.2.11.tgz",
       "integrity": "sha512-2FSb0Qa6YR+Rg6GWhYOGTUug3vtZ4uKcFdnrdiJoVXGyibKJMScKZIsivY0r/yQQZsaBjYqty5QuVJvdtEHxSA==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@loaders.gl/images": "~4.3.4",
         "@loaders.gl/schema": "~4.3.4",
@@ -1210,6 +1213,7 @@
       "resolved": "https://registry.npmjs.org/@deck.gl/mesh-layers/-/mesh-layers-9.2.11.tgz",
       "integrity": "sha512-zPB7TtnPXB3tOEoOfcOkNZo7coIq/ukIQa8HIUQLLiOE8AVSQfz3kbMmMK6rUabXlQbgSw/I/j3kFSYRHg3NGg==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@loaders.gl/gltf": "~4.3.4",
         "@loaders.gl/schema": "~4.3.4",
@@ -1241,6 +1245,7 @@
       "resolved": "https://registry.npmjs.org/@deck.gl/widgets/-/widgets-9.2.11.tgz",
       "integrity": "sha512-90HWlQPsiRyTPWR4aYfLwnYDrJdHG2mqCzRcyMUKewWBNQLu4upB//l4ewIkUeXXCzAprjjVeRnNb7wdYj2CXQ==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "preact": "^10.17.0"
       },
@@ -1266,6 +1271,7 @@
       "resolved": "https://registry.npmjs.org/@dnd-kit/core/-/core-6.3.1.tgz",
       "integrity": "sha512-xkGBRQQab4RLwgXxoqETICr6S5JlogafbhNsidmrkVv2YRs5MLwpjoF2qpiGjQt8S9AoxtIV603s0GIUpY5eYQ==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@dnd-kit/accessibility": "^3.1.1",
         "@dnd-kit/utilities": "^3.2.2",
@@ -1921,7 +1927,6 @@
       "resolved": "https://registry.npmjs.org/@esri/arcgis-html-sanitizer/-/arcgis-html-sanitizer-4.1.0.tgz",
       "integrity": "sha512-einEveDJ/k1180NOp78PB/4Hje9eBy3dyOGLLtLn6bSkizpUfCwuYBIXOA7Y3F/k/BsTQXgKqUVwQ0eiscWMdA==",
       "license": "Apache-2.0",
-      "peer": true,
       "dependencies": {
         "xss": "1.0.13"
       },
@@ -1934,7 +1939,6 @@
       "resolved": "https://registry.npmjs.org/@esri/calcite-components/-/calcite-components-3.3.3.tgz",
       "integrity": "sha512-tw+EfJ3pb+Odj71W6E9GUkm8rMbNxfW1KeiI8GgsKDzhr39hMKwY+zYYFFYuO0FONxWGvAB+B8yqB0NvH7WeHw==",
       "license": "SEE LICENSE.md",
-      "peer": true,
       "dependencies": {
         "@arcgis/lumina": ">=4.34.0-next.158 <4.35.0",
         "@arcgis/toolkit": ">=4.34.0-next.158 <4.35.0",
@@ -1958,7 +1962,6 @@
       "resolved": "https://registry.npmjs.org/@esri/calcite-ui-icons/-/calcite-ui-icons-4.3.0.tgz",
       "integrity": "sha512-iOOuRurpjFxFVw6+aXW2JpSkRBrdOpBcbdibfPOmSPqMd1aoHBtYmYXetKoH9vfrXoBiPyO2PkDnczhsu/N9IA==",
       "license": "SEE LICENSE.md",
-      "peer": true,
       "bin": {
         "spriter": "bin/spriter.js"
       }
@@ -1999,14 +2002,14 @@
       "version": "0.2.9",
       "resolved": "https://registry.npmjs.org/@floating-ui/utils/-/utils-0.2.9.tgz",
       "integrity": "sha512-MDWhGtE+eHw5JW7lq4qhc5yRLS11ERl1c7Z6Xd0a58DozHES6EnNNwUWbMiG4J9Cgj053Bhk8zvlhFYKVhULwg==",
-      "license": "MIT"
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/@foliojs-fork/fontkit": {
       "version": "1.9.2",
       "resolved": "https://registry.npmjs.org/@foliojs-fork/fontkit/-/fontkit-1.9.2.tgz",
       "integrity": "sha512-IfB5EiIb+GZk+77TRB86AHroVaqfq8JRFlUbz0WEwsInyCG0epX2tCPOy+UfaWPju30DeVoUAXfzWXmhn753KA==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@foliojs-fork/restructure": "^2.0.2",
         "brotli": "^1.2.0",
@@ -2023,7 +2026,6 @@
       "resolved": "https://registry.npmjs.org/@foliojs-fork/linebreak/-/linebreak-1.1.2.tgz",
       "integrity": "sha512-ZPohpxxbuKNE0l/5iBJnOAfUaMACwvUIKCvqtWGKIMv1lPYoNjYXRfhi9FeeV9McBkBLxsMFWTVVhHJA8cyzvg==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "base64-js": "1.3.1",
         "unicode-trie": "^2.0.0"
@@ -2033,15 +2035,13 @@
       "version": "1.3.1",
       "resolved": "https://registry.npmjs.org/base64-js/-/base64-js-1.3.1.tgz",
       "integrity": "sha512-mLQ4i2QO1ytvGWFWmcngKO//JXAQueZvwEKtjgQFM4jIK0kU+ytMfplL8j+n5mspOfjHwoAg+9yhb7BwAHm36g==",
-      "license": "MIT",
-      "peer": true
+      "license": "MIT"
     },
     "node_modules/@foliojs-fork/pdfkit": {
       "version": "0.15.3",
       "resolved": "https://registry.npmjs.org/@foliojs-fork/pdfkit/-/pdfkit-0.15.3.tgz",
       "integrity": "sha512-Obc0Wmy3bm7BINFVvPhcl2rnSSK61DQrlHU8aXnAqDk9LCjWdUOPwhgD8Ywz5VtuFjRxmVOM/kQ/XLIBjDvltw==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@foliojs-fork/fontkit": "^1.9.2",
         "@foliojs-fork/linebreak": "^1.1.1",
@@ -2054,8 +2054,7 @@
       "version": "2.0.2",
       "resolved": "https://registry.npmjs.org/@foliojs-fork/restructure/-/restructure-2.0.2.tgz",
       "integrity": "sha512-59SgoZ3EXbkfSX7b63tsou/SDGzwUEK6MuB5sKqgVK1/XE0fxmpsOb9DQI8LXW3KfGnAjImCGhhEb7uPPAUVNA==",
-      "license": "MIT",
-      "peer": true
+      "license": "MIT"
     },
     "node_modules/@hapi/address": {
       "version": "5.1.1",
@@ -2194,8 +2193,7 @@
       "version": "1.10.27",
       "resolved": "https://registry.npmjs.org/@interactjs/types/-/types-1.10.27.tgz",
       "integrity": "sha512-BUdv0cvs4H5ODuwft2Xp4eL8Vmi3LcihK42z0Ft/FbVJZoRioBsxH+LlsBdK4tAie7PqlKGy+1oyOncu1nQ6eA==",
-      "license": "MIT",
-      "peer": true
+      "license": "MIT"
     },
     "node_modules/@isaacs/cliui": {
       "version": "8.0.2",
@@ -2276,15 +2274,13 @@
       "version": "1.5.1",
       "resolved": "https://registry.npmjs.org/@lit-labs/ssr-dom-shim/-/ssr-dom-shim-1.5.1.tgz",
       "integrity": "sha512-Aou5UdlSpr5whQe8AA/bZG0jMj96CoJIWbGfZ91qieWu5AWUMKw8VR/pAkQkJYvBNhmCcWnZlyyk5oze8JIqYA==",
-      "license": "BSD-3-Clause",
-      "peer": true
+      "license": "BSD-3-Clause"
     },
     "node_modules/@lit/reactive-element": {
       "version": "2.1.2",
       "resolved": "https://registry.npmjs.org/@lit/reactive-element/-/reactive-element-2.1.2.tgz",
       "integrity": "sha512-pbCDiVMnne1lYUIaYNN5wrwQXDtHaYtg7YEFPeW+hws6U47WeFvISGUWekPGKWOP1ygrs0ef0o1VJMk1exos5A==",
       "license": "BSD-3-Clause",
-      "peer": true,
       "dependencies": {
         "@lit-labs/ssr-dom-shim": "^1.5.0"
       }
@@ -2349,6 +2345,7 @@
       "resolved": "https://registry.npmjs.org/@loaders.gl/core/-/core-4.3.4.tgz",
       "integrity": "sha512-cG0C5fMZ1jyW6WCsf4LoHGvaIAJCEVA/ioqKoYRwoSfXkOf+17KupK1OUQyUCw5XoRn+oWA1FulJQOYlXnb9Gw==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@loaders.gl/loader-utils": "4.3.4",
         "@loaders.gl/schema": "4.3.4",
@@ -2656,13 +2653,15 @@
       "version": "9.2.6",
       "resolved": "https://registry.npmjs.org/@luma.gl/constants/-/constants-9.2.6.tgz",
       "integrity": "sha512-rvFFrJuSm5JIWbDHFuR4Q2s4eudO3Ggsv0TsGKn9eqvO7bBiPm/ANugHredvh3KviEyYuMZZxtfJvBdr3kzldg==",
-      "license": "MIT"
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/@luma.gl/core": {
       "version": "9.2.6",
       "resolved": "https://registry.npmjs.org/@luma.gl/core/-/core-9.2.6.tgz",
       "integrity": "sha512-d8KcH8ZZcjDAodSN/G2nueA9YE2X8kMz7Q0OxDGpCww6to1MZXM3Ydate/Jqsb5DDKVgUF6yD6RL8P5jOki9Yw==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@math.gl/types": "^4.1.0",
         "@probe.gl/env": "^4.0.8",
@@ -2676,6 +2675,7 @@
       "resolved": "https://registry.npmjs.org/@luma.gl/engine/-/engine-9.2.6.tgz",
       "integrity": "sha512-1AEDs2AUqOWh7Wl4onOhXmQF+Rz1zNdPXF+Kxm4aWl92RQ42Sh2CmTvRt2BJku83VQ91KFIEm/v3qd3Urzf+Uw==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@math.gl/core": "^4.1.0",
         "@math.gl/types": "^4.1.0",
@@ -2710,6 +2710,7 @@
       "resolved": "https://registry.npmjs.org/@luma.gl/shadertools/-/shadertools-9.2.6.tgz",
       "integrity": "sha512-4+uUbynqPUra9d/z1nQChyHmhLgmKfSMjS7kOwLB6exSnhKnpHL3+Hu9fv55qyaX50nGH3oHawhGtJ6RRvu65w==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@math.gl/core": "^4.1.0",
         "@math.gl/types": "^4.1.0",
@@ -2724,6 +2725,7 @@
       "resolved": "https://registry.npmjs.org/@luma.gl/webgl/-/webgl-9.2.6.tgz",
       "integrity": "sha512-NGBTdxJMk7j8Ygr1zuTyAvr1Tw+EpupMIQo7RelFjEsZXg6pujFqiDMM+rgxex8voCeuhWBJc7Rs+MoSqd46UQ==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@luma.gl/constants": "9.2.6",
         "@math.gl/types": "^4.1.0",
@@ -2905,6 +2907,7 @@
       "integrity": "sha512-rftlrkhHZOcjDwkGlnUtZZkvaPHCsDATp4pGpuOOMDaTdDDXF91wuVDJoWoPsKX/3YPQ5fHuF3STjcYyKr+Qhg==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "funding": {
         "url": "https://github.com/sponsors/colinhacks"
       }
@@ -2958,8 +2961,7 @@
       "version": "1.4.0",
       "resolved": "https://registry.npmjs.org/@open-wc/dedupe-mixin/-/dedupe-mixin-1.4.0.tgz",
       "integrity": "sha512-Sj7gKl1TLcDbF7B6KUhtvr+1UCxdhMbNY5KxdU5IfMFWqL8oy1ZeAcCANjoB1TL0AJTcPmcCFsCbHf8X2jGDUA==",
-      "license": "MIT",
-      "peer": true
+      "license": "MIT"
     },
     "node_modules/@pkgjs/parseargs": {
       "version": "0.11.0",
@@ -3005,7 +3007,6 @@
       "resolved": "https://registry.npmjs.org/@polymer/polymer/-/polymer-3.5.2.tgz",
       "integrity": "sha512-fWwImY/UH4bb2534DVSaX+Azs2yKg8slkMBHOyGeU2kKx7Xmxp6Lee0jP8p6B3d7c1gFUPB2Z976dTUtX81pQA==",
       "license": "BSD-3-Clause",
-      "peer": true,
       "dependencies": {
         "@webcomponents/shadycss": "^1.9.1"
       }
@@ -4433,6 +4434,7 @@
       "resolved": "https://registry.npmjs.org/@svgdotjs/svg.js/-/svg.js-3.2.4.tgz",
       "integrity": "sha512-BjJ/7vWNowlX3Z8O4ywT58DqbNRyYlkk6Yz/D13aB7hGmfQTvGX4Tkgtm/ApYlu9M7lCQi15xUEidqMUmdMYwg==",
       "license": "MIT",
+      "peer": true,
       "funding": {
         "type": "github",
         "url": "https://github.com/sponsors/Fuzzyma"
@@ -4456,6 +4458,7 @@
       "resolved": "https://registry.npmjs.org/@svgdotjs/svg.select.js/-/svg.select.js-4.0.3.tgz",
       "integrity": "sha512-qkMgso1sd2hXKd1FZ1weO7ANq12sNmQJeGDjs46QwDVsxSRcHmvWKL2NDF7Yimpwf3sl5esOLkPqtV2bQ3v/Jg==",
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">= 14.18"
       },
@@ -4488,6 +4491,7 @@
       "resolved": "https://registry.npmjs.org/@tanstack/react-query/-/react-query-5.75.5.tgz",
       "integrity": "sha512-QrLCJe40BgBVlWdAdf2ZEVJ0cISOuEy/HKupId1aTKU6gPJZVhSvZpH+Si7csRflCJphzlQ77Yx6gUxGW9o0XQ==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@tanstack/query-core": "5.75.5"
       },
@@ -4576,7 +4580,6 @@
       "integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "color-convert": "^2.0.1"
       },
@@ -4593,7 +4596,6 @@
       "integrity": "sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "ansi-styles": "^4.1.0",
         "supports-color": "^7.1.0"
@@ -6737,8 +6739,7 @@
       "resolved": "https://registry.npmjs.org/@types/aria-query/-/aria-query-5.0.4.tgz",
       "integrity": "sha512-rfT93uj5s0PRL7EzccGMs3brplhcrghnDoV26NqKhCAS1hVo+WdNsPvE/yb6ilfr5hi2MEk6d5EWJTKdxg8jVw==",
       "dev": true,
-      "license": "MIT",
-      "peer": true
+      "license": "MIT"
     },
     "node_modules/@types/babel__core": {
       "version": "7.20.5",
@@ -7001,7 +7002,6 @@
       "resolved": "https://registry.npmjs.org/@types/d3-sankey/-/d3-sankey-0.11.2.tgz",
       "integrity": "sha512-U6SrTWUERSlOhnpSrgvMX64WblX1AxX6nEjI2t3mLK2USpQrnbwYYK+AS9SwiE7wgYmOsSSKoSdr8aoKBH0HgQ==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@types/d3-shape": "^1"
       }
@@ -7010,15 +7010,13 @@
       "version": "1.0.11",
       "resolved": "https://registry.npmjs.org/@types/d3-path/-/d3-path-1.0.11.tgz",
       "integrity": "sha512-4pQMp8ldf7UaB/gR8Fvvy69psNHkTpD/pVw3vmEi8iZAB9EPMBruB1JvHO4BIq9QkUUd2lV1F5YXpMNj7JPBpw==",
-      "license": "MIT",
-      "peer": true
+      "license": "MIT"
     },
     "node_modules/@types/d3-sankey/node_modules/@types/d3-shape": {
       "version": "1.3.12",
       "resolved": "https://registry.npmjs.org/@types/d3-shape/-/d3-shape-1.3.12.tgz",
       "integrity": "sha512-8oMzcd4+poSLGgV0R1Q1rOlx/xdmozS4Xab7np0eamFFUYq71AU9pOCJEFnkXW2aI/oXdVYJzw6pssbSut7Z9Q==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@types/d3-path": "^1"
       }
@@ -7154,6 +7152,7 @@
       "resolved": "https://registry.npmjs.org/@types/node/-/node-22.15.17.tgz",
       "integrity": "sha512-wIX2aSZL5FE+MR0JlvF87BNVrtFWf6AE6rxSE9X7OwnVvoyCQjpzSRJ+M87se/4QCkCiebQAqrJ0y6fwIyi7nw==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "undici-types": "~6.21.0"
       }
@@ -7180,8 +7179,7 @@
       "version": "1.1.3",
       "resolved": "https://registry.npmjs.org/@types/polylabel/-/polylabel-1.1.3.tgz",
       "integrity": "sha512-9Zw2KoDpi+T4PZz2G6pO2xArE0m/GSMTW1MIxF2s8ZY8x9XDO6fv9um0ydRGvcbkFLlaq8yNK6eZxnmMZtDgWQ==",
-      "license": "MIT",
-      "peer": true
+      "license": "MIT"
     },
     "node_modules/@types/prop-types": {
       "version": "15.7.14",
@@ -7196,6 +7194,7 @@
       "integrity": "sha512-gXLBtmlcRJeT09/sI4PxVwyrku6SaNUj/6cMubjE6T6XdY1fDmBL7r0nX0jbSZPU/Xr0KuwLLZh6aOYY5d91Xw==",
       "devOptional": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@types/prop-types": "*",
         "csstype": "^3.0.2"
@@ -7207,6 +7206,7 @@
       "integrity": "sha512-MEe3UeoENYVFXzoXEWsvcpg6ZvlrFNlOQ7EOsvhI3CfAXwzPfO8Qwuxd40nepsYKqyyVQnTdEfv68q91yLcKrQ==",
       "devOptional": true,
       "license": "MIT",
+      "peer": true,
       "peerDependencies": {
         "@types/react": "^18.0.0"
       }
@@ -7215,8 +7215,7 @@
       "version": "1.15.9",
       "resolved": "https://registry.npmjs.org/@types/sortablejs/-/sortablejs-1.15.9.tgz",
       "integrity": "sha512-7HP+rZGE2p886PKV9c9OJzLBI6BBJu1O7lJGYnPyG3fS4/duUCcngkNCjsLwIMV+WMqANe3tt4irrXHSIe68OQ==",
-      "license": "MIT",
-      "peer": true
+      "license": "MIT"
     },
     "node_modules/@types/supercluster": {
       "version": "7.1.3",
@@ -7231,15 +7230,13 @@
       "version": "3.2.3",
       "resolved": "https://registry.npmjs.org/@types/svg-arc-to-cubic-bezier/-/svg-arc-to-cubic-bezier-3.2.3.tgz",
       "integrity": "sha512-UNOnbTtl0nVTm8hwKaz5R5VZRvSulFMGojO5+Q7yucKxBoCaTtS4ibSQVRHo5VW5AaRo145U8p1Vfg5KrYe9Bg==",
-      "license": "MIT",
-      "peer": true
+      "license": "MIT"
     },
     "node_modules/@types/trusted-types": {
       "version": "2.0.7",
       "resolved": "https://registry.npmjs.org/@types/trusted-types/-/trusted-types-2.0.7.tgz",
       "integrity": "sha512-ScaPdn1dQczgbl0QFTeTOmVHFULt394XJgOQNoyVhZ6r2vLnMLJfBPd53SB52T/3G36VI1/g2MZaX0cwDuXsfw==",
-      "license": "MIT",
-      "peer": true
+      "license": "MIT"
     },
     "node_modules/@typescript-eslint/eslint-plugin": {
       "version": "8.32.0",
@@ -7277,6 +7274,7 @@
       "integrity": "sha512-B2MdzyWxCE2+SqiZHAjPphft+/2x2FlO9YBx7eKE1BCb+rqBlQdhtAEhzIEdozHd55DXPmxBdpMygFJjfjjA9A==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@typescript-eslint/scope-manager": "8.32.0",
         "@typescript-eslint/types": "8.32.0",
@@ -7452,7 +7450,6 @@
       "resolved": "https://registry.npmjs.org/@vaadin/a11y-base/-/a11y-base-24.9.13.tgz",
       "integrity": "sha512-yHTJXKNXNPlgbvRQrLfYRATSrbDSIHrm1kvwTOXxTHuK3+Jh337FumhNu5Xl8QWBp1Z3iPahxT9Qup/vcRtwIA==",
       "license": "Apache-2.0",
-      "peer": true,
       "dependencies": {
         "@open-wc/dedupe-mixin": "^1.3.0",
         "@polymer/polymer": "^3.0.0",
@@ -7465,7 +7462,6 @@
       "resolved": "https://registry.npmjs.org/@vaadin/checkbox/-/checkbox-24.9.13.tgz",
       "integrity": "sha512-sGu5xuyp/E64y8hAeh+uxEKvkOG5+NpWW1zI5qfYVCBKCrLcExngcpjpj2hckW5fWsYgVJNkokhzDPk4obBGcw==",
       "license": "Apache-2.0",
-      "peer": true,
       "dependencies": {
         "@open-wc/dedupe-mixin": "^1.3.0",
         "@polymer/polymer": "^3.0.0",
@@ -7483,7 +7479,6 @@
       "resolved": "https://registry.npmjs.org/@vaadin/component-base/-/component-base-24.9.13.tgz",
       "integrity": "sha512-OvP2kIDhO8NFunZeNXnGfQZhIxDn01skl/MKRiy/w3Syj0z/XXC1SoDBk1epR85EgsoNI7R6mF5VX/DzD9L46g==",
       "license": "Apache-2.0",
-      "peer": true,
       "dependencies": {
         "@open-wc/dedupe-mixin": "^1.3.0",
         "@polymer/polymer": "^3.0.0",
@@ -7497,7 +7492,6 @@
       "resolved": "https://registry.npmjs.org/@vaadin/field-base/-/field-base-24.9.13.tgz",
       "integrity": "sha512-ad2SqqXD/U+mfX8/0FXpfEMw2j+dKCy3t1zt3O1YppyarQVXVOFgCnPavubcvGyiSMlYW8r1iwbtUpB2oQuhJQ==",
       "license": "Apache-2.0",
-      "peer": true,
       "dependencies": {
         "@open-wc/dedupe-mixin": "^1.3.0",
         "@polymer/polymer": "^3.0.0",
@@ -7511,7 +7505,6 @@
       "resolved": "https://registry.npmjs.org/@vaadin/grid/-/grid-24.9.13.tgz",
       "integrity": "sha512-ePfp9IC3EE5NFsIzcNJzCWTGE3QX+pQpy7ozpkdZ1bV4yRVr5pzHW8mXie2BVltlhbXgarTPpr0WDIT39Npotw==",
       "license": "Apache-2.0",
-      "peer": true,
       "dependencies": {
         "@open-wc/dedupe-mixin": "^1.3.0",
         "@polymer/polymer": "^3.0.0",
@@ -7531,7 +7524,6 @@
       "resolved": "https://registry.npmjs.org/@vaadin/icon/-/icon-24.9.13.tgz",
       "integrity": "sha512-6S5e3XHURyy4WXzDVvYJl4WZPrWgJlCS3GEUMGmE1AwGwTsfE6pEqnJeKxJ9TxsIQaQYzUrjG1KAA1MyJ6RRgA==",
       "license": "Apache-2.0",
-      "peer": true,
       "dependencies": {
         "@open-wc/dedupe-mixin": "^1.3.0",
         "@polymer/polymer": "^3.0.0",
@@ -7546,7 +7538,6 @@
       "resolved": "https://registry.npmjs.org/@vaadin/input-container/-/input-container-24.9.13.tgz",
       "integrity": "sha512-DBhih7er0F5sBl6snTNwVgNS4LEAeILLMHWtARJrCOhuUSlPNDG1TMQ/xKPKDJs5okys8i//9sAC+3C2xiObNg==",
       "license": "Apache-2.0",
-      "peer": true,
       "dependencies": {
         "@polymer/polymer": "^3.0.0",
         "@vaadin/component-base": "~24.9.13",
@@ -7561,7 +7552,6 @@
       "resolved": "https://registry.npmjs.org/@vaadin/lit-renderer/-/lit-renderer-24.9.13.tgz",
       "integrity": "sha512-NQqAdRQJdPyICBB3a5YPtcx6txgFmFNlQvs5ayOpKJrLfLsd6crcZqEd6zberN+LoThENJqh/XzNqd52QYTBgQ==",
       "license": "Apache-2.0",
-      "peer": true,
       "dependencies": {
         "lit": "^3.0.0"
       }
@@ -7571,7 +7561,6 @@
       "resolved": "https://registry.npmjs.org/@vaadin/text-field/-/text-field-24.9.13.tgz",
       "integrity": "sha512-sqm0V7t58jA0UxMzskPDO9mYqpo4xCJbUkmRgZpTiMKyxEW+oHnNRInMzcnleUg/AAP1SNJxaK29I5H+1FOLoA==",
       "license": "Apache-2.0",
-      "peer": true,
       "dependencies": {
         "@open-wc/dedupe-mixin": "^1.3.0",
         "@polymer/polymer": "^3.0.0",
@@ -7589,15 +7578,13 @@
       "version": "2.0.7",
       "resolved": "https://registry.npmjs.org/@vaadin/vaadin-development-mode-detector/-/vaadin-development-mode-detector-2.0.7.tgz",
       "integrity": "sha512-9FhVhr0ynSR3X2ao+vaIEttcNU5XfzCbxtmYOV8uIRnUCtNgbvMOIcyGBvntsX9I5kvIP2dV3cFAOG9SILJzEA==",
-      "license": "Apache-2.0",
-      "peer": true
+      "license": "Apache-2.0"
     },
     "node_modules/@vaadin/vaadin-lumo-styles": {
       "version": "24.9.13",
       "resolved": "https://registry.npmjs.org/@vaadin/vaadin-lumo-styles/-/vaadin-lumo-styles-24.9.13.tgz",
       "integrity": "sha512-qUqXgTFLmpHcy/hGS7nmUEdrrfynrPSv8zPJVw4PPqfCIkcWe53oXT7QNJpwp+XRrrd1CoKZzSDubSFDTT9dxQ==",
       "license": "Apache-2.0",
-      "peer": true,
       "dependencies": {
         "@polymer/polymer": "^3.0.0",
         "@vaadin/component-base": "~24.9.13",
@@ -7610,7 +7597,6 @@
       "resolved": "https://registry.npmjs.org/@vaadin/vaadin-material-styles/-/vaadin-material-styles-24.9.13.tgz",
       "integrity": "sha512-PVkFC9XvI5KDWVWpdR5J8ju3Q7tKz8ueSPqZYJ0ETQNPBvsveJg+4o2FJcsKg3Cdruu9puOVgV+6mkwnvPXb3w==",
       "license": "Apache-2.0",
-      "peer": true,
       "dependencies": {
         "@polymer/polymer": "^3.0.0",
         "@vaadin/component-base": "~24.9.13",
@@ -7622,7 +7608,6 @@
       "resolved": "https://registry.npmjs.org/@vaadin/vaadin-themable-mixin/-/vaadin-themable-mixin-24.9.13.tgz",
       "integrity": "sha512-FYqDaqbRjF78a6e7oSFkw5heLHO9nczAHCbr/N+3oQGI9w3hkXt2uN51ByAajDCPVau2fPNsBN7fTJgYDRHL/g==",
       "license": "Apache-2.0",
-      "peer": true,
       "dependencies": {
         "@open-wc/dedupe-mixin": "^1.3.0",
         "lit": "^3.0.0",
@@ -7635,7 +7620,6 @@
       "integrity": "sha512-8r4TNknD7OJQADe3VygeofFR7UNAXZ2/jjBFP5dgI8+2uMfnuGYgbuHivasKr9WSQ64sPej6m8rDoM1uSllXjQ==",
       "hasInstallScript": true,
       "license": "Apache-2.0",
-      "peer": true,
       "dependencies": {
         "@vaadin/vaadin-development-mode-detector": "^2.0.0"
       },
@@ -7813,8 +7797,7 @@
       "version": "1.11.2",
       "resolved": "https://registry.npmjs.org/@webcomponents/shadycss/-/shadycss-1.11.2.tgz",
       "integrity": "sha512-vRq+GniJAYSBmTRnhCYPAPq6THYqovJ/gzGThWbgEZUQaBccndGTi1hdiUP15HzEco0I6t4RCtXyX0rsSmwgPw==",
-      "license": "BSD-3-Clause",
-      "peer": true
+      "license": "BSD-3-Clause"
     },
     "node_modules/@yr/monotone-cubic-spline": {
       "version": "1.0.3",
@@ -7827,7 +7810,6 @@
       "resolved": "https://registry.npmjs.org/@zip.js/zip.js/-/zip.js-2.8.23.tgz",
       "integrity": "sha512-RB+RLnxPJFPrGvQ9rgO+4JOcsob6lD32OcF0QE0yg24oeW9q8KnTTNlugcDaIveEcCbclobJcZP+fLQ++sH0bw==",
       "license": "BSD-3-Clause",
-      "peer": true,
       "engines": {
         "bun": ">=0.7.0",
         "deno": ">=1.0.0",
@@ -7863,6 +7845,7 @@
       "integrity": "sha512-OvQ/2pUDKmgfCg++xsTX1wGxfTaszcHVcTctW4UJB4hibJx2HXxxO5UmVgyjMa+ZDsiaf5wWLXYpRWMmBI0QHg==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "bin": {
         "acorn": "bin/acorn"
       },
@@ -7940,7 +7923,6 @@
       "integrity": "sha512-Cxwpt2SfTzTtXcfOlzGEee8O+c+MmUgGrNiBcXnuWxuFJHe6a5Hz7qwhwe5OgaSYI0IJvkLqWX1ASG+cJOkEiA==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=10"
       },
@@ -7972,6 +7954,7 @@
       "resolved": "https://registry.npmjs.org/apexcharts/-/apexcharts-4.7.0.tgz",
       "integrity": "sha512-iZSrrBGvVlL+nt2B1NpqfDuBZ9jX61X9I2+XV0hlYXHtTwhwLTHDKGXjNXAgFBDLuvSYCB/rq2nPWVPRv2DrGA==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@svgdotjs/svg.draggable.js": "^3.0.4",
         "@svgdotjs/svg.filter.js": "^3.0.8",
@@ -8247,6 +8230,7 @@
         }
       ],
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "caniuse-lite": "^1.0.30001716",
         "electron-to-chromium": "^1.5.149",
@@ -8313,7 +8297,6 @@
       "resolved": "https://registry.npmjs.org/call-bind/-/call-bind-1.0.8.tgz",
       "integrity": "sha512-oKlSFMcMwpUg2ednkhQ454wfWiU/ul3CkJe/PEHcTKuiX6RpbehUiFMXu13HalGZxfUwCQzZG747YXBn1im9ww==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "call-bind-apply-helpers": "^1.0.0",
         "es-define-property": "^1.0.0",
@@ -8597,7 +8580,6 @@
       "resolved": "https://registry.npmjs.org/clone/-/clone-1.0.4.tgz",
       "integrity": "sha512-JQHZ2QMW6l3aH/j6xCqQThY/9OH4D/9ls34cgkUBiEeocRTU04tHfKPBsUK1PqZCUQM7GiA0IIXJSuXHI64Kbg==",
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=0.8"
       }
@@ -8616,7 +8598,6 @@
       "resolved": "https://registry.npmjs.org/color/-/color-5.0.3.tgz",
       "integrity": "sha512-ezmVcLR3xAVp8kYOm4GS45ZLLgIE6SPAFoduLr6hTDajwb3KZ2F46gulK3XpcwRFb5KKGCSezCBAY4Dw4HsyXA==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "color-convert": "^3.1.3",
         "color-string": "^2.1.3"
@@ -8648,7 +8629,6 @@
       "resolved": "https://registry.npmjs.org/color-string/-/color-string-2.1.4.tgz",
       "integrity": "sha512-Bb6Cq8oq0IjDOe8wJmi4JeNn763Xs9cfrBcaylK1tPypWzyoy2G3l90v9k64kjphl/ZJjPIShFztenRomi8WTg==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "color-name": "^2.0.0"
       },
@@ -8661,7 +8641,6 @@
       "resolved": "https://registry.npmjs.org/color-name/-/color-name-2.1.0.tgz",
       "integrity": "sha512-1bPaDNFm0axzE4MEAzKPuqKWeRaT43U/hyxKPBdqTfmPF+d6n7FSoTFxLVULUJOmiLp01KjhIPPH+HrXZJN4Rg==",
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=12.20"
       }
@@ -8671,7 +8650,6 @@
       "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-3.1.3.tgz",
       "integrity": "sha512-fasDH2ont2GqF5HpyO4w0+BcewlhHEZOFn9c1ckZdHpJ56Qb7MHhH/IcJZbBGgvdtwdwNbLvxiBEdg336iA9Sg==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "color-name": "^2.0.0"
       },
@@ -8684,7 +8662,6 @@
       "resolved": "https://registry.npmjs.org/color-name/-/color-name-2.1.0.tgz",
       "integrity": "sha512-1bPaDNFm0axzE4MEAzKPuqKWeRaT43U/hyxKPBdqTfmPF+d6n7FSoTFxLVULUJOmiLp01KjhIPPH+HrXZJN4Rg==",
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=12.20"
       }
@@ -8737,7 +8714,6 @@
       "resolved": "https://registry.npmjs.org/composed-offset-position/-/composed-offset-position-0.0.6.tgz",
       "integrity": "sha512-Q7dLompI6lUwd7LWyIcP66r4WcS9u7AL2h8HaeipiRfCRPLMWqRx8fYsjb4OHi6UQFifO7XtNC2IlEJ1ozIFxw==",
       "license": "MIT",
-      "peer": true,
       "peerDependencies": {
         "@floating-ui/utils": "^0.2.5"
       }
@@ -8896,6 +8872,7 @@
       "integrity": "sha512-itvL5h8RETACmOTFc4UfIyB2RfEHi71Ax6E/PivVxq9NseKbOWpeyHEOIbmAw1rs8Ak0VursQNww7lf7YtUwzg==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "env-paths": "^2.2.1",
         "import-fresh": "^3.3.0",
@@ -8962,8 +8939,7 @@
       "version": "4.2.0",
       "resolved": "https://registry.npmjs.org/crypto-js/-/crypto-js-4.2.0.tgz",
       "integrity": "sha512-KALDyEYgpY+Rlob/iriUtjV6d5Eq+Y191A5g4UqLAi8CyGP9N1+FdVbkc1SxKc2r4YAYqG8JzO2KGL+AizD70Q==",
-      "license": "MIT",
-      "peer": true
+      "license": "MIT"
     },
     "node_modules/css.escape": {
       "version": "1.5.1",
@@ -8994,8 +8970,7 @@
       "version": "0.0.10",
       "resolved": "https://registry.npmjs.org/cssfilter/-/cssfilter-0.0.10.tgz",
       "integrity": "sha512-FAaLDaplstoRsDR8XGYH51znUN0UY7nMc6Z9/fvE8EXGwvJE9hu7W2vHwx1+bd6gCYnln9nLbzxFTrcO9YQDZw==",
-      "license": "MIT",
-      "peer": true
+      "license": "MIT"
     },
     "node_modules/cssstyle": {
       "version": "4.3.1",
@@ -9314,7 +9289,6 @@
       "resolved": "https://registry.npmjs.org/d3-sankey/-/d3-sankey-0.12.3.tgz",
       "integrity": "sha512-nQhsBRmM19Ax5xEIPLMY9ZmJ/cDvd1BG3UVvt5h3WRxKg5zGRbvnteTyWAbzeSvlh3tW7ZEmq4VwR5mB3tutmQ==",
       "license": "BSD-3-Clause",
-      "peer": true,
       "dependencies": {
         "d3-array": "1 - 2",
         "d3-shape": "^1.2.0"
@@ -9325,7 +9299,6 @@
       "resolved": "https://registry.npmjs.org/d3-array/-/d3-array-2.12.1.tgz",
       "integrity": "sha512-B0ErZK/66mHtEsR1TkPEEkwdy+WDesimkM5gpZr5Dsg54BiTA5RXtYW5qTLIAcekaS9xfZrzBLF/OAkB3Qn1YQ==",
       "license": "BSD-3-Clause",
-      "peer": true,
       "dependencies": {
         "internmap": "^1.0.0"
       }
@@ -9334,15 +9307,13 @@
       "version": "1.0.9",
       "resolved": "https://registry.npmjs.org/d3-path/-/d3-path-1.0.9.tgz",
       "integrity": "sha512-VLaYcn81dtHVTjEHd8B+pbe9yHWpXKZUC87PzoFmsFrJqgFwDe/qxfp5MlfsfM1V5E/iVt0MmEbWQ7FVIXh/bg==",
-      "license": "BSD-3-Clause",
-      "peer": true
+      "license": "BSD-3-Clause"
     },
     "node_modules/d3-sankey/node_modules/d3-shape": {
       "version": "1.3.7",
       "resolved": "https://registry.npmjs.org/d3-shape/-/d3-shape-1.3.7.tgz",
       "integrity": "sha512-EUkvKjqPFUAZyOlhY5gzCxCeI0Aep04LwIRpsZ/mLFelJiUfnK56jo5JMDSE7yyP2kLSb6LtF+S5chMk7uqPqw==",
       "license": "BSD-3-Clause",
-      "peer": true,
       "dependencies": {
         "d3-path": "1"
       }
@@ -9351,8 +9322,7 @@
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/internmap/-/internmap-1.0.1.tgz",
       "integrity": "sha512-lDB5YccMydFBtasVtxnZ3MRBHuaoE8GKsppq+EchKL2U4nK/DmEpPHNH8MZe5HkMtpSiTSOZwfN0tzYjO/lJEw==",
-      "license": "ISC",
-      "peer": true
+      "license": "ISC"
     },
     "node_modules/d3-scale": {
       "version": "4.0.2",
@@ -9388,6 +9358,7 @@
       "resolved": "https://registry.npmjs.org/d3-selection/-/d3-selection-3.0.0.tgz",
       "integrity": "sha512-fmTRWbNMmsmWq6xJV8D19U/gw/bwrHfNXxrIN+HfZgnzqTHp9jOmKMhsTUjXOJnZOdZY9Q28y4yebKzqDKlxlQ==",
       "license": "ISC",
+      "peer": true,
       "engines": {
         "node": ">=12"
       }
@@ -9467,7 +9438,6 @@
       "resolved": "https://registry.npmjs.org/d3-voronoi-map/-/d3-voronoi-map-2.1.1.tgz",
       "integrity": "sha512-mCXfz/kD9IQxjHaU2IMjkO8fSo4J6oysPR2iL+omDsCy1i1Qn6BQ/e4hEAW8C6ms2kfuHwqtbNom80Hih94YsA==",
       "license": "BSD-3-Clause",
-      "peer": true,
       "dependencies": {
         "d3-dispatch": "2.*",
         "d3-polygon": "2.*",
@@ -9479,29 +9449,25 @@
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/d3-dispatch/-/d3-dispatch-2.0.0.tgz",
       "integrity": "sha512-S/m2VsXI7gAti2pBoLClFFTMOO1HTtT0j99AuXLoGFKO6deHDdnv6ZGTxSTTUTgO1zVcv82fCOtDjYK4EECmWA==",
-      "license": "BSD-3-Clause",
-      "peer": true
+      "license": "BSD-3-Clause"
     },
     "node_modules/d3-voronoi-map/node_modules/d3-polygon": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/d3-polygon/-/d3-polygon-2.0.0.tgz",
       "integrity": "sha512-MsexrCK38cTGermELs0cO1d79DcTsQRN7IWMJKczD/2kBjzNXxLUWP33qRF6VDpiLV/4EI4r6Gs0DAWQkE8pSQ==",
-      "license": "BSD-3-Clause",
-      "peer": true
+      "license": "BSD-3-Clause"
     },
     "node_modules/d3-voronoi-map/node_modules/d3-timer": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/d3-timer/-/d3-timer-2.0.0.tgz",
       "integrity": "sha512-TO4VLh0/420Y/9dO3+f9abDEFYeCUr2WZRlxJvbp4HPTQcSylXNiL6yZa9FIUvV1yRiFufl1bszTCLDqv9PWNA==",
-      "license": "BSD-3-Clause",
-      "peer": true
+      "license": "BSD-3-Clause"
     },
     "node_modules/d3-voronoi-treemap": {
       "version": "1.1.2",
       "resolved": "https://registry.npmjs.org/d3-voronoi-treemap/-/d3-voronoi-treemap-1.1.2.tgz",
       "integrity": "sha512-7odu9HdG/yLPWwzDteJq4yd9Q/NwgQV7IE/u36VQtcCK7k1sZwDqbkHCeMKNTBsq5mQjDwolTsrXcU0j8ZEMCA==",
       "license": "BSD-3-Clause",
-      "peer": true,
       "dependencies": {
         "d3-voronoi-map": "2.*"
       }
@@ -9511,7 +9477,6 @@
       "resolved": "https://registry.npmjs.org/d3-weighted-voronoi/-/d3-weighted-voronoi-1.1.3.tgz",
       "integrity": "sha512-C3WdvSKl9aqhAy+f3QT3PPsQG6V+ajDfYO3BSclQDSD+araW2xDBFIH67aKzsSuuuKaX8K2y2dGq1fq/dWTVig==",
       "license": "BSD-3-Clause",
-      "peer": true,
       "dependencies": {
         "d3-array": "2",
         "d3-polygon": "2"
@@ -9522,7 +9487,6 @@
       "resolved": "https://registry.npmjs.org/d3-array/-/d3-array-2.12.1.tgz",
       "integrity": "sha512-B0ErZK/66mHtEsR1TkPEEkwdy+WDesimkM5gpZr5Dsg54BiTA5RXtYW5qTLIAcekaS9xfZrzBLF/OAkB3Qn1YQ==",
       "license": "BSD-3-Clause",
-      "peer": true,
       "dependencies": {
         "internmap": "^1.0.0"
       }
@@ -9531,15 +9495,13 @@
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/d3-polygon/-/d3-polygon-2.0.0.tgz",
       "integrity": "sha512-MsexrCK38cTGermELs0cO1d79DcTsQRN7IWMJKczD/2kBjzNXxLUWP33qRF6VDpiLV/4EI4r6Gs0DAWQkE8pSQ==",
-      "license": "BSD-3-Clause",
-      "peer": true
+      "license": "BSD-3-Clause"
     },
     "node_modules/d3-weighted-voronoi/node_modules/internmap": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/internmap/-/internmap-1.0.1.tgz",
       "integrity": "sha512-lDB5YccMydFBtasVtxnZ3MRBHuaoE8GKsppq+EchKL2U4nK/DmEpPHNH8MZe5HkMtpSiTSOZwfN0tzYjO/lJEw==",
-      "license": "ISC",
-      "peer": true
+      "license": "ISC"
     },
     "node_modules/d3-zoom": {
       "version": "3.0.0",
@@ -9692,7 +9654,6 @@
       "resolved": "https://registry.npmjs.org/deep-equal/-/deep-equal-1.1.2.tgz",
       "integrity": "sha512-5tdhKF6DbU7iIzrIOa1AOUt39ZRm13cmL1cGEh//aqR8x9+tNfbywRf0n5FD/18OKMdo7DNEtrX2t22ZAkI+eg==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "is-arguments": "^1.1.1",
         "is-date-object": "^1.0.5",
@@ -9732,7 +9693,6 @@
       "resolved": "https://registry.npmjs.org/define-data-property/-/define-data-property-1.1.4.tgz",
       "integrity": "sha512-rBMvIzlpA8v6E+SJZoo++HAYqsLrkg7MSfIinMPFhmkorw7X+dOXVJQs+QT69zGkzMyfDnIMN2Wid1+NbL3T+A==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "es-define-property": "^1.0.0",
         "es-errors": "^1.3.0",
@@ -9750,7 +9710,6 @@
       "resolved": "https://registry.npmjs.org/define-properties/-/define-properties-1.2.1.tgz",
       "integrity": "sha512-8QmQKqEASLd5nx0U1B1okLElbUuuttJ/AnYmRXbbbGDWh6uS208EjD4Xqq/I9wK7u0v6O08XhTWnt5XtEbR6Dg==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "define-data-property": "^1.0.1",
         "has-property-descriptors": "^1.0.0",
@@ -9817,8 +9776,7 @@
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/dfa/-/dfa-1.2.0.tgz",
       "integrity": "sha512-ED3jP8saaweFTjeGX8HQPjeC1YYyZs98jGNZx6IiBvxW7JG5v492kamAQB3m2wop07CvU/RQmzcKr6bgcC5D/Q==",
-      "license": "MIT",
-      "peer": true
+      "license": "MIT"
     },
     "node_modules/didyoumean": {
       "version": "1.2.2",
@@ -9837,8 +9795,7 @@
       "resolved": "https://registry.npmjs.org/dom-accessibility-api/-/dom-accessibility-api-0.5.16.tgz",
       "integrity": "sha512-X7BJ2yElsnOJ30pZF4uIIDfBEVgF4XEBxL9Bxhy6dnrm5hkzqmsWHGTiHqRiITNhMyFLyAiWndIJP7Z1NTteDg==",
       "dev": true,
-      "license": "MIT",
-      "peer": true
+      "license": "MIT"
     },
     "node_modules/dom-helpers": {
       "version": "5.2.1",
@@ -10015,7 +9972,6 @@
       "resolved": "https://registry.npmjs.org/es-toolkit/-/es-toolkit-1.45.1.tgz",
       "integrity": "sha512-/jhoOj/Fx+A+IIyDNOvO3TItGmlMKhtX8ISAHKE90c4b/k1tqaqEZ+uUqfpU8DMnW5cgNJv606zS55jGvza0Xw==",
       "license": "MIT",
-      "peer": true,
       "workspaces": [
         "docs",
         "benchmarks"
@@ -10098,6 +10054,7 @@
       "integrity": "sha512-Hx0MOjPh6uK9oq9nVsATZKE/Wlbai7KFjfCuw9UHaguDW3x+HF0O5nIi3ud39TWgrTjTO5nHxmL3R1eANinWHQ==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@eslint-community/eslint-utils": "^4.2.0",
         "@eslint-community/regexpp": "^4.12.1",
@@ -10520,6 +10477,7 @@
       "integrity": "sha512-hIS4idWWai69NezIdRt2xFVofaF4j+6INOpJlVOLDO8zXGpUVEVzIYk12UUi2JzjEzWL3IOAxcTubgz9Po0yXw==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "accepts": "^2.0.0",
         "body-parser": "^2.2.1",
@@ -10786,8 +10744,7 @@
       "version": "4.6.13",
       "resolved": "https://registry.npmjs.org/flatpickr/-/flatpickr-4.6.13.tgz",
       "integrity": "sha512-97PMG/aywoYpB4IvbvUJi0RQi8vearvU0oov1WW3k0WZPBMrTQVqekSX5CjSG/M4Q3i6A/0FKXC7RyAoAUUSPw==",
-      "license": "MIT",
-      "peer": true
+      "license": "MIT"
     },
     "node_modules/flatted": {
       "version": "3.4.2",
@@ -10801,7 +10758,6 @@
       "resolved": "https://registry.npmjs.org/focus-trap/-/focus-trap-7.8.0.tgz",
       "integrity": "sha512-/yNdlIkpWbM0ptxno3ONTuf+2g318kh2ez3KSeZN5dZ8YC6AAmgeWz+GasYYiBJPFaYcSAPeu4GfhUaChzIJXA==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "tabbable": "^6.4.0"
       }
@@ -10941,7 +10897,6 @@
       "resolved": "https://registry.npmjs.org/functions-have-names/-/functions-have-names-1.2.3.tgz",
       "integrity": "sha512-xckBUXyTIqT97tq2x2AMb+g163b5JFysYk0x4qxNFwbfQkmNZoiRHb6sPzI9/QV33WeuvVYBUIiD4NzNIyqaRQ==",
       "license": "MIT",
-      "peer": true,
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
       }
@@ -11221,7 +11176,6 @@
       "resolved": "https://registry.npmjs.org/has-property-descriptors/-/has-property-descriptors-1.0.2.tgz",
       "integrity": "sha512-55JNKuIW+vq4Ke1BjOTjM2YctQIvCT7GFzHwmfZPGo5wnrgkid0YQtnAleFSqumZm4az3n2BS+erby5ipJdgrg==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "es-define-property": "^1.0.0"
       },
@@ -11274,6 +11228,7 @@
       "integrity": "sha512-p1JfQMKaceuCbpJKAPKVqyqviZdS0eUxH9v82oWo1kb9xjQ5wA6iP3FNVAPDFlz5/p7d45lO+BpSk1tuSZMF4Q==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=16.9.0"
       }
@@ -11502,7 +11457,6 @@
       "resolved": "https://registry.npmjs.org/interactjs/-/interactjs-1.10.27.tgz",
       "integrity": "sha512-y/8RcCftGAF24gSp76X2JS3XpHiUvDQyhF8i7ujemBz77hwiHDuJzftHx7thY8cxGogwGiPJ+o97kWB6eAXnsA==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@interactjs/types": "1.10.27"
       }
@@ -11541,7 +11495,6 @@
       "resolved": "https://registry.npmjs.org/is-arguments/-/is-arguments-1.2.0.tgz",
       "integrity": "sha512-7bVbi0huj/wrIAOzb8U1aszg9kdi3KN/CyU19CTI7tAoZYEZoL9yCDXpbXN+uPsuWnP02cyug1gleqq+TU+YCA==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "call-bound": "^1.0.2",
         "has-tostringtag": "^1.0.2"
@@ -11598,7 +11551,6 @@
       "resolved": "https://registry.npmjs.org/is-date-object/-/is-date-object-1.1.0.tgz",
       "integrity": "sha512-PwwhEakHVKTdRNVOw+/Gyh0+MzlCl4R6qKvkhuvLtPMggI1WAHt9sOwZxQLSGpUaDnrdyDsomoRgNnCfKNSXXg==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "call-bound": "^1.0.2",
         "has-tostringtag": "^1.0.2"
@@ -11705,7 +11657,6 @@
       "resolved": "https://registry.npmjs.org/is-regex/-/is-regex-1.2.1.tgz",
       "integrity": "sha512-MjYsKHO5O7mCsmRGxWcLWheFqN9DJ/2TmngvjKXihe6efViPqc274+Fx/4fYj/r03+ESvBdTXK0V6tA3rgez1g==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "call-bound": "^1.0.2",
         "gopd": "^1.2.0",
@@ -11866,8 +11817,7 @@
       "resolved": "https://registry.npmjs.org/jpeg-exif/-/jpeg-exif-1.1.4.tgz",
       "integrity": "sha512-a+bKEcCjtuW5WTdgeXFzswSrdqi0jk4XlEtZlx5A94wCoBpFjfFTbo/Tra5SpNCl/YFZPvcV1dJc+TAYeg6ROQ==",
       "deprecated": "Package no longer supported. Contact Support at https://www.npmjs.com/support for more info.",
-      "license": "MIT",
-      "peer": true
+      "license": "MIT"
     },
     "node_modules/js-tokens": {
       "version": "4.0.0",
@@ -11894,6 +11844,7 @@
       "integrity": "sha512-Cvc9WUhxSMEo4McES3P7oK3QaXldCfNWp7pl2NNeiIFlCoLr3kfq9kb1fxftiwk1FLV7CvpvDfonxtzUDeSOPg==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "cssstyle": "^4.2.1",
         "data-urls": "^5.0.0",
@@ -12138,7 +12089,6 @@
       "resolved": "https://registry.npmjs.org/lit-element/-/lit-element-4.2.2.tgz",
       "integrity": "sha512-aFKhNToWxoyhkNDmWZwEva2SlQia+jfG0fjIWV//YeTaWrVnOxD89dPKfigCUspXFmjzOEUQpOkejH5Ly6sG0w==",
       "license": "BSD-3-Clause",
-      "peer": true,
       "dependencies": {
         "@lit-labs/ssr-dom-shim": "^1.5.0",
         "@lit/reactive-element": "^2.1.0",
@@ -12150,7 +12100,6 @@
       "resolved": "https://registry.npmjs.org/lit-html/-/lit-html-3.3.2.tgz",
       "integrity": "sha512-Qy9hU88zcmaxBXcc10ZpdK7cOLXvXpRoBxERdtqV9QOrfpMZZ6pSYP91LhpPtap3sFMUiL7Tw2RImbe0Al2/kw==",
       "license": "BSD-3-Clause",
-      "peer": true,
       "dependencies": {
         "@types/trusted-types": "^2.0.2"
       }
@@ -12292,7 +12241,6 @@
       "resolved": "https://registry.npmjs.org/luxon/-/luxon-3.7.2.tgz",
       "integrity": "sha512-vtEhXh/gNjI9Yg1u4jX/0YVPMvxzHuGgCm6tC5kZyb08yjGWGnqAjGJvcXbqQR2P3MyMEFnRbpcdFS6PBcLqew==",
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=12"
       }
@@ -12303,7 +12251,6 @@
       "integrity": "sha512-h5bgJWpxJNswbU7qCrV0tIKQCaS3blPDrqKWx+QxzuzL1zGUzij9XCWLrSLsJPu5t+eWA/ycetzYAO5IOMcWAQ==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "bin": {
         "lz-string": "bin/bin.js"
       }
@@ -12455,7 +12402,6 @@
       "resolved": "https://registry.npmjs.org/marked/-/marked-16.3.0.tgz",
       "integrity": "sha512-K3UxuKu6l6bmA5FUwYho8CfJBlsUWAooKtdGgMcERSpF7gcBUrCGsLH7wDaaNOzwq18JzSUDyoEb/YsrqMac3w==",
       "license": "MIT",
-      "peer": true,
       "bin": {
         "marked": "bin/marked.js"
       },
@@ -12467,8 +12413,7 @@
       "version": "2.32.7",
       "resolved": "https://registry.npmjs.org/markerjs2/-/markerjs2-2.32.7.tgz",
       "integrity": "sha512-HeFRZjmc43DOG3lSQp92z49cq2oCYpYn2pX++SkJAW1Dij4xJtRquVRf+cXeSZQWDX3ufns1Ry/bGk+zveP7rA==",
-      "license": "SEE LICENSE IN LICENSE",
-      "peer": true
+      "license": "SEE LICENSE IN LICENSE"
     },
     "node_modules/martinez-polygon-clipping": {
       "version": "0.8.1",
@@ -12798,7 +12743,6 @@
       "resolved": "https://registry.npmjs.org/object-is/-/object-is-1.1.6.tgz",
       "integrity": "sha512-F8cZ+KfGlSGi09lJT7/Nd6KJZ9ygtvYC0/UYYLI9nmQKLMnydpB9yvbv9K1uSkEu7FU9vYPmVwLg328tX+ot3Q==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "call-bind": "^1.0.7",
         "define-properties": "^1.2.1"
@@ -12815,7 +12759,6 @@
       "resolved": "https://registry.npmjs.org/object-keys/-/object-keys-1.1.1.tgz",
       "integrity": "sha512-NuAESUOUMrlIXOfHKzD6bpPu3tYt3xvjNdRIQ+FeT0lNb4K8WR70CaDxhuNguS2XG+GjkyMwOzsN5ZktImfhLA==",
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">= 0.4"
       }
@@ -13053,7 +12996,6 @@
       "resolved": "https://registry.npmjs.org/pdfmake/-/pdfmake-0.2.23.tgz",
       "integrity": "sha512-A/IksoKb/ikOZH1edSDJ/2zBbqJKDghD4+fXn3rT7quvCJDlsZMs3NmIB3eajLMMFU9Bd3bZPVvlUMXhvFI+bQ==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@foliojs-fork/linebreak": "^1.1.2",
         "@foliojs-fork/pdfkit": "^0.15.3",
@@ -13069,7 +13011,6 @@
       "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.7.2.tgz",
       "integrity": "sha512-im9DjEDQ55s9fL4EYzOAv0yMqmMBSZp6G0VvFyTMPKWxiSBHUj9NW/qqLmXUwXrrM7AvqSlTCfvqRb0cM8yYqw==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "safer-buffer": ">= 2.1.2 < 3.0.0"
       },
@@ -13177,8 +13118,7 @@
     "node_modules/png-js": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/png-js/-/png-js-1.0.0.tgz",
-      "integrity": "sha512-k+YsbhpA9e+EFfKjTCH3VW6aoKlyNYI6NYdTfDL4CIvFnvsuO84ttonmZE7rc+v23SLTH8XX+5w/Ak9v0xGY4g==",
-      "peer": true
+      "integrity": "sha512-k+YsbhpA9e+EFfKjTCH3VW6aoKlyNYI6NYdTfDL4CIvFnvsuO84ttonmZE7rc+v23SLTH8XX+5w/Ak9v0xGY4g=="
     },
     "node_modules/point-in-polygon": {
       "version": "1.1.0",
@@ -13216,7 +13156,6 @@
       "resolved": "https://registry.npmjs.org/polylabel/-/polylabel-1.1.0.tgz",
       "integrity": "sha512-bxaGcA40sL3d6M4hH72Z4NdLqxpXRsCFk8AITYg6x1rn1Ei3izf00UMLklerBZTO49aPA3CYrIwVulx2Bce2pA==",
       "license": "ISC",
-      "peer": true,
       "dependencies": {
         "tinyqueue": "^2.0.3"
       }
@@ -13240,6 +13179,7 @@
         }
       ],
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "nanoid": "^3.3.8",
         "picocolors": "^1.1.1",
@@ -13396,6 +13336,7 @@
       "integrity": "sha512-QQtaxnoDJeAkDvDKWCLiwIXkTgRhwYDEQCghU9Z6q03iyek/rxRh/2lC3HB7P8sWT2xC/y5JDctPLBIGzHKbhw==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "bin": {
         "prettier": "bin/prettier.cjs"
       },
@@ -13425,7 +13366,6 @@
       "integrity": "sha512-Qb1gy5OrP5+zDf2Bvnzdl3jsTf1qXVMazbvCoKhtKqVs4/YK4ozX4gKQJJVyNe+cajNPn0KoC0MC3FUmaHWEmQ==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "ansi-regex": "^5.0.1",
         "ansi-styles": "^5.0.0",
@@ -13608,6 +13548,7 @@
       "resolved": "https://registry.npmjs.org/react/-/react-18.3.1.tgz",
       "integrity": "sha512-wS+hAgJShR0KhEvPJArfuPVN1+Hz1t0Y6n5jLrGQbkb4urgPE/0Rve+1kMB1v/oWgHgm4WIcV+i7F2pTVj+2iQ==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "loose-envify": "^1.1.0"
       },
@@ -13633,6 +13574,7 @@
       "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-18.3.1.tgz",
       "integrity": "sha512-5m4nQKp+rZRb09LNH59GM4BxTh9251/ylbKIbpe7TpGxfJ+9kv6BLkLBXIjjspbgbnIBNqlI23tRnTWT0snUIw==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "loose-envify": "^1.1.0",
         "scheduler": "^0.23.2"
@@ -13658,8 +13600,7 @@
       "resolved": "https://registry.npmjs.org/react-is/-/react-is-17.0.2.tgz",
       "integrity": "sha512-w2GsyukL62IJnlaff/nRegPQR94C/XXamvMWmSHRJ4y7Ts/4ocGRmTHvOs8PSE6pB3dWOrD/nueuU5sduBsQ4w==",
       "dev": true,
-      "license": "MIT",
-      "peer": true
+      "license": "MIT"
     },
     "node_modules/react-map-gl": {
       "version": "7.1.9",
@@ -13945,7 +13886,6 @@
       "resolved": "https://registry.npmjs.org/regexp.prototype.flags/-/regexp.prototype.flags-1.5.4.tgz",
       "integrity": "sha512-dYqgNSZbDwkaJ2ceRd9ojCGjBq+mOm9LmtXnAnEGyHhN/5R7iDW2TRw3h+o/jCFxus3P2LfWIIiwowAjANm7IA==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "call-bind": "^1.0.8",
         "define-properties": "^1.2.1",
@@ -14155,7 +14095,6 @@
       "resolved": "https://registry.npmjs.org/sax/-/sax-1.5.0.tgz",
       "integrity": "sha512-21IYA3Q5cQf089Z6tgaUTr7lDAyzoTPx5HRtbhsME8Udispad8dC/+sziTNugOEx54ilvatQ9YCzl4KQLPcRHA==",
       "license": "BlueOak-1.0.0",
-      "peer": true,
       "engines": {
         "node": ">=11.0.0"
       }
@@ -14186,8 +14125,7 @@
       "version": "3.0.5",
       "resolved": "https://registry.npmjs.org/seedrandom/-/seedrandom-3.0.5.tgz",
       "integrity": "sha512-8OwmbklUNzwezjGInmZ+2clQmExQPvomqjL7LFqOYqtmuxRgQYqOD3mHaU+MvZn5FLUeVxVfQjwLZW/n/JFuqg==",
-      "license": "MIT",
-      "peer": true
+      "license": "MIT"
     },
     "node_modules/semver": {
       "version": "7.7.1",
@@ -14260,7 +14198,6 @@
       "resolved": "https://registry.npmjs.org/set-function-length/-/set-function-length-1.2.2.tgz",
       "integrity": "sha512-pgRc4hJ4/sNjWCSS9AmnS40x3bNMDTknHgL5UaMBTMyJnU90EgWh1Rz+MC9eFu4BuN/UwZjKQuY/1v3rM7HMfg==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "define-data-property": "^1.1.4",
         "es-errors": "^1.3.0",
@@ -14278,7 +14215,6 @@
       "resolved": "https://registry.npmjs.org/set-function-name/-/set-function-name-2.0.2.tgz",
       "integrity": "sha512-7PGFlmtwsEADb0WYyvCMa1t+yke6daIG4Wirafur5kcf+MhUnPms1UeR0CKQdTZD81yESwMHbtn+TR+dMviakQ==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "define-data-property": "^1.1.4",
         "es-errors": "^1.3.0",
@@ -14494,8 +14430,7 @@
       "version": "1.15.7",
       "resolved": "https://registry.npmjs.org/sortablejs/-/sortablejs-1.15.7.tgz",
       "integrity": "sha512-Kk8wLQPlS+yi1ZEf48a4+fzHa4yxjC30M/Sr2AnQu+f/MPwvvX9XjZ6OWejiz8crBsLwSq8GHqaxaET7u6ux0A==",
-      "license": "MIT",
-      "peer": true
+      "license": "MIT"
     },
     "node_modules/source-map-js": {
       "version": "1.2.1",
@@ -14752,8 +14687,7 @@
           "url": "https://opencollective.com/leaverou"
         }
       ],
-      "license": "MIT",
-      "peer": true
+      "license": "MIT"
     },
     "node_modules/sucrase": {
       "version": "3.35.0",
@@ -14824,8 +14758,7 @@
       "version": "3.2.0",
       "resolved": "https://registry.npmjs.org/svg-arc-to-cubic-bezier/-/svg-arc-to-cubic-bezier-3.2.0.tgz",
       "integrity": "sha512-djbJ/vZKZO+gPoSDThGNpKDO+o+bAeA4XQKovvkNCqnIS2t+S4qnLAGQhyyrulhCFRl1WWzAp0wUDV8PpTVU3g==",
-      "license": "ISC",
-      "peer": true
+      "license": "ISC"
     },
     "node_modules/sweepline-intersections": {
       "version": "1.5.0",
@@ -14864,8 +14797,7 @@
       "version": "6.4.0",
       "resolved": "https://registry.npmjs.org/tabbable/-/tabbable-6.4.0.tgz",
       "integrity": "sha512-05PUHKSNE8ou2dwIxTngl4EzcnsCDZGJ/iCLtDflR/SHB/ny14rXc+qU5P4mG9JkusiV7EivzY9Mhm55AzAvCg==",
-      "license": "MIT",
-      "peer": true
+      "license": "MIT"
     },
     "node_modules/tailwind-merge": {
       "version": "3.2.0",
@@ -14882,6 +14814,7 @@
       "resolved": "https://registry.npmjs.org/tailwindcss/-/tailwindcss-3.4.17.tgz",
       "integrity": "sha512-w33E2aCvSDP0tW9RZuNXadXlkHXqFzSkQew/aIa2i/Sj8fThxwovwlXHSPXTbAHwEIhBFXAedUhP2tueAKP8Og==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@alloc/quick-lru": "^5.2.0",
         "arg": "^5.0.2",
@@ -15041,7 +14974,6 @@
       "resolved": "https://registry.npmjs.org/timezone-groups/-/timezone-groups-0.10.4.tgz",
       "integrity": "sha512-AnkJYrbb7uPkDCEqGeVJiawZNiwVlSkkeX4jZg1gTEguClhyX+/Ezn07KB6DT29tG3UN418ldmS/W6KqGOTDjg==",
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=18.12.0"
       }
@@ -15050,8 +14982,7 @@
       "version": "1.0.3",
       "resolved": "https://registry.npmjs.org/tiny-inflate/-/tiny-inflate-1.0.3.tgz",
       "integrity": "sha512-pkY1fj1cKHb2seWDy0B16HeWyczlJA9/WW3u3c4z/NiWDsO3DOU5D7nhTLE9CF0yXv/QZFY7sEJmj24dK+Rrqw==",
-      "license": "MIT",
-      "peer": true
+      "license": "MIT"
     },
     "node_modules/tiny-invariant": {
       "version": "1.3.3",
@@ -15111,6 +15042,7 @@
       "integrity": "sha512-QP88BAKvMam/3NxH6vj2o21R6MjxZUAd6nlwAS/pnGvN9IVLocLHxGYIzFhg6fUQ+5th6P4dv4eW9jX3DSIj7A==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=12"
       },
@@ -15303,7 +15235,6 @@
       "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-4.41.0.tgz",
       "integrity": "sha512-TeTSQ6H5YHvpqVwBRcnLDCBnDOHWYu7IvGbHT6N8AOymcr9PJGjc1GTtiWZTYg0NCgYwvnYWEkVChQAr9bjfwA==",
       "license": "(MIT OR CC0-1.0)",
-      "peer": true,
       "engines": {
         "node": ">=16"
       },
@@ -15332,6 +15263,7 @@
       "integrity": "sha512-p1diW6TqL9L07nNxvRMM7hMMw4c5XOo/1ibL4aAIGmSAt9slTE1Xgw5KWuof2uTOvCg9BY7ZRi+GaF+7sfgPeQ==",
       "dev": true,
       "license": "Apache-2.0",
+      "peer": true,
       "bin": {
         "tsc": "bin/tsc",
         "tsserver": "bin/tsserver"
@@ -15389,7 +15321,6 @@
       "resolved": "https://registry.npmjs.org/unicode-properties/-/unicode-properties-1.4.1.tgz",
       "integrity": "sha512-CLjCCLQ6UuMxWnbIylkisbRj31qxHPAurvena/0iwSVbQ2G1VY5/HjV0IRabOEbDHlzZlRdCrD4NhB0JtU40Pg==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "base64-js": "^1.3.0",
         "unicode-trie": "^2.0.0"
@@ -15400,7 +15331,6 @@
       "resolved": "https://registry.npmjs.org/unicode-trie/-/unicode-trie-2.0.0.tgz",
       "integrity": "sha512-x7bc76x0bm4prf1VLg79uhAzKw8DVboClSN5VxJuQ+LKDOVEW9CdH+VY7SP+vX7xCYQqzzgQpFqz15zeLvAtZQ==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "pako": "^0.2.5",
         "tiny-inflate": "^1.0.0"
@@ -15410,8 +15340,7 @@
       "version": "0.2.9",
       "resolved": "https://registry.npmjs.org/pako/-/pako-0.2.9.tgz",
       "integrity": "sha512-NUcwaKxUxWrZLpDG+z/xZaCgQITkA/Dv4V/T6bw7VON6l1Xz/VnrBqrYjZQ12TamKHzITTfOEIYUj48y2KXImA==",
-      "license": "MIT",
-      "peer": true
+      "license": "MIT"
     },
     "node_modules/unicorn-magic": {
       "version": "0.1.0",
@@ -15601,6 +15530,7 @@
       "integrity": "sha512-2N/55r4JDJ4gdrCvGgINMy+HH3iRpNIz8K6SFwVsA+JbQScLiC+clmAxBgwiSPgcG9U15QmvqCGWzMbqda5zGQ==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "esbuild": "^0.25.0",
         "fdir": "^6.4.4",
@@ -15714,6 +15644,7 @@
       "integrity": "sha512-QP88BAKvMam/3NxH6vj2o21R6MjxZUAd6nlwAS/pnGvN9IVLocLHxGYIzFhg6fUQ+5th6P4dv4eW9jX3DSIj7A==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=12"
       },
@@ -15727,6 +15658,7 @@
       "integrity": "sha512-188iM4hAHQ0km23TN/adso1q5hhwKqUpv+Sd6p5sOuh6FhQnRNW3IsiIpvxqahtBabsJ2SLZgmGSpcYK4wQYJw==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@vitest/expect": "3.1.3",
         "@vitest/mocker": "3.1.3",
@@ -16072,7 +16004,6 @@
       "resolved": "https://registry.npmjs.org/xmldoc/-/xmldoc-2.0.3.tgz",
       "integrity": "sha512-6gRk4NY/Jvg67xn7OzJuxLRsGgiXBaPUQplVJ/9l99uIugxh4FTOewYz5ic8WScj7Xx/2WvhENiQKwkK9RpE4w==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "sax": "^1.4.3"
       },
@@ -16085,7 +16016,6 @@
       "resolved": "https://registry.npmjs.org/xss/-/xss-1.0.13.tgz",
       "integrity": "sha512-clu7dxTm1e8Mo5fz3n/oW3UCXBfV89xZ72jM8yzo1vR/pIS0w3sgB3XV2H8Vm6zfGnHL0FzvLJPJEBhd86/z4Q==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "commander": "^2.20.3",
         "cssfilter": "0.0.10"
@@ -16101,8 +16031,7 @@
       "version": "2.20.3",
       "resolved": "https://registry.npmjs.org/commander/-/commander-2.20.3.tgz",
       "integrity": "sha512-GpVkmM8vF2vQUkj2LvZmD35JxeJOLCwJ9cUkugyk2nuhbv3+mJvpLYYt+0+USMxE+oj+ey/lJEnhZw75x/OMcQ==",
-      "license": "MIT",
-      "peer": true
+      "license": "MIT"
     },
     "node_modules/y18n": {
       "version": "5.0.8",

--- a/src/components/nodes/NodeDetailContent.tsx
+++ b/src/components/nodes/NodeDetailContent.tsx
@@ -15,11 +15,13 @@ import { PercentGauge } from '@/components/nodes/PercentGauge';
 import { Card, CardHeader, CardTitle, CardContent, CardDescription } from '@/components/ui/card';
 import { useState, useEffect, useMemo } from 'react';
 import { Button } from '@/components/ui/button';
-import { CheckCircle, Clock, Copy } from 'lucide-react';
+import { CheckCircle, Clock, Copy, Settings } from 'lucide-react';
 import { Badge } from '@/components/ui/badge';
 import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from '@/components/ui/select';
 import { authService } from '@/lib/auth/authService';
 import { getRoleLabel } from '@/lib/meshtastic';
+import type { EnvironmentExposureSlug, WeatherUseSlug } from '@/lib/models';
+import { NodeEnvironmentSettingsDialog } from '@/components/nodes/NodeEnvironmentSettingsDialog';
 
 interface NodeDetailContentProps {
   nodeId: number;
@@ -111,6 +113,7 @@ function TracerouteLinksSection({ nodeId }: { nodeId: number }) {
 export function NodeDetailContent({ nodeId, compact = false }: NodeDetailContentProps) {
   const node = useNodeSuspense(nodeId);
   const { recentNodes, addRecentNode } = useRecentNodes();
+  const [settingsOpen, setSettingsOpen] = useState(false);
 
   const handleCopyToClipboard = (text: string) => {
     navigator.clipboard.writeText(text);
@@ -177,14 +180,36 @@ export function NodeDetailContent({ nodeId, compact = false }: NodeDetailContent
             </div>
           )}
         </div>
-        {(!node.owner || hasPendingClaim) && (
-          <Link
-            to={`/nodes/${nodeId}/claim`}
-            className="px-4 py-2 bg-teal-600 dark:bg-teal-500 text-white rounded-md hover:bg-teal-700 dark:hover:bg-teal-600 transition-colors text-sm whitespace-nowrap"
-          >
-            {hasPendingClaim ? 'View Claim' : 'Claim Node'}
-          </Link>
-        )}
+        <div className="flex flex-shrink-0 items-start gap-2">
+          {node.environment_settings_editable && (
+            <>
+              <Button
+                type="button"
+                variant="outline"
+                size="icon"
+                aria-label="Node settings"
+                onClick={() => setSettingsOpen(true)}
+              >
+                <Settings className="h-4 w-4" />
+              </Button>
+              <NodeEnvironmentSettingsDialog
+                open={settingsOpen}
+                onOpenChange={setSettingsOpen}
+                nodeId={nodeId}
+                initialEnvironmentExposure={(node.environment_exposure ?? 'unknown') as EnvironmentExposureSlug}
+                initialWeatherUse={(node.weather_use ?? 'unknown') as WeatherUseSlug}
+              />
+            </>
+          )}
+          {(!node.owner || hasPendingClaim) && (
+            <Link
+              to={`/nodes/${nodeId}/claim`}
+              className="px-4 py-2 bg-teal-600 dark:bg-teal-500 text-white rounded-md hover:bg-teal-700 dark:hover:bg-teal-600 transition-colors text-sm whitespace-nowrap"
+            >
+              {hasPendingClaim ? 'View Claim' : 'Claim Node'}
+            </Link>
+          )}
+        </div>
       </div>
 
       {!compact && recentNodes.length > 1 && (
@@ -226,6 +251,12 @@ export function NodeDetailContent({ nodeId, compact = false }: NodeDetailContent
                   <span className="font-medium">Role:</span> {roleLabel}
                 </p>
               )}
+              <p>
+                <span className="font-medium">Sensor placement:</span> {node.environment_exposure ?? '—'}
+              </p>
+              <p>
+                <span className="font-medium">Weather views:</span> {node.weather_use ?? '—'}
+              </p>
               {node.mac_addr && (
                 <p>
                   <span className="font-medium">MAC Address:</span> <span className="font-mono">{node.mac_addr}</span>

--- a/src/components/nodes/NodeDetailContent.tsx
+++ b/src/components/nodes/NodeDetailContent.tsx
@@ -251,12 +251,6 @@ export function NodeDetailContent({ nodeId, compact = false }: NodeDetailContent
                   <span className="font-medium">Role:</span> {roleLabel}
                 </p>
               )}
-              <p>
-                <span className="font-medium">Sensor placement:</span> {node.environment_exposure ?? '—'}
-              </p>
-              <p>
-                <span className="font-medium">Weather views:</span> {node.weather_use ?? '—'}
-              </p>
               {node.mac_addr && (
                 <p>
                   <span className="font-medium">MAC Address:</span> <span className="font-mono">{node.mac_addr}</span>
@@ -342,22 +336,36 @@ export function NodeDetailContent({ nodeId, compact = false }: NodeDetailContent
           </Card>
         )}
 
-        {node.latest_environment_metrics && (
+        {(node.latest_environment_metrics || node.environment_exposure != null || node.weather_use != null) && (
           <MetricsCard
             title="Environment Metrics"
-            reportedTime={node.latest_environment_metrics.reported_time}
+            reportedTime={node.latest_environment_metrics?.reported_time}
             metrics={[
-              { label: 'Temperature', value: node.latest_environment_metrics.temperature, unit: '°C' },
-              { label: 'Relative Humidity', value: node.latest_environment_metrics.relative_humidity, unit: '%' },
-              { label: 'Barometric Pressure', value: node.latest_environment_metrics.barometric_pressure, unit: 'hPa' },
-              { label: 'Gas Resistance', value: node.latest_environment_metrics.gas_resistance, unit: 'Ω' },
-              { label: 'IAQ', value: node.latest_environment_metrics.iaq },
-              { label: 'Lux', value: node.latest_environment_metrics.lux, unit: 'lx' },
-              { label: 'Wind Direction', value: node.latest_environment_metrics.wind_direction, unit: '°' },
-              { label: 'Wind Speed', value: node.latest_environment_metrics.wind_speed, unit: 'm/s' },
-              { label: 'Radiation', value: node.latest_environment_metrics.radiation },
-              { label: 'Rainfall 1h', value: node.latest_environment_metrics.rainfall_1h, unit: 'mm' },
-              { label: 'Rainfall 24h', value: node.latest_environment_metrics.rainfall_24h, unit: 'mm' },
+              { label: 'Sensor placement', value: node.environment_exposure },
+              { label: 'Use for weather', value: node.weather_use },
+              ...(node.latest_environment_metrics
+                ? [
+                    { label: 'Temperature', value: node.latest_environment_metrics.temperature, unit: '°C' },
+                    {
+                      label: 'Relative Humidity',
+                      value: node.latest_environment_metrics.relative_humidity,
+                      unit: '%',
+                    },
+                    {
+                      label: 'Barometric Pressure',
+                      value: node.latest_environment_metrics.barometric_pressure,
+                      unit: 'hPa',
+                    },
+                    { label: 'Gas Resistance', value: node.latest_environment_metrics.gas_resistance, unit: 'Ω' },
+                    { label: 'IAQ', value: node.latest_environment_metrics.iaq },
+                    { label: 'Lux', value: node.latest_environment_metrics.lux, unit: 'lx' },
+                    { label: 'Wind Direction', value: node.latest_environment_metrics.wind_direction, unit: '°' },
+                    { label: 'Wind Speed', value: node.latest_environment_metrics.wind_speed, unit: 'm/s' },
+                    { label: 'Radiation', value: node.latest_environment_metrics.radiation },
+                    { label: 'Rainfall 1h', value: node.latest_environment_metrics.rainfall_1h, unit: 'mm' },
+                    { label: 'Rainfall 24h', value: node.latest_environment_metrics.rainfall_24h, unit: 'mm' },
+                  ]
+                : []),
             ]}
           />
         )}

--- a/src/components/nodes/NodeEnvironmentSettingsDialog.tsx
+++ b/src/components/nodes/NodeEnvironmentSettingsDialog.tsx
@@ -1,0 +1,156 @@
+import { useEffect, useState } from 'react';
+import { useMutation, useQueryClient } from '@tanstack/react-query';
+import { toast } from 'sonner';
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
+} from '@/components/ui/dialog';
+import { Button } from '@/components/ui/button';
+import { Label } from '@/components/ui/label';
+import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from '@/components/ui/select';
+import { Card, CardDescription, CardHeader, CardTitle } from '@/components/ui/card';
+import { useMeshtasticApi } from '@/hooks/api/useApi';
+import type { EnvironmentExposureSlug, WeatherUseSlug } from '@/lib/models';
+
+const EXPOSURE_OPTIONS: EnvironmentExposureSlug[] = ['unknown', 'indoor', 'outdoor', 'sheltered'];
+const WEATHER_USE_OPTIONS: WeatherUseSlug[] = ['unknown', 'include', 'exclude'];
+
+function labelExposure(v: EnvironmentExposureSlug): string {
+  switch (v) {
+    case 'unknown':
+      return 'Unknown';
+    case 'indoor':
+      return 'Indoor';
+    case 'outdoor':
+      return 'Outdoor';
+    case 'sheltered':
+      return 'Sheltered (e.g. porch)';
+    default:
+      return v;
+  }
+}
+
+function labelWeatherUse(v: WeatherUseSlug): string {
+  switch (v) {
+    case 'unknown':
+      return 'Unknown';
+    case 'include':
+      return 'Include in weather views';
+    case 'exclude':
+      return 'Exclude from weather views';
+    default:
+      return v;
+  }
+}
+
+export interface NodeEnvironmentSettingsDialogProps {
+  open: boolean;
+  onOpenChange: (open: boolean) => void;
+  nodeId: number;
+  initialEnvironmentExposure: EnvironmentExposureSlug;
+  initialWeatherUse: WeatherUseSlug;
+}
+
+export function NodeEnvironmentSettingsDialog({
+  open,
+  onOpenChange,
+  nodeId,
+  initialEnvironmentExposure,
+  initialWeatherUse,
+}: NodeEnvironmentSettingsDialogProps) {
+  const api = useMeshtasticApi();
+  const queryClient = useQueryClient();
+  const [environmentExposure, setEnvironmentExposure] = useState<EnvironmentExposureSlug>(initialEnvironmentExposure);
+  const [weatherUse, setWeatherUse] = useState<WeatherUseSlug>(initialWeatherUse);
+
+  useEffect(() => {
+    if (open) {
+      setEnvironmentExposure(initialEnvironmentExposure);
+      setWeatherUse(initialWeatherUse);
+    }
+  }, [open, initialEnvironmentExposure, initialWeatherUse]);
+
+  const mutation = useMutation({
+    mutationFn: () =>
+      api.patchObservedNodeEnvironmentSettings(nodeId, {
+        environment_exposure: environmentExposure,
+        weather_use: weatherUse,
+      }),
+    onSuccess: () => {
+      void queryClient.invalidateQueries({ queryKey: ['nodes', nodeId] });
+      void queryClient.invalidateQueries({ queryKey: ['nodes', 'weather'] });
+      toast.success('Node settings saved');
+      onOpenChange(false);
+    },
+    onError: () => {
+      toast.error('Could not save settings. Check permissions or try again.');
+    },
+  });
+
+  return (
+    <Dialog open={open} onOpenChange={onOpenChange}>
+      <DialogContent className="sm:max-w-md">
+        <DialogHeader>
+          <DialogTitle>Node settings</DialogTitle>
+          <DialogDescription>
+            Environment placement and whether this node appears in weather-style views. Further options can be added
+            here later.
+          </DialogDescription>
+        </DialogHeader>
+        <div className="grid gap-4 py-2">
+          <div className="grid gap-2">
+            <Label htmlFor="node-env-exposure">Sensor placement</Label>
+            <Select
+              value={environmentExposure}
+              onValueChange={(v) => setEnvironmentExposure(v as EnvironmentExposureSlug)}
+            >
+              <SelectTrigger id="node-env-exposure">
+                <SelectValue />
+              </SelectTrigger>
+              <SelectContent>
+                {EXPOSURE_OPTIONS.map((opt) => (
+                  <SelectItem key={opt} value={opt}>
+                    {labelExposure(opt)}
+                  </SelectItem>
+                ))}
+              </SelectContent>
+            </Select>
+          </div>
+          <div className="grid gap-2">
+            <Label htmlFor="node-weather-use">Weather views</Label>
+            <Select value={weatherUse} onValueChange={(v) => setWeatherUse(v as WeatherUseSlug)}>
+              <SelectTrigger id="node-weather-use">
+                <SelectValue />
+              </SelectTrigger>
+              <SelectContent>
+                {WEATHER_USE_OPTIONS.map((opt) => (
+                  <SelectItem key={opt} value={opt}>
+                    {labelWeatherUse(opt)}
+                  </SelectItem>
+                ))}
+              </SelectContent>
+            </Select>
+          </div>
+          <Card className="border-dashed bg-muted/40">
+            <CardHeader className="py-3">
+              <CardTitle className="text-sm font-medium text-muted-foreground">More settings</CardTitle>
+              <CardDescription className="text-xs">Reserved for future node options.</CardDescription>
+            </CardHeader>
+          </Card>
+        </div>
+        <DialogFooter>
+          <Button type="button" variant="outline" onClick={() => onOpenChange(false)}>
+            Cancel
+          </Button>
+          <Button type="button" onClick={() => mutation.mutate()} disabled={mutation.isPending}>
+            {mutation.isPending ? 'Saving…' : 'Save'}
+          </Button>
+        </DialogFooter>
+      </DialogContent>
+    </Dialog>
+  );
+}

--- a/src/components/nodes/NodesAndConstellationsMap.tsx
+++ b/src/components/nodes/NodesAndConstellationsMap.tsx
@@ -59,6 +59,8 @@ export interface NodesAndConstellationsMapProps {
   getMarkerLabel?: (node: ObservedNode) => string;
   /** Optional opacity 0-1 for observed node markers (e.g. age-based fading) */
   getMarkerOpacity?: (node: ObservedNode) => number;
+  /** When set with getMarkerLabel, overrides role colour (e.g. weather age blend) */
+  getMarkerColor?: (node: ObservedNode) => string;
   /** Optional grayscale 0-1 for observed node markers (e.g. 24h = 100% gray) */
   getMarkerGrayscale?: (node: ObservedNode) => number;
 }
@@ -79,6 +81,7 @@ export function NodesAndConstellationsMap({
   selectedNodeId: selectedNodeIdProp,
   getMarkerLabel,
   getMarkerOpacity,
+  getMarkerColor,
   getMarkerGrayscale,
 }: NodesAndConstellationsMapProps) {
   const mapRef = useRef<HTMLDivElement>(null);
@@ -404,7 +407,9 @@ export function NodesAndConstellationsMap({
         : node.short_name || node.node_id_str?.toString().slice(-4) || '?';
       const opacity = getMarkerOpacity?.(node as ObservedNode);
       const grayscale = getMarkerGrayscale?.(node as ObservedNode);
-      const color = getRoleColor('role' in node ? node.role : undefined);
+      const color = getMarkerColor
+        ? getMarkerColor(node as ObservedNode)
+        : getRoleColor('role' in node ? node.role : undefined);
       const iconFn = getMarkerLabel ? createWeatherNodeIcon : createNodeIcon;
       const marker = L.marker(position, {
         icon: iconFn(label, color, isSelected, hasSelection && !isSelected, opacity, grayscale),
@@ -467,6 +472,7 @@ export function NodesAndConstellationsMap({
     handleMarkerClick,
     getMarkerLabel,
     getMarkerOpacity,
+    getMarkerColor,
     getMarkerGrayscale,
   ]);
 

--- a/src/components/nodes/WeatherMapAgeLegend.tsx
+++ b/src/components/nodes/WeatherMapAgeLegend.tsx
@@ -1,0 +1,28 @@
+import { WEATHER_MARKER_FRESH_HEX, WEATHER_MARKER_STALE_HEX } from './map-utils';
+
+export interface WeatherMapAgeLegendProps {
+  /** Must match `WeatherNodesMap` cutoff (hours until markers are hidden / fully gray). */
+  fadeHours?: number;
+}
+
+export function WeatherMapAgeLegend({ fadeHours = 24 }: WeatherMapAgeLegendProps) {
+  const label = `Marker colour: fresh env reading on the left, fading to gray by ${fadeHours} hours on the right`;
+
+  return (
+    <div className="mb-3">
+      <div
+        className="h-2.5 w-full rounded-full border border-border/70 shadow-sm ring-1 ring-black/5 dark:ring-white/10"
+        style={{
+          background: `linear-gradient(to right, ${WEATHER_MARKER_FRESH_HEX}, ${WEATHER_MARKER_STALE_HEX})`,
+        }}
+        role="img"
+        aria-label={label}
+      />
+      <div className="mt-1.5 flex justify-between gap-2 text-xs text-muted-foreground">
+        <span>Fresh</span>
+        <span className="tabular-nums">{fadeHours}h</span>
+        <span>Stale</span>
+      </div>
+    </div>
+  );
+}

--- a/src/components/nodes/WeatherNodesMap.tsx
+++ b/src/components/nodes/WeatherNodesMap.tsx
@@ -2,6 +2,7 @@ import { useMemo } from 'react';
 import { subHours } from 'date-fns';
 import { ObservedNode } from '@/lib/models';
 import { NodesAndConstellationsMap } from './NodesAndConstellationsMap';
+import { weatherMarkerBackgroundColor, WEATHER_MARKER_STALE_COLOR } from './map-utils';
 import { LatestEnvironmentMetrics } from '@/lib/models';
 
 const MAP_CUTOFF_HOURS = 24;
@@ -41,8 +42,8 @@ export interface WeatherNodesMapProps {
 }
 
 /**
- * Map of weather nodes with temp/pressure/RH labels and age-based grayscale fading.
- * Nodes with env readings > cutoffHours ago are hidden.
+ * Map of weather nodes with temp labels and a fixed sky-blue pill that fades to slate gray
+ * as the env reading ages (linear over cutoffHours). Nodes older than cutoff are hidden.
  */
 export function WeatherNodesMap({ nodes, cutoffHours = MAP_CUTOFF_HOURS }: WeatherNodesMapProps) {
   const cutoff = useMemo(() => subHours(new Date(), cutoffHours), [cutoffHours]);
@@ -58,16 +59,13 @@ export function WeatherNodesMap({ nodes, cutoffHours = MAP_CUTOFF_HOURS }: Weath
 
   const getMarkerLabel = useMemo(() => (node: ObservedNode) => formatWeatherLabel(node.latest_environment_metrics), []);
 
-  const getMarkerGrayscale = useMemo(
+  const getMarkerColor = useMemo(
     () => (node: ObservedNode) => {
       const reported = getEnvironmentReportedTime(node);
-      if (!reported) return 1;
-      const ageMs = Date.now() - reported.getTime();
-      const ageHours = ageMs / (1000 * 60 * 60);
-      if (ageHours >= MAP_CUTOFF_HOURS) return 1;
-      return ageHours / MAP_CUTOFF_HOURS;
+      if (!reported) return WEATHER_MARKER_STALE_COLOR;
+      return weatherMarkerBackgroundColor(reported, cutoffHours);
     },
-    []
+    [cutoffHours]
   );
 
   return (
@@ -80,7 +78,7 @@ export function WeatherNodesMap({ nodes, cutoffHours = MAP_CUTOFF_HOURS }: Weath
       drawPositionUncertainty={false}
       enableBubbles={true}
       getMarkerLabel={getMarkerLabel}
-      getMarkerGrayscale={getMarkerGrayscale}
+      getMarkerColor={getMarkerColor}
     />
   );
 }

--- a/src/components/nodes/map-utils.ts
+++ b/src/components/nodes/map-utils.ts
@@ -16,6 +16,34 @@ export function getRoleColor(role: number | null | undefined): string {
   return role != null && ROLE_COLORS[role] ? ROLE_COLORS[role] : DEFAULT_ROLE_COLOR;
 }
 
+/** Fresh weather marker fill (sky). Fades toward stale slate over `fadeHours`. */
+export const WEATHER_MARKER_FRESH_HEX = '#0ea5e9';
+export const WEATHER_MARKER_STALE_HEX = '#94a3b8';
+
+const WEATHER_MARKER_FRESH_RGB = { r: 14, g: 165, b: 233 }; // sync with WEATHER_MARKER_FRESH_HEX
+const WEATHER_MARKER_STALE_RGB = { r: 148, g: 163, b: 184 }; // sync with WEATHER_MARKER_STALE_HEX
+
+/** Pill colour when env time is missing (should not appear on map for long). */
+export const WEATHER_MARKER_STALE_COLOR = `rgb(${WEATHER_MARKER_STALE_RGB.r},${WEATHER_MARKER_STALE_RGB.g},${WEATHER_MARKER_STALE_RGB.b})`;
+
+/**
+ * Background color for a weather map pill by env reading age: full sky blue when fresh, slate gray at `fadeHours`.
+ */
+export function weatherMarkerBackgroundColor(
+  reportedTime: Date,
+  fadeHours: number,
+  nowMs: number = Date.now()
+): string {
+  const ageMs = Math.max(0, nowMs - reportedTime.getTime());
+  const t = Math.min(1, ageMs / (fadeHours * 60 * 60 * 1000));
+  const a = WEATHER_MARKER_FRESH_RGB;
+  const b = WEATHER_MARKER_STALE_RGB;
+  const r = Math.round(a.r + (b.r - a.r) * t);
+  const g = Math.round(a.g + (b.g - a.g) * t);
+  const bl = Math.round(a.b + (b.b - a.b) * t);
+  return `rgb(${r},${g},${bl})`;
+}
+
 /** Minimal node fields for popup content */
 export interface NodePopupData {
   node_id: number;

--- a/src/hooks/api/useNodes.ts
+++ b/src/hooks/api/useNodes.ts
@@ -370,6 +370,8 @@ export function useInfrastructureNodesSuspense(options?: UseInfrastructureNodesO
 export interface UseWeatherNodesOptions {
   pageSize?: number;
   environmentReportedAfter?: Date;
+  weatherUse?: string[];
+  environmentExposure?: string[];
 }
 
 /**
@@ -381,15 +383,19 @@ export function useWeatherNodesSuspense(options?: UseWeatherNodesOptions) {
   const environmentReportedAfterKey = options?.environmentReportedAfter
     ? roundToFiveMinutes(options.environmentReportedAfter)
     : null;
+  const weatherUseKey = [...(options?.weatherUse ?? [])].sort().join(',') || 'all';
+  const environmentExposureKey = [...(options?.environmentExposure ?? [])].sort().join(',') || 'all';
 
   const nodesQuery = useSuspenseInfiniteQuery<PaginatedResponse<ObservedNode>, Error>({
     refetchInterval: 1000 * 60, // 1 minute
-    queryKey: ['nodes', 'weather', pageSize, environmentReportedAfterKey],
+    queryKey: ['nodes', 'weather', pageSize, environmentReportedAfterKey, weatherUseKey, environmentExposureKey],
     queryFn: async ({ pageParam = 1 }) =>
       api.getWeatherNodes({
         page: pageParam as number,
         pageSize,
         environmentReportedAfter: options?.environmentReportedAfter,
+        weatherUse: options?.weatherUse,
+        environmentExposure: options?.environmentExposure,
       }),
     initialPageParam: 1,
     getNextPageParam: (lastPage, allPages) => (lastPage.next ? allPages.length + 1 : undefined),

--- a/src/lib/api/meshtastic-api.ts
+++ b/src/lib/api/meshtastic-api.ts
@@ -123,6 +123,9 @@ export class MeshtasticApi extends BaseApi {
     environmentReportedAfter?: Date;
     page?: number;
     pageSize?: number;
+    /** Repeat query param; typical default for maps: include + unknown */
+    weatherUse?: string[];
+    environmentExposure?: string[];
   }): Promise<PaginatedResponse<ObservedNode>> {
     const searchParams = new URLSearchParams();
     if (params?.page) searchParams.append('page', params.page.toString());
@@ -130,12 +133,29 @@ export class MeshtasticApi extends BaseApi {
     if (params?.environmentReportedAfter) {
       searchParams.append('environment_reported_after', params.environmentReportedAfter.toISOString());
     }
+    for (const w of params?.weatherUse ?? []) {
+      searchParams.append('weather_use', w);
+    }
+    for (const e of params?.environmentExposure ?? []) {
+      searchParams.append('environment_exposure', e);
+    }
 
     const response = await this.get<PaginatedResponse<ObservedNode>>('/nodes/observed-nodes/weather/', searchParams);
     return {
       ...response,
       results: response.results.map((node) => parseObservedNodeFromAPI(node)),
     };
+  }
+
+  /**
+   * Update environment exposure / weather_use (staff or claim owner only).
+   */
+  async patchObservedNodeEnvironmentSettings(
+    nodeId: number,
+    body: { environment_exposure?: string; weather_use?: string }
+  ): Promise<ObservedNode> {
+    const node = await this.patch<ObservedNode>(`/nodes/observed-nodes/${nodeId}/environment-settings/`, body);
+    return parseObservedNodeFromAPI(node);
   }
 
   /**

--- a/src/lib/models.ts
+++ b/src/lib/models.ts
@@ -16,6 +16,12 @@ export interface ObservedNodeClaimEmbedded {
   accepted_at: string | null;
 }
 
+/** API slugs for ObservedNode.environment_exposure */
+export type EnvironmentExposureSlug = 'unknown' | 'indoor' | 'outdoor' | 'sheltered';
+
+/** API slugs for ObservedNode.weather_use */
+export type WeatherUseSlug = 'unknown' | 'include' | 'exclude';
+
 // ObservedNode from Meshflow API v2
 export interface ObservedNode {
   internal_id: number;
@@ -30,6 +36,10 @@ export interface ObservedNode {
   is_licensed?: boolean | null;
   is_unmessagable?: boolean | null;
   inferred_max_hops?: number | null;
+  environment_exposure?: EnvironmentExposureSlug;
+  weather_use?: WeatherUseSlug;
+  /** True when the current user may PATCH environment-settings (staff or claim owner). */
+  environment_settings_editable?: boolean;
   // Additional fields for UI compatibility
   last_heard?: Date | null;
   latest_device_metrics?: DeviceMetrics | null;

--- a/src/pages/Weather.tsx
+++ b/src/pages/Weather.tsx
@@ -61,6 +61,7 @@ function WeatherContent() {
   const { nodes, totalNodes, fetchNextPage, hasNextPage } = useWeatherNodesSuspense({
     environmentReportedAfter,
     pageSize: 100,
+    weatherUse: ['include', 'unknown'],
   });
 
   const { metricsMap } = useMultiNodeEnvironmentMetricsSuspense(nodes, chartDateRange);

--- a/src/pages/Weather.tsx
+++ b/src/pages/Weather.tsx
@@ -3,6 +3,7 @@ import { subHours } from 'date-fns';
 import { useWeatherNodesSuspense } from '@/hooks/api/useNodes';
 import { useMultiNodeEnvironmentMetricsSuspense } from '@/hooks/api/useMultiNodeEnvironmentMetrics';
 import { WeatherNodeCard } from '@/components/nodes/WeatherNodeCard';
+import { WeatherMapAgeLegend } from '@/components/nodes/WeatherMapAgeLegend';
 import { WeatherNodesMap } from '@/components/nodes/WeatherNodesMap';
 import { TimeRangeSelect } from '@/components/TimeRangeSelect';
 import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from '@/components/ui/select';
@@ -17,6 +18,9 @@ const CHART_TIME_RANGE_OPTIONS = [
 ];
 
 type EnvCutoffRange = '2h' | '6h' | '12h' | '24h';
+
+/** Map legend and marker fade/hide window (hours). */
+const WEATHER_MAP_ENV_AGE_HOURS = 24;
 
 const ENV_CUTOFF_OPTIONS: { value: EnvCutoffRange; label: string }[] = [
   { value: '2h', label: '2 hours' },
@@ -127,12 +131,14 @@ function WeatherContent() {
           <CardHeader>
             <CardTitle>Weather Node Locations</CardTitle>
             <p className="text-sm text-muted-foreground">
-              Nodes fade to gray based on reading age (24h ago = 100% gray). Nodes with readings &gt;24h ago are hidden.
+              Markers use a sky-blue tone when fresh and fade to gray as the reading ages (linear over 24h). Older
+              readings are hidden.
             </p>
           </CardHeader>
           <CardContent>
+            <WeatherMapAgeLegend fadeHours={WEATHER_MAP_ENV_AGE_HOURS} />
             <div className="h-[600px] w-full">
-              <WeatherNodesMap nodes={nodes} cutoffHours={24} />
+              <WeatherNodesMap nodes={nodes} cutoffHours={WEATHER_MAP_ENV_AGE_HOURS} />
             </div>
           </CardContent>
         </Card>


### PR DESCRIPTION
# Summary

Weather-focused UI and node environment controls, backed by meshflow-api.

- Weather page with node list, charts, and map (sky-blue markers that fade to slate by reading age over 24h; gradient legend above map)
- Observed node environment settings dialog (staff / claim owner)
- Sensor placement and weather-use fields grouped under Environment Metrics on node details
- API client hooks and types for weather nodes and `PATCH` environment settings

**Related API PR:** [meshflow-api#143](https://github.com/pskillen/meshflow-api/pull/143) — merge before or with this branch.

Closes #131

## Testing performed

- `npm test` (Vitest)
- `npm run lint` (warnings only, pre-existing)
- Manual check of Weather page and node detail flows in dev
