### PR TITLE
feat(nodes): mesh monitoring watches (My Nodes + Infrastructure)

### DIFF
--- a/src/components/nodes/InfrastructureNodeCard.tsx
+++ b/src/components/nodes/InfrastructureNodeCard.tsx
@@ -1,6 +1,8 @@
 import { Link } from 'react-router-dom';
 import { formatDistanceToNow } from 'date-fns';
-import { DeviceMetrics, ObservedNode } from '@/lib/models';
+import { DeviceMetrics, ObservedNode, NodeWatch, PaginatedResponse } from '@/lib/models';
+import { MeshWatchControls } from '@/components/nodes/MeshWatchControls';
+import type { UseQueryResult } from '@tanstack/react-query';
 import { getRoleLabel } from '@/lib/meshtastic';
 import { Badge } from '@/components/ui/badge';
 import { NodeMiniChart } from '@/components/nodes/NodeMiniChart';
@@ -16,9 +18,20 @@ interface InfrastructureNodeCardProps {
   compareSelected?: boolean;
   /** Called when the compare checkbox is toggled. Receives (nodeId, newState). */
   onCompareToggle?: (nodeId: number, newState: boolean) => void;
+  /** Current user's watch for this node, if any */
+  watch?: NodeWatch;
+  /** From useNodeWatches — loading/error for watch list */
+  watchesQuery?: Pick<UseQueryResult<PaginatedResponse<NodeWatch>>, 'isLoading' | 'isError'>;
 }
 
-function InfrastructureNodeCardInner({ node, metrics, dateRange, onCompareToggle }: InfrastructureNodeCardProps) {
+function InfrastructureNodeCardInner({
+  node,
+  metrics,
+  dateRange,
+  onCompareToggle,
+  watch,
+  watchesQuery,
+}: InfrastructureNodeCardProps) {
   const roleLabel = getRoleLabel(node.role);
   const [compareSelected, setCompareSelected] = useState(false);
 
@@ -91,6 +104,18 @@ function InfrastructureNodeCardInner({ node, metrics, dateRange, onCompareToggle
         {metrics != null && metrics.length > 0 && dateRange && (
           <div className="mt-3 -mx-2">
             <NodeMiniChart metrics={metrics} dateRange={dateRange} />
+          </div>
+        )}
+        {watchesQuery != null && (
+          <div className="mt-4 pt-3 border-t border-slate-200 dark:border-slate-600">
+            <p className="text-xs font-medium text-muted-foreground mb-2">Mesh monitoring</p>
+            <MeshWatchControls
+              node={node}
+              watch={watch}
+              watchesQuery={watchesQuery}
+              idPrefix={`infra-card-${node.node_id}`}
+              compact
+            />
           </div>
         )}
       </div>

--- a/src/components/nodes/MeshWatchControls.tsx
+++ b/src/components/nodes/MeshWatchControls.tsx
@@ -1,3 +1,4 @@
+import { Loader2 } from 'lucide-react';
 import { Checkbox } from '@/components/ui/checkbox';
 import { Button } from '@/components/ui/button';
 import { Badge } from '@/components/ui/badge';
@@ -84,7 +85,14 @@ export function MeshWatchControls({ node, watch, watchesQuery, idPrefix, compact
             })
           }
         >
-          Remove watch
+          {deleteWatch.isPending ? (
+            <>
+              <Loader2 className="mr-1.5 h-3.5 w-3.5 animate-spin" aria-hidden />
+              Removing…
+            </>
+          ) : (
+            'Remove watch'
+          )}
         </Button>
       </div>
     );
@@ -106,7 +114,14 @@ export function MeshWatchControls({ node, watch, watchesQuery, idPrefix, compact
         )
       }
     >
-      Add watch
+      {createWatch.isPending ? (
+        <>
+          <Loader2 className="mr-1.5 h-3.5 w-3.5 animate-spin" aria-hidden />
+          Adding…
+        </>
+      ) : (
+        'Add watch'
+      )}
     </Button>
   );
 }

