### PR TITLE
feat(ui): Discord notifications (profile + connect OAuth)

### DIFF
--- a/src/hooks/api/useDiscordNotifications.ts
+++ b/src/hooks/api/useDiscordNotifications.ts
@@ -1,0 +1,34 @@
+import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query';
+import { useMeshtasticApi } from '@/hooks/api/useApi';
+
+export const discordNotificationPrefsQueryKey = ['auth', 'discord-notifications'] as const;
+
+export function useDiscordNotificationPrefs() {
+  const api = useMeshtasticApi();
+  return useQuery({
+    queryKey: discordNotificationPrefsQueryKey,
+    queryFn: () => api.getDiscordNotificationPrefs(),
+  });
+}
+
+export function usePatchDiscordNotificationPrefs() {
+  const api = useMeshtasticApi();
+  const queryClient = useQueryClient();
+  return useMutation({
+    mutationFn: () => api.patchDiscordNotificationPrefs(),
+    onSuccess: () => {
+      queryClient.invalidateQueries({ queryKey: discordNotificationPrefsQueryKey });
+    },
+  });
+}
+
+export function usePostDiscordNotificationTest() {
+  const api = useMeshtasticApi();
+  const queryClient = useQueryClient();
+  return useMutation({
+    mutationFn: () => api.postDiscordNotificationTest(),
+    onSuccess: () => {
+      queryClient.invalidateQueries({ queryKey: discordNotificationPrefsQueryKey });
+    },
+  });
+}

--- a/src/lib/api/meshtastic-api.ts
+++ b/src/lib/api/meshtastic-api.ts
@@ -21,6 +21,7 @@ import {
   NodeApiKey,
   CreateNodeApiKey,
   AutoTraceRoute,
+  DiscordNotificationPrefs,
 } from '../models';
 import {
   ApiConfig,
@@ -766,5 +767,22 @@ export class MeshtasticApi extends BaseApi {
       searchParams.append('triggered_at_after', params.triggered_at_after);
     }
     return this.get(`/nodes/observed-nodes/${nodeId}/traceroute-links/`, searchParams);
+  }
+
+  // ===== Discord notification prefs (Mesh Monitoring phase 02) =====
+
+  /** GET /api/auth/discord/notifications/ */
+  async getDiscordNotificationPrefs(): Promise<DiscordNotificationPrefs> {
+    return this.get<DiscordNotificationPrefs>('/auth/discord/notifications/');
+  }
+
+  /** PATCH /api/auth/discord/notifications/ — re-sync from SocialAccount */
+  async patchDiscordNotificationPrefs(): Promise<DiscordNotificationPrefs> {
+    return this.patch<DiscordNotificationPrefs>('/auth/discord/notifications/', {});
+  }
+
+  /** POST /api/auth/discord/notifications/test/ */
+  async postDiscordNotificationTest(): Promise<{ detail: string }> {
+    return this.post<{ detail: string }>('/auth/discord/notifications/test/', {});
   }
 }

--- a/src/lib/auth/authService.ts
+++ b/src/lib/auth/authService.ts
@@ -441,6 +441,33 @@ export const authService = {
     return data.authorization_url;
   },
 
