### PR TITLE
feat(traceroutes): per-source stats on TR statistics (issue #136)

### DIFF
--- a/.cursor/skills/meshflow-git-workflow/SKILL.md
+++ b/.cursor/skills/meshflow-git-workflow/SKILL.md
@@ -39,13 +39,15 @@ When executing the plan:
 
 ## 2. Branch Naming
 
-Format: `{repo-prefix}-{issue-number}/{author}/{short-description}`
+Format: `{issue-repo-prefix}-{issue-number}/{author}/{short-description}`
 
-| Repo              | Prefix | Example                                |
-| ----------------- | ------ | -------------------------------------- |
-| meshflow-api      | `api`  | `api-456/paddy/fix-endpoint-bug`       |
-| meshtastic-bot    | `bot`  | `bot-123/paddy/add-traceroute-command` |
-| meshtastic-bot-ui | `ui`   | `ui-78/paddy/add-cool-new-page`        |
+**Which prefix?** Use the prefix for the **GitHub repository where the tracking issue lives**, not the repo you are committing in. That keeps one issue number traceable across Meshflow repos.
+
+| Issue filed in    | Prefix | Use that prefix in every repo that has a branch for the work                                                        |
+| ----------------- | ------ | ------------------------------------------------------------------------------------------------------------------- |
+| meshtastic-bot-ui | `ui`   | e.g. UI #136 → `ui-136/paddy/...` in **both** meshtastic-bot-ui **and** meshflow-api (and meshtastic-bot if needed) |
+| meshflow-api      | `api`  | e.g. API #456 → `api-456/paddy/...` in every affected repo                                                          |
+| meshtastic-bot    | `bot`  | e.g. bot #123 → `bot-123/paddy/...` in every affected repo                                                          |
 
 Use kebab-case for the description. Keep it short.
 
@@ -129,7 +131,7 @@ When the work is done:
 | Step       | Action                                                                                        |
 | ---------- | --------------------------------------------------------------------------------------------- |
 | Plan       | Issue in relevant repo(s); parent in meshflow-api if multi-repo                               |
-| Branch     | `{prefix}-{num}/{author}/{description}`                                                       |
+| Branch     | `{issue-repo-prefix}-{num}/{author}/{description}` (prefix = repo where the issue lives)      |
 | Pre-commit | meshflow-api/meshtastic-bot: venv + black, isort, flake8; meshtastic-bot-ui: `npm run format` |
 | Commit     | Conventional commits, no "enhance"                                                            |
 | PR         | Open in all affected repos, link issues and related PRs                                       |

--- a/src/components/traceroutes/TracerouteStatsSection.tsx
+++ b/src/components/traceroutes/TracerouteStatsSection.tsx
@@ -1,9 +1,12 @@
 import { useMemo, useState } from 'react';
 import { subHours, subDays } from 'date-fns';
-import { Cell, Legend, Line, LineChart, Pie, PieChart, XAxis, YAxis, Tooltip } from 'recharts';
-import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card';
+import { Cell, Legend, Line, LineChart, Pie, PieChart, XAxis, YAxis, Tooltip as RechartsTooltip } from 'recharts';
+import { Card, CardContent, CardDescription, CardHeader, CardTitle } from '@/components/ui/card';
 import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from '@/components/ui/select';
 import { ChartConfig, ChartContainer, ChartTooltipContent } from '@/components/ui/chart';
+import { Table, TableBody, TableCell, TableHead, TableHeader, TableRow } from '@/components/ui/table';
+import { Tooltip, TooltipContent, TooltipProvider, TooltipTrigger } from '@/components/ui/tooltip';
+import { HelpCircle } from 'lucide-react';
 import { useTracerouteStats } from '@/hooks/api/useTraceroutes';
 
 const TR_STATS_TIMEFRAME_OPTIONS = [
@@ -119,7 +122,7 @@ export function TracerouteStatsSection() {
                       <Cell key={idx} fill={entry.fill} />
                     ))}
                   </Pie>
-                  <Tooltip content={<ChartTooltipContent formatter={(v) => [v, '']} />} />
+                  <RechartsTooltip content={<ChartTooltipContent formatter={(v) => [v, '']} />} />
                 </PieChart>
               </ChartContainer>
             ) : (
@@ -154,7 +157,7 @@ export function TracerouteStatsSection() {
                       <Cell key={idx} fill={entry.fill} />
                     ))}
                   </Pie>