--- a/src/components/nodes/MeshWatchControls.tsx
+++ b/src/components/nodes/MeshWatchControls.tsx
@@ -1,0 +1,112 @@
+import { Checkbox } from '@/components/ui/checkbox';
+import { Button } from '@/components/ui/button';
+import { Badge } from '@/components/ui/badge';
+import { toast } from 'sonner';
+import type { ObservedNode, NodeWatch, PaginatedResponse } from '@/lib/models';
+import {
+  useCreateNodeWatchMutation,
+  usePatchNodeWatchMutation,
+  useDeleteNodeWatchMutation,
+} from '@/hooks/api/useNodeWatches';
+import type { UseQueryResult } from '@tanstack/react-query';
+
+export interface MeshWatchControlsProps {
+  node: ObservedNode;
+  watch: NodeWatch | undefined;
+  watchesQuery: Pick<UseQueryResult<PaginatedResponse<NodeWatch>>, 'isLoading' | 'isError'>;
+  /** Unique prefix for checkbox ids (e.g. page + node id) */
+  idPrefix: string;
+  /** Slightly tighter spacing for cards */
+  compact?: boolean;
+}
+
+/**
+ * Add / enable / remove mesh monitoring watch for an observed node (My Nodes, Infrastructure, etc.).
+ */
+export function MeshWatchControls({ node, watch, watchesQuery, idPrefix, compact }: MeshWatchControlsProps) {
+  const createWatch = useCreateNodeWatchMutation();
+  const patchWatch = usePatchNodeWatchMutation();
+  const deleteWatch = useDeleteNodeWatchMutation();
+
+  const gapClass = compact ? 'gap-1.5' : 'gap-2';
+  const maxW = compact ? 'max-w-none' : 'max-w-[200px]';
+
+  if (watchesQuery.isLoading) {
+    return <span className="text-muted-foreground text-sm">…</span>;
+  }
+  if (watchesQuery.isError) {
+    return <span className="text-muted-foreground text-sm">—</span>;
+  }
+
+  if (watch) {
+    return (
+      <div className={`flex flex-col ${gapClass} ${maxW}`}>
+        <div className={`flex items-center ${gapClass}`}>
+          <Checkbox
+            id={`${idPrefix}-enabled`}
+            checked={watch.enabled}
+            disabled={patchWatch.isPending}
+            onCheckedChange={(checked) => {
+              if (checked === 'indeterminate') return;
+              patchWatch.mutate(
+                { id: watch.id, enabled: Boolean(checked) },
+                {
+                  onError: (e) => toast.error(e instanceof Error ? e.message : 'Could not update watch'),
+                }
+              );
+            }}
+          />
+          <label htmlFor={`${idPrefix}-enabled`} className="text-sm cursor-pointer">
+            Alerts on
+          </label>
+        </div>
+        <div className="flex flex-wrap gap-1">
+          {watch.observed_node.monitoring_verification_started_at && (
+            <Badge variant="secondary" className="text-xs">
+              Verifying
+            </Badge>
+          )}
+          {watch.observed_node.monitoring_offline_confirmed_at && (
+            <Badge variant="destructive" className="text-xs">
+              Offline
+            </Badge>
+          )}
+        </div>
+        <Button
+          type="button"
+          variant="ghost"
+          size="sm"
+          className={`h-7 px-2 text-xs text-muted-foreground ${compact ? 'self-start' : ''}`}
+          disabled={deleteWatch.isPending}
+          onClick={() =>
+            deleteWatch.mutate(watch.id, {
+              onError: (e) => toast.error(e instanceof Error ? e.message : 'Could not remove watch'),
+            })
+          }
+        >
+          Remove watch
+        </Button>
+      </div>
+    );
+  }
+
+  return (
+    <Button
+      type="button"
+      size="sm"
+      variant="outline"
+      className="text-xs"
+      disabled={createWatch.isPending}
+      onClick={() =>
+        createWatch.mutate(
+          { observed_node_id: String(node.internal_id), offline_after: 7200, enabled: true },
+          {
+            onError: (e) => toast.error(e instanceof Error ? e.message : 'Could not add watch'),
+          }
+        )
+      }
+    >
+      Add watch
+    </Button>
+  );
+}

