### PR TITLE
fix(traceroutes): toast when monitor source has no recent ingestion

### DIFF
--- a/src/pages/traceroutes/TracerouteHistory.tsx
+++ b/src/pages/traceroutes/TracerouteHistory.tsx
@@ -34,6 +34,9 @@ function getTracerouteErrorMessage(error: unknown): string {
     if (detail.toLowerCase().includes('allow_auto_traceroute')) {
       return "This node doesn't allow traceroutes. Enable it in the node settings.";
     }
+    if (detail.toLowerCase().includes('no recent packet ingestion')) {
+      return 'That source is not reporting packets right now (monitor offline or quiet). Pick another source or wait for the bot to ingest again.';
+    }
     return detail;
   }
   return err.message ?? (error instanceof Error ? error.message : 'Failed to trigger traceroute. Please try again.');


### PR DESCRIPTION
## Summary

Depends on **meshflow-api** PR that filters `triggerable-nodes` / `can_trigger` by recent packet ingestion (same rule as auto TR). The Traceroute page already uses those endpoints for the source dropdown and Trigger buttons, so **offline sources disappear** once the API ships.

This PR adds a **shorter toast** when the API returns **400** with “no recent packet ingestion” (e.g. stale tab or direct API use).

**API PR:** https://github.com/pskillen/meshflow-api/pull/145

## Testing

- `npx eslint src/pages/traceroutes/TracerouteHistory.tsx`
- `vitest run` (via pre-commit hook)

Fixes #129