-                  <Tooltip content={<ChartTooltipContent formatter={(v) => [v, '']} />} />
+                  <RechartsTooltip content={<ChartTooltipContent formatter={(v) => [v, '']} />} />
                 </PieChart>
               </ChartContainer>
             ) : (
@@ -211,7 +214,7 @@ export function TracerouteStatsSection() {
                     tick={{ fontSize: 10 }}
                   />
                   <YAxis tickLine={false} axisLine={false} width={28} tick={{ fontSize: 10 }} />
-                  <Tooltip
+                  <RechartsTooltip
                     content={
                       <ChartTooltipContent
                         formatter={(v) => [v, '']}
@@ -237,6 +240,84 @@ export function TracerouteStatsSection() {
           </CardContent>
         </Card>
       </div>
+
+      <TooltipProvider>
+        <Card>
+          <CardHeader className="pb-2">
+            <CardTitle className="text-sm">By source node</CardTitle>
+            <CardDescription className="text-xs text-muted-foreground">
+              Managed nodes that initiated traceroutes in this period. Success rate uses only completed and failed runs;
+              pending and sent count toward Total only.
+            </CardDescription>
+          </CardHeader>
+          <CardContent>
+            {isLoading ? (
+              <div className="min-h-[120px] flex items-center justify-center text-muted-foreground text-sm">
+                Loading…
+              </div>
+            ) : data?.by_source?.length ? (
+              <div className="rounded-md border overflow-x-auto">
+                <Table>
+                  <TableHeader>
+                    <TableRow>
+                      <TableHead>Source</TableHead>
+                      <TableHead className="text-right tabular-nums">Total</TableHead>
+                      <TableHead className="text-right tabular-nums">Completed</TableHead>
+                      <TableHead className="text-right tabular-nums">Failed</TableHead>
+                      <TableHead className="text-right">
+                        <span className="inline-flex items-center justify-end gap-1">
+                          Success rate
+                          <Tooltip>
+                            <TooltipTrigger asChild>
+                              <button
+                                type="button"
+                                className="text-muted-foreground hover:text-foreground inline-flex"
+                                aria-label="Success rate definition"
+                              >
+                                <HelpCircle className="h-3.5 w-3.5" />
+                              </button>
+                            </TooltipTrigger>
+                            <TooltipContent className="max-w-xs text-left" side="top">
+                              Completed ÷ (completed + failed) for this period. If there are no finished runs, rate is
+                              shown as —.
+                            </TooltipContent>
+                          </Tooltip>
+                        </span>
+                      </TableHead>
+                    </TableRow>
+                  </TableHeader>
+                  <TableBody>
+                    {data.by_source.map((row) => (
+                      <TableRow key={row.managed_node_id}>
+                        <TableCell>
+                          <div className="flex flex-col gap-0.5 min-w-0">
+                            <span className="font-medium truncate" title={row.short_name}>
+                              {row.short_name}
+                            </span>
+                            <span className="text-xs text-muted-foreground font-mono truncate" title={row.node_id_str}>
+                              {row.node_id_str}
+                            </span>
+                          </div>
+                        </TableCell>
+                        <TableCell className="text-right tabular-nums">{row.total}</TableCell>
+                        <TableCell className="text-right tabular-nums">{row.completed}</TableCell>
+                        <TableCell className="text-right tabular-nums">{row.failed}</TableCell>
+                        <TableCell className="text-right tabular-nums">
+                          {row.success_rate != null ? `${(row.success_rate * 100).toFixed(0)}%` : '—'}
+                        </TableCell>
+                      </TableRow>
+                    ))}
+                  </TableBody>
+                </Table>
+              </div>
+            ) : (
+              <div className="min-h-[120px] flex items-center justify-center text-muted-foreground text-sm">
+                No data
+              </div>
+            )}
+          </CardContent>
+        </Card>
+      </TooltipProvider>
     </div>
   );
 }

--- a/src/lib/api/meshtastic-api.ts
+++ b/src/lib/api/meshtastic-api.ts
@@ -666,12 +666,23 @@ export class MeshtasticApi extends BaseApi {
   }
 
   /**
-   * Get traceroute statistics (sources, success/failure, top routers, success over time)
+   * Get traceroute statistics (sources, success/failure, top routers, by source, success over time)
    */
   async getTracerouteStats(params?: { triggered_at_after?: string }): Promise<{
     sources: Array<{ trigger_type: string; count: number }>;
     success_failure: Array<{ status: string; count: number }>;
     top_routers: Array<{ node_id: number; node_id_str: string; short_name: string; count: number }>;
+    by_source: Array<{
+      managed_node_id: string;
+      node_id: number;
+      node_id_str: string;
+      name: string;
+      short_name: string;
+      total: number;
+      completed: number;
+      failed: number;
+      success_rate: number | null;
+    }>;
     success_over_time: Array<{ date: string; completed: number; failed: number }>;
   }> {
     const searchParams = new URLSearchParams();


### PR DESCRIPTION
## Summary

Traceroute Statistics now includes a full-width **By source node** table (total, completed, failed, success rate) backed by the new `by_source` field from `GET /api/traceroutes/stats/`. Card description and header tooltip explain that success rate uses only completed and failed runs.

**Depends on API:** merge [pskillen/meshflow-api#153](https://github.com/pskillen/meshflow-api/pull/153) first (or deploy together).

Closes #136

## Testing performed

- `npm run build`
- Pre-commit (eslint, prettier, vitest)