--- a/src/hooks/api/useNodeWatches.ts
+++ b/src/hooks/api/useNodeWatches.ts
@@ -1,7 +1,40 @@
 import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query';
 import { useMeshtasticApi } from './useApi';
+import type { NodeWatch, PaginatedResponse } from '@/lib/models';
 
 const watchesKey = ['monitoring', 'watches'] as const;
+
+function mergeWatchIntoWatchesCache(
+  old: PaginatedResponse<NodeWatch> | undefined,
+  watch: NodeWatch
+): PaginatedResponse<NodeWatch> | undefined {
+  if (!old) return old;
+  const idx = old.results.findIndex((w) => w.id === watch.id);
+  if (idx >= 0) {
+    const next = [...old.results];
+    next[idx] = watch;
+    return { ...old, results: next };
+  }
+  return {
+    ...old,
+    count: old.count + 1,
+    results: [...old.results, watch],
+  };
+}
+
+function removeWatchFromWatchesCache(
+  old: PaginatedResponse<NodeWatch> | undefined,
+  id: number
+): PaginatedResponse<NodeWatch> | undefined {
+  if (!old) return old;
+  const filtered = old.results.filter((w) => w.id !== id);
+  if (filtered.length === old.results.length) return old;
+  return {
+    ...old,
+    count: Math.max(0, old.count - 1),
+    results: filtered,
+  };
+}
 
 export function useNodeWatches(pageSize = 500) {
   const api = useMeshtasticApi();
@@ -17,7 +50,10 @@ export function useCreateNodeWatchMutation() {
   return useMutation({
     mutationFn: (body: { observed_node_id: string; offline_after?: number; enabled?: boolean }) =>
       api.createNodeWatch(body),
-    onSuccess: () => {
+    onSuccess: (newWatch) => {
+      queryClient.setQueriesData<PaginatedResponse<NodeWatch>>({ queryKey: watchesKey }, (old) =>
+        mergeWatchIntoWatchesCache(old, newWatch)
+      );
       queryClient.invalidateQueries({ queryKey: watchesKey });
       queryClient.invalidateQueries({ queryKey: ['observed-nodes', 'mine'] });
     },
@@ -30,7 +66,10 @@ export function usePatchNodeWatchMutation() {
   return useMutation({
     mutationFn: ({ id, ...body }: { id: number; offline_after?: number; enabled?: boolean }) =>
       api.patchNodeWatch(id, body),
-    onSuccess: () => {
+    onSuccess: (updated) => {
+      queryClient.setQueriesData<PaginatedResponse<NodeWatch>>({ queryKey: watchesKey }, (old) =>
+        mergeWatchIntoWatchesCache(old, updated)
+      );
       queryClient.invalidateQueries({ queryKey: watchesKey });
       queryClient.invalidateQueries({ queryKey: ['observed-nodes', 'mine'] });
     },
@@ -42,7 +81,10 @@ export function useDeleteNodeWatchMutation() {
   const queryClient = useQueryClient();
   return useMutation({
     mutationFn: (id: number) => api.deleteNodeWatch(id),
-    onSuccess: () => {
+    onSuccess: (_, id) => {
+      queryClient.setQueriesData<PaginatedResponse<NodeWatch>>({ queryKey: watchesKey }, (old) =>
+        removeWatchFromWatchesCache(old, id)
+      );
       queryClient.invalidateQueries({ queryKey: watchesKey });
       queryClient.invalidateQueries({ queryKey: ['observed-nodes', 'mine'] });
     },

--- a/src/hooks/api/useNodeWatches.ts
+++ b/src/hooks/api/useNodeWatches.ts
@@ -1,0 +1,50 @@
+import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query';
+import { useMeshtasticApi } from './useApi';
+
+const watchesKey = ['monitoring', 'watches'] as const;
+
+export function useNodeWatches(pageSize = 500) {
+  const api = useMeshtasticApi();
+  return useQuery({
+    queryKey: [...watchesKey, pageSize],
+    queryFn: () => api.getNodeWatches({ page: 1, page_size: pageSize }),
+  });
+}
+
+export function useCreateNodeWatchMutation() {
+  const api = useMeshtasticApi();
+  const queryClient = useQueryClient();
+  return useMutation({
+    mutationFn: (body: { observed_node_id: string; offline_after?: number; enabled?: boolean }) =>
+      api.createNodeWatch(body),
+    onSuccess: () => {
+      queryClient.invalidateQueries({ queryKey: watchesKey });
+      queryClient.invalidateQueries({ queryKey: ['observed-nodes', 'mine'] });
+    },
+  });
+}
+
+export function usePatchNodeWatchMutation() {
+  const api = useMeshtasticApi();
+  const queryClient = useQueryClient();
+  return useMutation({
+    mutationFn: ({ id, ...body }: { id: number; offline_after?: number; enabled?: boolean }) =>
+      api.patchNodeWatch(id, body),
+    onSuccess: () => {
+      queryClient.invalidateQueries({ queryKey: watchesKey });
+      queryClient.invalidateQueries({ queryKey: ['observed-nodes', 'mine'] });
+    },
+  });
+}
+
+export function useDeleteNodeWatchMutation() {
+  const api = useMeshtasticApi();
+  const queryClient = useQueryClient();
+  return useMutation({
+    mutationFn: (id: number) => api.deleteNodeWatch(id),
+    onSuccess: () => {
+      queryClient.invalidateQueries({ queryKey: watchesKey });
+      queryClient.invalidateQueries({ queryKey: ['observed-nodes', 'mine'] });
+    },
+  });
+}

--- a/src/lib/api/meshtastic-api.ts
+++ b/src/lib/api/meshtastic-api.ts
@@ -22,6 +22,7 @@ import {
   CreateNodeApiKey,
   AutoTraceRoute,
   DiscordNotificationPrefs,
+  NodeWatch,
 } from '../models';
 import {
   ApiConfig,
@@ -795,5 +796,30 @@ export class MeshtasticApi extends BaseApi {
   /** POST /api/auth/discord/notifications/test/ */
   async postDiscordNotificationTest(): Promise<{ detail: string }> {
     return this.post<{ detail: string }>('/auth/discord/notifications/test/', {});
+  }
+
+  // ===== Mesh monitoring watches (Phase 04) =====
+
+  async getNodeWatches(params?: PaginationParams): Promise<PaginatedResponse<NodeWatch>> {
+    const searchParams = new URLSearchParams();
+    if (params?.page) searchParams.append('page', params.page.toString());
+    if (params?.page_size) searchParams.append('page_size', params.page_size.toString());
+    return this.get<PaginatedResponse<NodeWatch>>('/monitoring/watches/', searchParams);
+  }
+
+  async createNodeWatch(body: {
+    observed_node_id: string;
+    offline_after?: number;
+    enabled?: boolean;
+  }): Promise<NodeWatch> {
+    return this.post<NodeWatch>('/monitoring/watches/', body);
+  }
+
+  async patchNodeWatch(id: number, body: { offline_after?: number; enabled?: boolean }): Promise<NodeWatch> {
+    return this.patch<NodeWatch>(`/monitoring/watches/${id}/`, body);
+  }
+
+  async deleteNodeWatch(id: number): Promise<void> {
+    await this.delete<unknown>(`/monitoring/watches/${id}/`);
   }
 }

--- a/src/lib/models.ts
+++ b/src/lib/models.ts
@@ -421,3 +421,22 @@ export interface DiscordNotificationPrefs {
   discord_linked: boolean;
   discord_notify_verified: boolean;
 }
+
+/** Subset of observed node on mesh monitoring watch responses (API `ObservedNodeWatchSummary`). */
+export interface ObservedNodeWatchSummary {
+  internal_id: string;
+  node_id_str: string;
+  long_name: string | null;
+  last_heard: string | null;
+  monitoring_verification_started_at?: string | null;
+  monitoring_offline_confirmed_at?: string | null;
+}
+
+/** User watch on an observed node (`GET/POST /monitoring/watches/`). */
+export interface NodeWatch {
+  id: number;
+  observed_node: ObservedNodeWatchSummary;
+  offline_after: number;
+  enabled: boolean;
+  created_at: string;
+}

--- a/src/pages/nodes/MeshInfrastructure.tsx
+++ b/src/pages/nodes/MeshInfrastructure.tsx
@@ -2,6 +2,7 @@ import { useMemo, useState, useCallback, Suspense } from 'react';
 import { Link } from 'react-router-dom';
 import { subDays, subHours, format, formatDistanceToNow } from 'date-fns';
 import { useInfrastructureNodesSuspense, useManagedNodesSuspense } from '@/hooks/api/useNodes';
+import { useNodeWatches } from '@/hooks/api/useNodeWatches';
 import { useMultiNodeMetricsSuspense } from '@/hooks/api/useMultiNodeMetrics';
 import { InfrastructureNodeCard } from '@/components/nodes/InfrastructureNodeCard';
 import { NodesAndConstellationsMap } from '@/components/nodes/NodesAndConstellationsMap';
@@ -15,7 +16,8 @@ import { Switch } from '@/components/ui/switch';
 import { Label } from '@/components/ui/label';
 import { Badge } from '@/components/ui/badge';
 import { Button } from '@/components/ui/button';
-import { ObservedNode } from '@/lib/models';
+import { ObservedNode, type NodeWatch } from '@/lib/models';
+import { MeshWatchControls } from '@/components/nodes/MeshWatchControls';
 import { MapPinOff } from 'lucide-react';
 
 const CHART_TIME_RANGE_OPTIONS = [
@@ -96,6 +98,15 @@ function MeshInfrastructureContent() {
     pageSize: 100,
     includeClientBase,
   });
+
+  const watchesQuery = useNodeWatches();
+  const watchesByNodeIdStr = useMemo(() => {
+    const m = new Map<string, NodeWatch>();
+    for (const w of watchesQuery.data?.results ?? []) {
+      m.set(w.observed_node.node_id_str, w);
+    }
+    return m;
+  }, [watchesQuery.data]);
 
   const { managedNodes } = useManagedNodesSuspense(500);
 
@@ -220,6 +231,7 @@ function MeshInfrastructureContent() {
                   <TableHead>Last heard</TableHead>
                   <TableHead>Last GPS position reported</TableHead>
                   <TableHead>Owner</TableHead>
+                  <TableHead>Mesh watch</TableHead>
                   <TableHead className="w-0"></TableHead>
                 </TableRow>
               </TableHeader>
@@ -230,6 +242,7 @@ function MeshInfrastructureContent() {
                   const isOffline =
                     !node.last_heard ||
                     (node.last_heard instanceof Date ? node.last_heard : new Date(node.last_heard)) < cutoff;
+                  const watch = watchesByNodeIdStr.get(node.node_id_str);
                   return (
                     <TableRow key={node.internal_id}>
                       <TableCell>
@@ -288,6 +301,14 @@ function MeshInfrastructureContent() {
                       </TableCell>
                       <TableCell>{node.owner?.username ?? '—'}</TableCell>
                       <TableCell>
+                        <MeshWatchControls
+                          node={node}
+                          watch={watch}
+                          watchesQuery={watchesQuery}
+                          idPrefix={`infra-no-loc-${node.node_id}`}
+                        />
+                      </TableCell>
+                      <TableCell>
                         <Link to={`/nodes/${node.node_id}`} className="text-primary text-sm hover:underline">
                           View details
                         </Link>
@@ -316,6 +337,8 @@ function MeshInfrastructureContent() {
               metrics={metricsMap[node.node_id] ?? []}
               dateRange={chartDateRange}
               onCompareToggle={handleCompareToggle}
+              watch={watchesByNodeIdStr.get(node.node_id_str)}
+              watchesQuery={watchesQuery}
             />
           ))}
         </div>

--- a/src/pages/nodes/MyNodes.tsx
+++ b/src/pages/nodes/MyNodes.tsx
@@ -1,12 +1,7 @@
 import { useState, Suspense, useMemo } from 'react';
 import { useNavigate, Link } from 'react-router-dom';
 import { useMyClaimedNodesSuspense, useMyManagedNodesSuspense } from '@/hooks/api/useNodes';
-import {
-  useNodeWatches,
-  useCreateNodeWatchMutation,
-  usePatchNodeWatchMutation,
-  useDeleteNodeWatchMutation,
-} from '@/hooks/api/useNodeWatches';
+import { useNodeWatches } from '@/hooks/api/useNodeWatches';
 import { Card, CardHeader, CardTitle, CardContent, CardDescription } from '@/components/ui/card';
 import { Button } from '@/components/ui/button';
 import { Alert, AlertDescription, AlertTitle } from '@/components/ui/alert';
@@ -14,8 +9,7 @@ import { Loader2, AlertCircle, Radio, Settings, CheckCircle2 } from 'lucide-reac
 import { useConfig } from '@/providers/ConfigProvider';
 import { BotSetupInstructions, type BotDefaults } from '@/components/nodes/BotSetupInstructions';
 import { ObservedNode, type NodeWatch } from '@/lib/models';
-import { Checkbox } from '@/components/ui/checkbox';
-import { toast } from 'sonner';
+import { MeshWatchControls } from '@/components/nodes/MeshWatchControls';
 import type { NodeApiKeyConstellation } from '@/lib/models';
 import { Badge } from '@/components/ui/badge';
 import { Table, TableBody, TableCell, TableHead, TableHeader, TableRow } from '@/components/ui/table';
@@ -50,10 +44,6 @@ function MyNodesContent() {
   });
 
   const watchesQuery = useNodeWatches();
-  const createWatch = useCreateNodeWatchMutation();
-  const patchWatch = usePatchNodeWatchMutation();
-  const deleteWatch = useDeleteNodeWatchMutation();
-
   const watchesByNodeIdStr = useMemo(() => {
     const m = new Map<string, NodeWatch>();
     for (const w of watchesQuery.data?.results ?? []) {
@@ -169,78 +159,12 @@ function MyNodesContent() {
                       )}
                     </TableCell>
                     <TableCell>
-                      {watchesQuery.isLoading ? (
-                        <span className="text-muted-foreground text-sm">…</span>
-                      ) : watchesQuery.isError ? (
-                        <span className="text-muted-foreground text-sm">—</span>
-                      ) : watch ? (
-                        <div className="flex flex-col gap-2 max-w-[200px]">
-                          <div className="flex items-center gap-2">
-                            <Checkbox
-                              id={`watch-enabled-${watch.id}`}
-                              checked={watch.enabled}
-                              disabled={patchWatch.isPending}
-                              onCheckedChange={(checked) => {
-                                if (checked === 'indeterminate') return;
-                                patchWatch.mutate(
-                                  { id: watch.id, enabled: Boolean(checked) },
-                                  {
-                                    onError: (e) =>
-                                      toast.error(e instanceof Error ? e.message : 'Could not update watch'),
-                                  }
-                                );
-                              }}
-                            />
-                            <label htmlFor={`watch-enabled-${watch.id}`} className="text-sm cursor-pointer">
-                              Alerts on
-                            </label>
-                          </div>
-                          <div className="flex flex-wrap gap-1">
-                            {watch.observed_node.monitoring_verification_started_at && (
-                              <Badge variant="secondary" className="text-xs">
-                                Verifying
-                              </Badge>
-                            )}
-                            {watch.observed_node.monitoring_offline_confirmed_at && (
-                              <Badge variant="destructive" className="text-xs">
-                                Offline
-                              </Badge>
-                            )}
-                          </div>
-                          <Button
-                            type="button"
-                            variant="ghost"
-                            size="sm"
-                            className="h-7 px-2 text-xs text-muted-foreground"
-                            disabled={deleteWatch.isPending}
-                            onClick={() =>
-                              deleteWatch.mutate(watch.id, {
-                                onError: (e) => toast.error(e instanceof Error ? e.message : 'Could not remove watch'),
-                              })
-                            }
-                          >
-                            Remove watch
-                          </Button>
-                        </div>
-                      ) : (
-                        <Button
-                          type="button"
-                          size="sm"
-                          variant="outline"
-                          className="text-xs"
-                          disabled={createWatch.isPending}
-                          onClick={() =>
-                            createWatch.mutate(
-                              { observed_node_id: String(node.internal_id), offline_after: 7200, enabled: true },
-                              {
-                                onError: (e) => toast.error(e instanceof Error ? e.message : 'Could not add watch'),
-                              }
-                            )
-                          }
-                        >
-                          Add watch
-                        </Button>
-                      )}
+                      <MeshWatchControls
+                        node={node}
+                        watch={watch}
+                        watchesQuery={watchesQuery}
+                        idPrefix={`my-nodes-${node.node_id}`}
+                      />
                     </TableCell>
                     <TableCell>
                       <div className="flex gap-2">

--- a/src/pages/nodes/MyNodes.tsx
+++ b/src/pages/nodes/MyNodes.tsx
@@ -1,13 +1,21 @@
-import { useState, Suspense } from 'react';
+import { useState, Suspense, useMemo } from 'react';
 import { useNavigate, Link } from 'react-router-dom';
 import { useMyClaimedNodesSuspense, useMyManagedNodesSuspense } from '@/hooks/api/useNodes';
+import {
+  useNodeWatches,
+  useCreateNodeWatchMutation,
+  usePatchNodeWatchMutation,
+  useDeleteNodeWatchMutation,
+} from '@/hooks/api/useNodeWatches';
 import { Card, CardHeader, CardTitle, CardContent, CardDescription } from '@/components/ui/card';
 import { Button } from '@/components/ui/button';
 import { Alert, AlertDescription, AlertTitle } from '@/components/ui/alert';
 import { Loader2, AlertCircle, Radio, Settings, CheckCircle2 } from 'lucide-react';
 import { useConfig } from '@/providers/ConfigProvider';
 import { BotSetupInstructions, type BotDefaults } from '@/components/nodes/BotSetupInstructions';
-import { ObservedNode } from '@/lib/models';
+import { ObservedNode, type NodeWatch } from '@/lib/models';
+import { Checkbox } from '@/components/ui/checkbox';
+import { toast } from 'sonner';
 import type { NodeApiKeyConstellation } from '@/lib/models';
 import { Badge } from '@/components/ui/badge';
 import { Table, TableBody, TableCell, TableHead, TableHeader, TableRow } from '@/components/ui/table';
@@ -40,6 +48,19 @@ function MyNodesContent() {
     queryKey: ['api-keys'],
     queryFn: () => api.getApiKeys(),
   });
+
+  const watchesQuery = useNodeWatches();
+  const createWatch = useCreateNodeWatchMutation();
+  const patchWatch = usePatchNodeWatchMutation();
+  const deleteWatch = useDeleteNodeWatchMutation();
+
+  const watchesByNodeIdStr = useMemo(() => {
+    const m = new Map<string, NodeWatch>();
+    for (const w of watchesQuery.data?.results ?? []) {
+      m.set(w.observed_node.node_id_str, w);
+    }
+    return m;
+  }, [watchesQuery.data]);
 
   // Create a Set of managed node IDs for quick lookup
   const managedNodeIds = new Set(myManagedNodes.map((n) => n.node_id));
@@ -84,6 +105,7 @@ function MyNodesContent() {
                 <TableHead>Last Heard</TableHead>
                 <TableHead>Battery</TableHead>
                 <TableHead>Position</TableHead>
+                <TableHead>Mesh watch</TableHead>
                 <TableHead></TableHead>
               </TableRow>
             </TableHeader>
@@ -91,6 +113,7 @@ function MyNodesContent() {
               {allNodes.map((node) => {
                 const isManaged = managedNodeIds.has(node.node_id);
                 const isClaimed = node.owner?.id !== undefined;
+                const watch = watchesByNodeIdStr.get(node.node_id_str);
 
                 return (
                   <TableRow key={node.node_id}>
@@ -143,6 +166,80 @@ function MyNodesContent() {
                         </div>
                       ) : (
                         '-'
+                      )}
+                    </TableCell>
+                    <TableCell>
+                      {watchesQuery.isLoading ? (
+                        <span className="text-muted-foreground text-sm">…</span>
+                      ) : watchesQuery.isError ? (
+                        <span className="text-muted-foreground text-sm">—</span>
+                      ) : watch ? (
+                        <div className="flex flex-col gap-2 max-w-[200px]">
+                          <div className="flex items-center gap-2">
+                            <Checkbox
+                              id={`watch-enabled-${watch.id}`}
+                              checked={watch.enabled}
+                              disabled={patchWatch.isPending}
+                              onCheckedChange={(checked) => {
+                                if (checked === 'indeterminate') return;
+                                patchWatch.mutate(
+                                  { id: watch.id, enabled: Boolean(checked) },
+                                  {
+                                    onError: (e) =>
+                                      toast.error(e instanceof Error ? e.message : 'Could not update watch'),
+                                  }
+                                );
+                              }}
+                            />
+                            <label htmlFor={`watch-enabled-${watch.id}`} className="text-sm cursor-pointer">
+                              Alerts on
+                            </label>
+                          </div>
+                          <div className="flex flex-wrap gap-1">
+                            {watch.observed_node.monitoring_verification_started_at && (
+                              <Badge variant="secondary" className="text-xs">
+                                Verifying
+                              </Badge>
+                            )}
+                            {watch.observed_node.monitoring_offline_confirmed_at && (
+                              <Badge variant="destructive" className="text-xs">
+                                Offline
+                              </Badge>
+                            )}
+                          </div>
+                          <Button
+                            type="button"
+                            variant="ghost"
+                            size="sm"
+                            className="h-7 px-2 text-xs text-muted-foreground"
+                            disabled={deleteWatch.isPending}
+                            onClick={() =>
+                              deleteWatch.mutate(watch.id, {
+                                onError: (e) => toast.error(e instanceof Error ? e.message : 'Could not remove watch'),
+                              })
+                            }
+                          >
+                            Remove watch
+                          </Button>
+                        </div>
+                      ) : (
+                        <Button
+                          type="button"
+                          size="sm"
+                          variant="outline"
+                          className="text-xs"
+                          disabled={createWatch.isPending}
+                          onClick={() =>
+                            createWatch.mutate(
+                              { observed_node_id: String(node.internal_id), offline_after: 7200, enabled: true },
+                              {
+                                onError: (e) => toast.error(e instanceof Error ? e.message : 'Could not add watch'),
+                              }
+                            )
+                          }
+                        >
+                          Add watch
+                        </Button>
                       )}
                     </TableCell>
                     <TableCell>


### PR DESCRIPTION
# Summary

- **My Nodes:** mesh monitoring column with add/remove watch, alerts toggle, Verifying/Offline badges (`MeshWatchControls`).
- **Mesh Infrastructure:** same watch controls on node cards and on the “nodes without recent location” table.
- **Shared `MeshWatchControls`** component for both pages.
- **React Query:** after create/patch/delete, `setQueriesData` updates the watches list immediately so the UI does not flash back to “Add watch” while refetch runs; spinners show **Adding…** / **Removing…** during mutations.

Depends on / pairs with the meshflow-api PR for mesh monitoring watches (Phase 04) if that is not merged yet.

Closes #149

## Testing performed

- `npm run build`
- `npm test` (Vitest)
- Manual: add/remove watch and toggle alerts on My Nodes and Mesh Infrastructure; confirm no UI flicker after create.