+  /**
+   * Authenticated: Discord OAuth URL to link Discord to the current Meshflow account
+   * (separate redirect URI from login). Requires Bearer JWT.
+   */
+  async getDiscordConnectAuthUrl(baseUrl: string): Promise<string> {
+    const accessToken = this.getAccessToken();
+    if (!accessToken) {
+      throw new Error('You must be signed in to link Discord');
+    }
+    const response = await fetch(`${baseUrl}/api/auth/social/discord/connect/`, {
+      method: 'GET',
+      headers: {
+        'Content-Type': 'application/json',
+        Accept: 'application/json',
+        Authorization: `Bearer ${accessToken}`,
+      },
+    });
+
+    if (!response.ok) {
+      const errText = await response.text();
+      throw new Error(errText || 'Failed to get Discord connect authorization URL');
+    }
+
+    const data = await response.json();
+    return data.authorization_url as string;
+  },
+
   // Update API config with current token
   updateApiConfig(config: ApiConfig): ApiConfig {
     const accessToken = this.getAccessToken();

--- a/src/lib/models.ts
+++ b/src/lib/models.ts
@@ -415,3 +415,9 @@ export interface CreateNodeApiKey {
   name: string;
   constellation: number;
 }
+
+/** GET/PATCH `/api/auth/discord/notifications/` (Mesh Monitoring phase 02) */
+export interface DiscordNotificationPrefs {
+  discord_linked: boolean;
+  discord_notify_verified: boolean;
+}

--- a/src/pages/user/DiscordNotificationsPanel.tsx
+++ b/src/pages/user/DiscordNotificationsPanel.tsx
@@ -1,0 +1,136 @@
+import { Card, CardContent, CardHeader, CardTitle, CardDescription } from '@/components/ui/card';
+import { Alert, AlertDescription, AlertTitle } from '@/components/ui/alert';
+import { Button } from '@/components/ui/button';
+import { Badge } from '@/components/ui/badge';
+import { Loader2, AlertCircle, Info, Bell } from 'lucide-react';
+import { useConfig } from '@/providers/ConfigProvider';
+import {
+  useDiscordNotificationPrefs,
+  usePatchDiscordNotificationPrefs,
+  usePostDiscordNotificationTest,
+} from '@/hooks/api/useDiscordNotifications';
+import { authService } from '@/lib/auth/authService';
+import { toast } from 'sonner';
+
+function discordPrefsErrorDetail(err: unknown): string {
+  if (typeof err === 'object' && err !== null && 'data' in err) {
+    const data = (err as { data?: { detail?: string } }).data;
+    if (data?.detail) return data.detail;
+  }
+  if (err instanceof Error) return err.message;
+  return 'Request failed';
+}
+
+export function DiscordNotificationsPanel() {
+  const config = useConfig();
+  const { data, isLoading, error, refetch } = useDiscordNotificationPrefs();
+  const patchPrefs = usePatchDiscordNotificationPrefs();
+  const testDm = usePostDiscordNotificationTest();
+
+  const linked = data?.discord_linked ?? false;
+  const verified = data?.discord_notify_verified ?? false;
+
+  const handleConnectDiscord = async () => {
+    try {
+      const url = await authService.getDiscordConnectAuthUrl(config.apis.meshBot.baseUrl);
+      window.location.href = url;
+    } catch (e) {
+      toast.error(e instanceof Error ? e.message : 'Could not start Discord linking');
+    }
+  };
+
+  const handleResync = () => {
+    patchPrefs.mutate(undefined, {
+      onSuccess: () => {
+        toast.success('Discord status refreshed');
+      },
+      onError: (e) => toast.error(discordPrefsErrorDetail(e)),
+    });
+  };
+
+  const handleTest = () => {
+    testDm.mutate(undefined, {
+      onSuccess: (res) => {
+        toast.success(res.detail === 'ok' ? 'Test DM sent' : res.detail);
+      },
+      onError: (e) => toast.error(discordPrefsErrorDetail(e)),
+    });
+  };
+
+  return (
+    <Card>
+      <CardHeader>
+        <CardTitle className="flex items-center gap-2">
+          <Bell className="h-5 w-5" />
+          Discord
+        </CardTitle>
+        <CardDescription>
+          Link your Discord account to Meshflow so we can send you direct messages (e.g. test ping below, or future
+          alerts). After linking, use &quot;Send test notification&quot; to confirm the bot can DM you.
+        </CardDescription>
+      </CardHeader>
+      <CardContent className="space-y-4">
+        {isLoading ? (
+          <div className="flex justify-center py-8">
+            <Loader2 className="h-8 w-8 animate-spin text-slate-500 dark:text-slate-400" />
+          </div>
+        ) : error ? (
+          <Alert variant="destructive">
+            <AlertCircle className="h-4 w-4" />
+            <AlertTitle>Could not load settings</AlertTitle>
+            <AlertDescription className="flex flex-col gap-2 sm:flex-row sm:items-center">
+              <span>{error instanceof Error ? error.message : 'Unknown error'}</span>
+              <Button type="button" variant="outline" size="sm" onClick={() => refetch()}>
+                Retry
+              </Button>
+            </AlertDescription>
+          </Alert>
+        ) : (
+          <>
+            <div className="grid gap-2 text-sm">
+              <div className="flex flex-wrap items-center gap-2">
+                <span className="text-muted-foreground">Discord account</span>
+                <Badge variant={linked ? 'default' : 'secondary'}>{linked ? 'Connected' : 'Not connected'}</Badge>
+              </div>
+              <div className="flex flex-wrap items-center gap-2">
+                <span className="text-muted-foreground">Alerts</span>
+                <Badge variant={verified ? 'default' : 'secondary'}>
+                  {verified ? 'Ready for alerts' : 'Not verified'}
+                </Badge>
+              </div>
+            </div>
+
+            {!linked && (
+              <Alert>
+                <Info className="h-4 w-4" />
+                <AlertTitle>Link Discord</AlertTitle>
+                <AlertDescription className="text-xs leading-relaxed">
+                  You&apos;ll sign in with Discord once to attach that account to your current Meshflow login (Google,
+                  GitHub, password, etc.). The redirect returns you to this profile with your session preserved.
+                </AlertDescription>
+              </Alert>
+            )}
+
+            <div className="flex flex-wrap gap-2">
+              <Button type="button" variant="default" onClick={() => void handleConnectDiscord()}>
+                {linked ? 'Change linked Discord' : 'Link Discord'}
+              </Button>
+              <Button type="button" variant="outline" disabled={patchPrefs.isPending} onClick={handleResync}>
+                {patchPrefs.isPending ? 'Refreshing…' : 'Refresh status'}
+              </Button>
+              <Button
+                type="button"
+                variant="secondary"
+                disabled={!verified || testDm.isPending}
+                onClick={handleTest}
+                title={verified ? 'Send a test DM via the Meshflow bot' : 'Link and verify Discord first (OAuth sync)'}
+              >
+                {testDm.isPending ? 'Sending…' : 'Send test notification'}
+              </Button>
+            </div>
+          </>
+        )}
+      </CardContent>
+    </Card>
+  );
+}

--- a/src/pages/user/NodeSettings.tsx
+++ b/src/pages/user/NodeSettings.tsx
@@ -6,7 +6,7 @@ import { useConstellationChannels } from '@/hooks/api/useConstellations';
 import { useMyManagedNodesSuspense, useMyClaimedNodesSuspense } from '@/hooks/api/useNodes';
 import { formatDistanceToNow } from 'date-fns';
 import { Badge } from '@/components/ui/badge';
-import { Loader2, AlertCircle, Info, Copy, Radio, HelpCircle, ChevronDown, KeyRound, Bell } from 'lucide-react';
+import { Loader2, AlertCircle, Info, Copy, Radio, HelpCircle, ChevronDown, KeyRound } from 'lucide-react';
 import { useConfig } from '@/providers/ConfigProvider';
 import { BotSetupInstructions } from '@/components/nodes/BotSetupInstructions';
 import { Alert, AlertDescription, AlertTitle } from '@/components/ui/alert';
@@ -27,138 +27,8 @@ import { ObservedNode, type MessageChannel, type OwnedManagedNode, type NodeApiK
 import { SetupManagedNode } from '@/components/nodes/SetupManagedNode';
 import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query';
 import { useMeshtasticApi } from '@/hooks/api/useApi';
-import {
-  useDiscordNotificationPrefs,
-  usePatchDiscordNotificationPrefs,
-  usePostDiscordNotificationTest,
-} from '@/hooks/api/useDiscordNotifications';
-import { authService } from '@/lib/auth/authService';
-import { toast } from 'sonner';
 import { cn } from '@/lib/utils';
 // TODO: Add QRCode support for API keys in the future
-
-function discordPrefsErrorDetail(err: unknown): string {
-  if (typeof err === 'object' && err !== null && 'data' in err) {
-    const data = (err as { data?: { detail?: string } }).data;
-    if (data?.detail) return data.detail;
-  }
-  if (err instanceof Error) return err.message;
-  return 'Request failed';
-}
-
-function DiscordNotificationsPanel() {
-  const config = useConfig();
-  const { data, isLoading, error, refetch } = useDiscordNotificationPrefs();
-  const patchPrefs = usePatchDiscordNotificationPrefs();
-  const testDm = usePostDiscordNotificationTest();
-
-  const linked = data?.discord_linked ?? false;
-  const verified = data?.discord_notify_verified ?? false;
-
-  const handleConnectDiscord = async () => {
-    try {
-      const url = await authService.getDiscordConnectAuthUrl(config.apis.meshBot.baseUrl);
-      window.location.href = url;
-    } catch (e) {
-      toast.error(e instanceof Error ? e.message : 'Could not start Discord linking');
-    }
-  };
-
-  const handleResync = () => {
-    patchPrefs.mutate(undefined, {
-      onSuccess: () => {
-        toast.success('Discord status refreshed');
-      },
-      onError: (e) => toast.error(discordPrefsErrorDetail(e)),
-    });
-  };
-
-  const handleTest = () => {
-    testDm.mutate(undefined, {
-      onSuccess: (res) => {
-        toast.success(res.detail === 'ok' ? 'Test DM sent' : res.detail);
-      },
-      onError: (e) => toast.error(discordPrefsErrorDetail(e)),
-    });
-  };
-
-  return (
-    <Card>
-      <CardHeader>
-        <CardTitle className="flex items-center gap-2">
-          <Bell className="h-5 w-5" />
-          Discord
-        </CardTitle>
-        <CardDescription>
-          Link your Discord account to Meshflow so we can send you direct messages (e.g. test ping below, or future
-          alerts). After linking, use &quot;Send test notification&quot; to confirm the bot can DM you.
-        </CardDescription>
-      </CardHeader>
-      <CardContent className="space-y-4">
-        {isLoading ? (
-          <div className="flex justify-center py-8">
-            <Loader2 className="h-8 w-8 animate-spin text-slate-500 dark:text-slate-400" />
-          </div>
-        ) : error ? (
-          <Alert variant="destructive">
-            <AlertCircle className="h-4 w-4" />
-            <AlertTitle>Could not load settings</AlertTitle>
-            <AlertDescription className="flex flex-col gap-2 sm:flex-row sm:items-center">
-              <span>{error instanceof Error ? error.message : 'Unknown error'}</span>
-              <Button type="button" variant="outline" size="sm" onClick={() => refetch()}>
-                Retry
-              </Button>
-            </AlertDescription>
-          </Alert>
-        ) : (
-          <>
-            <div className="grid gap-2 text-sm">
-              <div className="flex flex-wrap items-center gap-2">
-                <span className="text-muted-foreground">Discord account</span>
-                <Badge variant={linked ? 'default' : 'secondary'}>{linked ? 'Connected' : 'Not connected'}</Badge>
-              </div>
-              <div className="flex flex-wrap items-center gap-2">
-                <span className="text-muted-foreground">Alerts</span>
-                <Badge variant={verified ? 'default' : 'secondary'}>
-                  {verified ? 'Ready for alerts' : 'Not verified'}
-                </Badge>
-              </div>
-            </div>
-
-            {!linked && (
-              <Alert>
-                <Info className="h-4 w-4" />
-                <AlertTitle>Link Discord</AlertTitle>
-                <AlertDescription className="text-xs leading-relaxed">
-                  You&apos;ll sign in with Discord once to attach that account to your current Meshflow login (Google,
-                  GitHub, password, etc.). The redirect returns you here with your session preserved.
-                </AlertDescription>
-              </Alert>
-            )}
-
-            <div className="flex flex-wrap gap-2">
-              <Button type="button" variant="default" onClick={() => void handleConnectDiscord()}>
-                {linked ? 'Change linked Discord' : 'Link Discord'}
-              </Button>
-              <Button type="button" variant="outline" disabled={patchPrefs.isPending} onClick={handleResync}>
-                {patchPrefs.isPending ? 'Refreshing…' : 'Refresh status'}
-              </Button>
-              <Button
-                type="button"
-                variant="secondary"
-                disabled={!verified || testDm.isPending}
-                onClick={handleTest}
-                title={verified ? 'Send a test DM via the Meshflow bot' : 'Link and verify Discord first (OAuth sync)'}
-              >
-                {testDm.isPending ? 'Sending…' : 'Send test notification'}
-              </Button>
-            </div>
-          </>
-        )}
-      </CardContent>
-    </Card>
-  );
-}
 
 function NodeSettingsContent() {
   const api = useMeshtasticApi();
@@ -177,9 +47,7 @@ function NodeSettingsContent() {
   const cancelClaimMutation = useCancelNodeClaim();
   const [searchParams, setSearchParams] = useSearchParams();
   const tabParam = searchParams.get('tab');
-  const activeTab = ['nodes', 'pending-claims', 'managed', 'notifications'].includes(tabParam ?? '')
-    ? tabParam!
-    : 'nodes';
+  const activeTab = ['nodes', 'pending-claims', 'managed'].includes(tabParam ?? '') ? tabParam! : 'nodes';
 
   const handleTabChange = (value: string) => {
     const next = new URLSearchParams(searchParams);
@@ -227,10 +95,6 @@ function NodeSettingsContent() {
           <TabsTrigger value="nodes">My Nodes</TabsTrigger>
           <TabsTrigger value="pending-claims">Pending Claims</TabsTrigger>
           <TabsTrigger value="managed">Managed Nodes</TabsTrigger>
-          <TabsTrigger value="notifications" className="gap-1.5">
-            <Bell className="h-3.5 w-3.5" />
-            Notifications
-          </TabsTrigger>
         </TabsList>
 
         <TabsContent value="nodes">
@@ -289,10 +153,6 @@ function NodeSettingsContent() {
               )}
             </CardContent>
           </Card>
-        </TabsContent>
-
-        <TabsContent value="notifications">
-          <DiscordNotificationsPanel />
         </TabsContent>
 
         <TabsContent value="pending-claims">

--- a/src/pages/user/NodeSettings.tsx
+++ b/src/pages/user/NodeSettings.tsx
@@ -32,7 +32,7 @@ import {
   usePatchDiscordNotificationPrefs,
   usePostDiscordNotificationTest,
 } from '@/hooks/api/useDiscordNotifications';
-import { useAuth } from '@/providers/AuthProvider';
+import { authService } from '@/lib/auth/authService';
 import { toast } from 'sonner';
 import { cn } from '@/lib/utils';
 // TODO: Add QRCode support for API keys in the future
@@ -47,13 +47,22 @@ function discordPrefsErrorDetail(err: unknown): string {
 }
 
 function DiscordNotificationsPanel() {
-  const { loginWithDiscord } = useAuth();
+  const config = useConfig();
   const { data, isLoading, error, refetch } = useDiscordNotificationPrefs();
   const patchPrefs = usePatchDiscordNotificationPrefs();
   const testDm = usePostDiscordNotificationTest();
 
   const linked = data?.discord_linked ?? false;
   const verified = data?.discord_notify_verified ?? false;
+
+  const handleConnectDiscord = async () => {
+    try {
+      const url = await authService.getDiscordConnectAuthUrl(config.apis.meshBot.baseUrl);
+      window.location.href = url;
+    } catch (e) {
+      toast.error(e instanceof Error ? e.message : 'Could not start Discord linking');
+    }
+  };
 
   const handleResync = () => {
     patchPrefs.mutate(undefined, {
@@ -78,11 +87,11 @@ function DiscordNotificationsPanel() {
       <CardHeader>
         <CardTitle className="flex items-center gap-2">
           <Bell className="h-5 w-5" />
-          Discord notifications
+          Discord
         </CardTitle>
         <CardDescription>
-          Mesh Monitoring can send you a direct message on Discord when a watched node goes offline (once the backend
-          feature is enabled). Link Discord with the same account you use here, then send a test message to confirm.
+          Link your Discord account to Meshflow so we can send you direct messages (e.g. test ping below, or future
+          alerts). After linking, use &quot;Send test notification&quot; to confirm the bot can DM you.
         </CardDescription>
       </CardHeader>
       <CardContent className="space-y-4">
@@ -119,18 +128,17 @@ function DiscordNotificationsPanel() {
             {!linked && (
               <Alert>
                 <Info className="h-4 w-4" />
-                <AlertTitle>Connect Discord</AlertTitle>
+                <AlertTitle>Link Discord</AlertTitle>
                 <AlertDescription className="text-xs leading-relaxed">
-                  Use the same sign-in flow as &quot;Login with Discord&quot;. After you return, we refresh your link
-                  status here. If you use another sign-in method, connecting Discord may sign you in as your Discord
-                  identity—use the account you want for alerts.
+                  You&apos;ll sign in with Discord once to attach that account to your current Meshflow login (Google,
+                  GitHub, password, etc.). The redirect returns you here with your session preserved.
                 </AlertDescription>
               </Alert>
             )}
 
             <div className="flex flex-wrap gap-2">
-              <Button type="button" variant="default" onClick={() => void loginWithDiscord()}>
-                {linked ? 'Reconnect Discord' : 'Connect Discord'}
+              <Button type="button" variant="default" onClick={() => void handleConnectDiscord()}>
+                {linked ? 'Change linked Discord' : 'Link Discord'}
               </Button>
               <Button type="button" variant="outline" disabled={patchPrefs.isPending} onClick={handleResync}>
                 {patchPrefs.isPending ? 'Refreshing…' : 'Refresh status'}

--- a/src/pages/user/NodeSettings.tsx
+++ b/src/pages/user/NodeSettings.tsx
@@ -6,7 +6,7 @@ import { useConstellationChannels } from '@/hooks/api/useConstellations';
 import { useMyManagedNodesSuspense, useMyClaimedNodesSuspense } from '@/hooks/api/useNodes';
 import { formatDistanceToNow } from 'date-fns';
 import { Badge } from '@/components/ui/badge';
-import { Loader2, AlertCircle, Info, Copy, Radio, HelpCircle, ChevronDown, KeyRound } from 'lucide-react';
+import { Loader2, AlertCircle, Info, Copy, Radio, HelpCircle, ChevronDown, KeyRound, Bell } from 'lucide-react';
 import { useConfig } from '@/providers/ConfigProvider';
 import { BotSetupInstructions } from '@/components/nodes/BotSetupInstructions';
 import { Alert, AlertDescription, AlertTitle } from '@/components/ui/alert';
@@ -27,8 +27,130 @@ import { ObservedNode, type MessageChannel, type OwnedManagedNode, type NodeApiK
 import { SetupManagedNode } from '@/components/nodes/SetupManagedNode';
 import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query';
 import { useMeshtasticApi } from '@/hooks/api/useApi';
+import {
+  useDiscordNotificationPrefs,
+  usePatchDiscordNotificationPrefs,
+  usePostDiscordNotificationTest,
+} from '@/hooks/api/useDiscordNotifications';
+import { useAuth } from '@/providers/AuthProvider';
+import { toast } from 'sonner';
 import { cn } from '@/lib/utils';
 // TODO: Add QRCode support for API keys in the future
+
+function discordPrefsErrorDetail(err: unknown): string {
+  if (typeof err === 'object' && err !== null && 'data' in err) {
+    const data = (err as { data?: { detail?: string } }).data;
+    if (data?.detail) return data.detail;
+  }
+  if (err instanceof Error) return err.message;
+  return 'Request failed';
+}
+
+function DiscordNotificationsPanel() {
+  const { loginWithDiscord } = useAuth();
+  const { data, isLoading, error, refetch } = useDiscordNotificationPrefs();
+  const patchPrefs = usePatchDiscordNotificationPrefs();
+  const testDm = usePostDiscordNotificationTest();
+
+  const linked = data?.discord_linked ?? false;
+  const verified = data?.discord_notify_verified ?? false;
+
+  const handleResync = () => {
+    patchPrefs.mutate(undefined, {
+      onSuccess: () => {
+        toast.success('Discord status refreshed');
+      },
+      onError: (e) => toast.error(discordPrefsErrorDetail(e)),
+    });
+  };
+
+  const handleTest = () => {
+    testDm.mutate(undefined, {
+      onSuccess: (res) => {
+        toast.success(res.detail === 'ok' ? 'Test DM sent' : res.detail);
+      },
+      onError: (e) => toast.error(discordPrefsErrorDetail(e)),
+    });
+  };
+
+  return (
+    <Card>
+      <CardHeader>
+        <CardTitle className="flex items-center gap-2">
+          <Bell className="h-5 w-5" />
+          Discord notifications
+        </CardTitle>
+        <CardDescription>
+          Mesh Monitoring can send you a direct message on Discord when a watched node goes offline (once the backend
+          feature is enabled). Link Discord with the same account you use here, then send a test message to confirm.
+        </CardDescription>
+      </CardHeader>
+      <CardContent className="space-y-4">
+        {isLoading ? (
+          <div className="flex justify-center py-8">
+            <Loader2 className="h-8 w-8 animate-spin text-slate-500 dark:text-slate-400" />
+          </div>
+        ) : error ? (
+          <Alert variant="destructive">
+            <AlertCircle className="h-4 w-4" />
+            <AlertTitle>Could not load settings</AlertTitle>
+            <AlertDescription className="flex flex-col gap-2 sm:flex-row sm:items-center">
+              <span>{error instanceof Error ? error.message : 'Unknown error'}</span>
+              <Button type="button" variant="outline" size="sm" onClick={() => refetch()}>
+                Retry
+              </Button>
+            </AlertDescription>
+          </Alert>
+        ) : (
+          <>
+            <div className="grid gap-2 text-sm">
+              <div className="flex flex-wrap items-center gap-2">
+                <span className="text-muted-foreground">Discord account</span>
+                <Badge variant={linked ? 'default' : 'secondary'}>{linked ? 'Connected' : 'Not connected'}</Badge>
+              </div>
+              <div className="flex flex-wrap items-center gap-2">
+                <span className="text-muted-foreground">Alerts</span>
+                <Badge variant={verified ? 'default' : 'secondary'}>
+                  {verified ? 'Ready for alerts' : 'Not verified'}
+                </Badge>
+              </div>
+            </div>
+
+            {!linked && (
+              <Alert>
+                <Info className="h-4 w-4" />
+                <AlertTitle>Connect Discord</AlertTitle>
+                <AlertDescription className="text-xs leading-relaxed">
+                  Use the same sign-in flow as &quot;Login with Discord&quot;. After you return, we refresh your link
+                  status here. If you use another sign-in method, connecting Discord may sign you in as your Discord
+                  identity—use the account you want for alerts.
+                </AlertDescription>
+              </Alert>
+            )}
+
+            <div className="flex flex-wrap gap-2">
+              <Button type="button" variant="default" onClick={() => void loginWithDiscord()}>
+                {linked ? 'Reconnect Discord' : 'Connect Discord'}
+              </Button>
+              <Button type="button" variant="outline" disabled={patchPrefs.isPending} onClick={handleResync}>
+                {patchPrefs.isPending ? 'Refreshing…' : 'Refresh status'}
+              </Button>
+              <Button
+                type="button"
+                variant="secondary"
+                disabled={!verified || testDm.isPending}
+                onClick={handleTest}
+                title={verified ? 'Send a test DM via the Meshflow bot' : 'Link and verify Discord first (OAuth sync)'}
+              >
+                {testDm.isPending ? 'Sending…' : 'Send test notification'}
+              </Button>
+            </div>
+          </>
+        )}
+      </CardContent>
+    </Card>
+  );
+}
 
 function NodeSettingsContent() {
   const api = useMeshtasticApi();
@@ -47,7 +169,9 @@ function NodeSettingsContent() {
   const cancelClaimMutation = useCancelNodeClaim();
   const [searchParams, setSearchParams] = useSearchParams();
   const tabParam = searchParams.get('tab');
-  const activeTab = ['nodes', 'pending-claims', 'managed'].includes(tabParam ?? '') ? tabParam! : 'nodes';
+  const activeTab = ['nodes', 'pending-claims', 'managed', 'notifications'].includes(tabParam ?? '')
+    ? tabParam!
+    : 'nodes';
 
   const handleTabChange = (value: string) => {
     const next = new URLSearchParams(searchParams);
@@ -91,10 +215,14 @@ function NodeSettingsContent() {
       )}
 
       <Tabs value={activeTab} onValueChange={handleTabChange}>
-        <TabsList className="mb-4">
+        <TabsList className="mb-4 flex flex-wrap gap-1">
           <TabsTrigger value="nodes">My Nodes</TabsTrigger>
           <TabsTrigger value="pending-claims">Pending Claims</TabsTrigger>
           <TabsTrigger value="managed">Managed Nodes</TabsTrigger>
+          <TabsTrigger value="notifications" className="gap-1.5">
+            <Bell className="h-3.5 w-3.5" />
+            Notifications
+          </TabsTrigger>
         </TabsList>
 
         <TabsContent value="nodes">
@@ -153,6 +281,10 @@ function NodeSettingsContent() {
               )}
             </CardContent>
           </Card>
+        </TabsContent>
+
+        <TabsContent value="notifications">
+          <DiscordNotificationsPanel />
         </TabsContent>
 
         <TabsContent value="pending-claims">

--- a/src/pages/user/UserPage.tsx
+++ b/src/pages/user/UserPage.tsx
@@ -6,6 +6,7 @@ import { Button } from '@/components/ui/button';
 import { useToast } from '@/hooks/use-toast';
 import { authService } from '@/lib/auth/authService';
 import { useConfig } from '@/providers/ConfigProvider';
+import { DiscordNotificationsPanel } from '@/pages/user/DiscordNotificationsPanel';
 
 export function UserPage() {
   const { toast } = useToast();
@@ -149,6 +150,10 @@ export function UserPage() {
           </Button>
         </CardContent>
       </Card>
+
+      <div className="mb-6">
+        <DiscordNotificationsPanel />
+      </div>
 
       <Card>
         <CardHeader>

--- a/src/providers/AuthProvider.tsx
+++ b/src/providers/AuthProvider.tsx
@@ -1,9 +1,11 @@
 import React, { createContext, useContext, useEffect, useState } from 'react';
 import { useNavigate, useLocation } from 'react-router-dom';
+import { useQueryClient } from '@tanstack/react-query';
 import { authService, AuthProvider as AuthProviderType } from '@/lib/auth/authService';
 import { useConfig } from './ConfigProvider';
 import { eventService } from '@/lib/events/eventService';
 import { AuthEventType } from '@/lib/auth/authService';
+import { discordNotificationPrefsQueryKey } from '@/hooks/api/useDiscordNotifications';
 
 // Auth context interface
 interface AuthContextType {
@@ -36,6 +38,7 @@ export function AuthProvider({ children }: AuthProviderProps) {
   const config = useConfig();
   const navigate = useNavigate();
   const location = useLocation();
+  const queryClient = useQueryClient();
 
   // Proactive token refresh: check every 90s, refresh if expired within 5 min
   useEffect(() => {
@@ -273,7 +276,8 @@ export function AuthProvider({ children }: AuthProviderProps) {
       await authService.loginWithDiscord(config.apis.meshBot.baseUrl, code);
       setIsAuthenticated(authService.isAuthenticated());
       setAuthProvider(authService.getAuthProvider());
-      navigate('/');
+      await queryClient.invalidateQueries({ queryKey: discordNotificationPrefsQueryKey });
+      navigate('/user/nodes?tab=notifications');
     } catch (err) {
       setError(err instanceof Error ? err.message : 'Discord login failed');
       setIsAuthenticated(false);

--- a/src/providers/AuthProvider.tsx
+++ b/src/providers/AuthProvider.tsx
@@ -128,6 +128,23 @@ export function AuthProvider({ children }: AuthProviderProps) {
       // Handle /auth/callback (code+state) and /oauth/callback (token)
       if ((location.pathname === '/auth/callback' || location.pathname === '/oauth/callback') && location.search) {
         const params = new URLSearchParams(location.search);
+        const oauthError = params.get('error');
+        if (oauthError?.startsWith('discord_connect_')) {
+          const discordConnectMessages: Record<string, string> = {
+            discord_connect_account_in_use: 'That Discord account is already linked to another Meshflow user.',
+            discord_connect_invalid_state: 'This Discord link expired or was already used. Try connecting again.',
+            discord_connect_missing_params: 'Discord did not return a complete authorization. Try again.',
+            discord_connect_user_missing: 'Your Meshflow session could not be matched. Sign in again.',
+            discord_connect_disabled: 'Your account cannot link Discord right now.',
+            discord_connect_token_exchange: 'Could not complete Discord authorization. Try again.',
+            discord_connect_no_access_token: 'Could not complete Discord authorization. Try again.',
+            discord_connect_discord_profile: 'Could not read your Discord profile. Try again.',
+          };
+          setError(discordConnectMessages[oauthError] ?? `Discord linking failed (${oauthError}).`);
+          navigate('/user/nodes?tab=notifications', { replace: true });
+          setIsLoading(false);
+          return;
+        }
         const token = params.get('token');
         if (token) {
           try {
@@ -135,7 +152,8 @@ export function AuthProvider({ children }: AuthProviderProps) {
             authService.setAccessTokenOnly(token);
             setIsAuthenticated(authService.isAuthenticated());
             setAuthProvider(authService.getAuthProvider());
-            navigate('/');
+            await queryClient.invalidateQueries({ queryKey: discordNotificationPrefsQueryKey });
+            navigate('/user/nodes?tab=notifications');
           } catch (err) {
             setError(err instanceof Error ? err.message : 'OAuth token handling failed');
           } finally {

--- a/src/providers/AuthProvider.tsx
+++ b/src/providers/AuthProvider.tsx
@@ -141,7 +141,7 @@ export function AuthProvider({ children }: AuthProviderProps) {
             discord_connect_discord_profile: 'Could not read your Discord profile. Try again.',
           };
           setError(discordConnectMessages[oauthError] ?? `Discord linking failed (${oauthError}).`);
-          navigate('/user/nodes?tab=notifications', { replace: true });
+          navigate('/user', { replace: true });
           setIsLoading(false);
           return;
         }
@@ -153,7 +153,7 @@ export function AuthProvider({ children }: AuthProviderProps) {
             setIsAuthenticated(authService.isAuthenticated());
             setAuthProvider(authService.getAuthProvider());
             await queryClient.invalidateQueries({ queryKey: discordNotificationPrefsQueryKey });
-            navigate('/user/nodes?tab=notifications');
+            navigate('/user');
           } catch (err) {
             setError(err instanceof Error ? err.message : 'OAuth token handling failed');
           } finally {
@@ -295,7 +295,7 @@ export function AuthProvider({ children }: AuthProviderProps) {
       setIsAuthenticated(authService.isAuthenticated());
       setAuthProvider(authService.getAuthProvider());
       await queryClient.invalidateQueries({ queryKey: discordNotificationPrefsQueryKey });
-      navigate('/user/nodes?tab=notifications');
+      navigate('/user');
     } catch (err) {
       setError(err instanceof Error ? err.message : 'Discord login failed');
       setIsAuthenticated(false);


### PR DESCRIPTION
## Summary

- Discord notification prefs UI: link Discord via authenticated connect OAuth, refresh status, send test DM.
- `DiscordNotificationsPanel` on **User Profile** (`/user`); removed from Node Settings.
- OAuth redirects after Discord connect / Discord login go to `/user`.

Closes #139

Related: https://github.com/pskillen/meshflow-api/pull/150

## Testing performed

- `npm run build`, `npm test`
- Manual: profile layout and spacing between Account / Discord / Change password