### PR TITLE
feat(traceroutes): direct-path UI and node detail links

### DIFF
--- a/src/components/traceroutes/TracerouteFlowDiagram.tsx
+++ b/src/components/traceroutes/TracerouteFlowDiagram.tsx
@@ -48,7 +48,19 @@ export function TracerouteFlowDiagram({ traceroute }: { traceroute: AutoTraceRou
   const targetLabel = traceroute.target_node?.short_name ?? traceroute.target_node?.node_id_str ?? 'Target';
 
   if (routeNodes.length === 0 && routeBackNodes.length === 0) {
-    return null;
+    if (traceroute.status !== 'completed') {
+      return null;
+    }
+    return (
+      <div className="space-y-2 rounded-md border border-blue-500/25 bg-blue-500/5 px-3 py-3 dark:border-blue-400/30 dark:bg-blue-950/40">
+        <p className="text-sm text-muted-foreground">No intermediate relays — direct RF path.</p>
+        <div className="flex flex-wrap items-center gap-2">
+          <Badge className="bg-blue-500/20 text-blue-700 dark:text-blue-300">{sourceLabel}</Badge>
+          <ArrowRight className="h-4 w-4 shrink-0 text-muted-foreground" />
+          <Badge className="bg-green-500/20 text-green-700 dark:text-green-300">{targetLabel}</Badge>
+        </div>
+      </div>
+    );
   }
 
   return (

--- a/src/components/traceroutes/TracerouteFlowDiagram.tsx
+++ b/src/components/traceroutes/TracerouteFlowDiagram.tsx
@@ -1,42 +1,90 @@
+import { Link } from 'react-router-dom';
 import { Badge } from '@/components/ui/badge';
 import { AutoTraceRoute, TracerouteRouteNode } from '@/lib/models';
 import { ArrowRight } from 'lucide-react';
 
-function NodeBadge({ node, isUnknown }: { node: TracerouteRouteNode; isUnknown: boolean }) {
-  const label = node.short_name ?? node.node_id_str;
+const UNKNOWN_NODE_ID = 0xffffffff;
+
+function FlowEndpointBadge({
+  label,
+  nodeId,
+  directionColor,
+}: {
+  label: string;
+  nodeId: number;
+  directionColor: string;
+}) {
   return (
+    <Link
+      to={`/nodes/${nodeId}`}
+      onClick={(e) => e.stopPropagation()}
+      className="inline-flex max-w-full rounded-md focus:outline-none focus:ring-2 focus:ring-ring focus:ring-offset-2"
+    >
+      <Badge className={`max-w-full cursor-pointer ${directionColor}`}>{label}</Badge>
+    </Link>
+  );
+}
+
+function NodeBadge({ node }: { node: TracerouteRouteNode }) {
+  const isPlaceholderUnknown = node.node_id === UNKNOWN_NODE_ID;
+  const useMutedStyle = isPlaceholderUnknown || !node.position;
+  const label = node.short_name ?? node.node_id_str;
+  const badge = (
     <Badge
-      variant={isUnknown ? 'outline' : 'secondary'}
-      className={isUnknown ? 'border-dashed font-mono text-muted-foreground' : ''}
+      variant={useMutedStyle ? 'outline' : 'secondary'}
+      className={
+        useMutedStyle
+          ? 'max-w-full border-dashed font-mono text-muted-foreground ' +
+            (isPlaceholderUnknown ? 'cursor-default' : 'cursor-pointer')
+          : 'max-w-full cursor-pointer'
+      }
     >
       {label}
-      {node.snr != null && !isUnknown && <span className="ml-1 text-xs opacity-75">({node.snr})</span>}
+      {node.snr != null && !isPlaceholderUnknown && <span className="ml-1 text-xs opacity-75">({node.snr})</span>}
     </Badge>
+  );
+
+  if (isPlaceholderUnknown) {
+    return badge;
+  }
+
+  return (
+    <Link
+      to={`/nodes/${node.node_id}`}
+      onClick={(e) => e.stopPropagation()}
+      className="inline-flex max-w-full rounded-md focus:outline-none focus:ring-2 focus:ring-ring focus:ring-offset-2"
+    >
+      {badge}
+    </Link>
   );
 }
 
 function FlowRow({
   startLabel,
+  startNodeId,
   nodes,
   endLabel,
+  endNodeId,
   directionColor,
 }: {
   startLabel: string;
+  startNodeId: number;
   nodes: TracerouteRouteNode[];
   endLabel: string;
+  endNodeId: number;
   directionColor: string;
 }) {
   return (
     <div className="flex flex-wrap items-center gap-1">
-      <Badge className={directionColor}>{startLabel}</Badge>
+      <FlowEndpointBadge label={startLabel} nodeId={startNodeId} directionColor={directionColor} />
       {nodes.map((node, i) => (
         <span key={`${node.node_id}-${i}`} className="flex items-center gap-1">
           <ArrowRight className="h-4 w-4 shrink-0 text-muted-foreground" />
-          <NodeBadge node={node} isUnknown={node.node_id === 0xffffffff || !node.position} />
+          <NodeBadge node={node} />
         </span>
       ))}
       <ArrowRight className="h-4 w-4 shrink-0 text-muted-foreground" />
-      <Badge className={directionColor}>{endLabel}</Badge>
+      <FlowEndpointBadge label={endLabel} nodeId={endNodeId} directionColor={directionColor} />
     </div>
   );
 }
@@ -46,6 +94,8 @@ export function TracerouteFlowDiagram({ traceroute }: { traceroute: AutoTraceRou
   const routeBackNodes = traceroute.route_back_nodes ?? [];
   const sourceLabel = traceroute.source_node?.short_name ?? traceroute.source_node?.node_id_str ?? 'Source';
   const targetLabel = traceroute.target_node?.short_name ?? traceroute.target_node?.node_id_str ?? 'Target';
+  const sourceNodeId = traceroute.source_node.node_id;
+  const targetNodeId = traceroute.target_node.node_id;
 
   if (routeNodes.length === 0 && routeBackNodes.length === 0) {
     if (traceroute.status !== 'completed') {
@@ -55,9 +105,17 @@ export function TracerouteFlowDiagram({ traceroute }: { traceroute: AutoTraceRou
       <div className="space-y-2 rounded-md border border-blue-500/25 bg-blue-500/5 px-3 py-3 dark:border-blue-400/30 dark:bg-blue-950/40">
         <p className="text-sm text-muted-foreground">No intermediate relays — direct RF path.</p>
         <div className="flex flex-wrap items-center gap-2">
-          <Badge className="bg-blue-500/20 text-blue-700 dark:text-blue-300">{sourceLabel}</Badge>
+          <FlowEndpointBadge
+            label={sourceLabel}
+            nodeId={sourceNodeId}
+            directionColor="bg-blue-500/20 text-blue-700 dark:text-blue-300"
+          />
           <ArrowRight className="h-4 w-4 shrink-0 text-muted-foreground" />
-          <Badge className="bg-green-500/20 text-green-700 dark:text-green-300">{targetLabel}</Badge>
+          <FlowEndpointBadge
+            label={targetLabel}
+            nodeId={targetNodeId}
+            directionColor="bg-green-500/20 text-green-700 dark:text-green-300"
+          />
         </div>
       </div>
     );
@@ -69,8 +127,10 @@ export function TracerouteFlowDiagram({ traceroute }: { traceroute: AutoTraceRou
         <h4 className="mb-2 text-sm font-medium text-muted-foreground">Outbound</h4>
         <FlowRow
           startLabel={sourceLabel}
+          startNodeId={sourceNodeId}
           nodes={routeNodes}
           endLabel={targetLabel}
+          endNodeId={targetNodeId}
           directionColor="bg-blue-500/20 text-blue-700 dark:text-blue-300"
         />
       </div>
@@ -79,8 +139,10 @@ export function TracerouteFlowDiagram({ traceroute }: { traceroute: AutoTraceRou
           <h4 className="mb-2 text-sm font-medium text-muted-foreground">Return</h4>
           <FlowRow
             startLabel={targetLabel}
+            startNodeId={targetNodeId}
             nodes={routeBackNodes}
             endLabel={sourceLabel}
+            endNodeId={sourceNodeId}
             directionColor="bg-green-500/20 text-green-700 dark:text-green-300"
           />
         </div>

--- a/src/components/traceroutes/TracerouteMap.tsx
+++ b/src/components/traceroutes/TracerouteMap.tsx
@@ -9,7 +9,6 @@ const DEFAULT_CENTER: L.LatLngExpression = [55.8642, -4.2518];
 const SOURCE_COLOR = '#2563eb';
 const TARGET_COLOR = '#16a34a';
 const INTERMEDIATE_COLOR = '#64748b';
-const PENDING_LINE_COLOR = '#94a3b8';
 const FAILED_LINE_COLOR = '#dc2626';
 const UNKNOWN_NODE_ID = 0xffffffff;
 
@@ -174,25 +173,41 @@ export function TracerouteMap({ traceroute }: { traceroute: AutoTraceRoute }) {
       bounds.extend(targetPos);
     }
 
-    // Pending/sent/failed: show dashed direct line between source and target
     const statusLower = traceroute.status?.toLowerCase();
+    // Pending/sent: solid blue (same weight/style as completed outbound). Failed: dashed red.
     const needsDirectLine = statusLower === 'pending' || statusLower === 'sent' || statusLower === 'failed';
     if (needsDirectLine && sourcePos && targetPos) {
-      const lineColor = statusLower === 'failed' ? FAILED_LINE_COLOR : PENDING_LINE_COLOR;
+      const isFailed = statusLower === 'failed';
       const directLine = L.polyline([sourcePos, targetPos], {
-        color: lineColor,
-        weight: 3,
-        dashArray: '10, 10',
-        className: statusLower === 'failed' ? 'traceroute-failed' : 'traceroute-pending',
+        color: isFailed ? FAILED_LINE_COLOR : SOURCE_COLOR,
+        weight: 4,
+        ...(isFailed ? { dashArray: '10, 8' as const } : {}),
+        className: isFailed ? 'traceroute-failed' : 'traceroute-pending',
       }).addTo(map);
       layersRef.current.push(directLine);
     }
 
     // Route segments only when completed
     const isCompleted = statusLower === 'completed';
+    const isDirectPathCompleted =
+      isCompleted && sourcePos && targetPos && routeNodes.length === 0 && routeBackNodes.length === 0;
+
     if (isCompleted) {
-      const outboundSegments = sourcePos && targetPos ? buildSegments(sourcePos, routeNodes, targetPos) : [];
-      const returnSegments = sourcePos && targetPos ? buildSegments(targetPos, routeBackNodes, sourcePos) : [];
+      if (isDirectPathCompleted) {
+        const directCompleted = L.polyline([sourcePos, targetPos], {
+          color: SOURCE_COLOR,
+          weight: 4,
+          className: 'traceroute-direct-completed',
+        }).addTo(map);
+        layersRef.current.push(directCompleted);
+        bounds.extend(sourcePos);
+        bounds.extend(targetPos);
+      }
+
+      const outboundSegments =
+        !isDirectPathCompleted && sourcePos && targetPos ? buildSegments(sourcePos, routeNodes, targetPos) : [];
+      const returnSegments =
+        !isDirectPathCompleted && sourcePos && targetPos ? buildSegments(targetPos, routeBackNodes, sourcePos) : [];
 
       outboundSegments.forEach((seg) => {
         const poly = L.polyline(seg.latlngs, {

--- a/src/pages/traceroutes/TracerouteDetailModal.tsx
+++ b/src/pages/traceroutes/TracerouteDetailModal.tsx
@@ -1,4 +1,5 @@
 import { format } from 'date-fns';
+import { Link } from 'react-router-dom';
 import { Dialog, DialogContent, DialogDescription, DialogHeader, DialogTitle } from '@/components/ui/dialog';
 import { Badge } from '@/components/ui/badge';
 import { useTraceroute } from '@/hooks/api/useTraceroutes';
@@ -41,10 +42,28 @@ export function TracerouteDetailModal({ tracerouteId, open, onOpenChange }: Trac
       <DialogContent className="max-w-2xl max-h-[90vh] overflow-y-auto">
         <DialogHeader>
           <DialogTitle>Traceroute Details</DialogTitle>
-          <DialogDescription>
-            {traceroute
-              ? `${traceroute.source_node?.short_name ?? traceroute.source_node?.node_id_str} → ${traceroute.target_node?.short_name ?? traceroute.target_node?.node_id_str}`
-              : 'Loading...'}
+          <DialogDescription className="flex flex-wrap items-center gap-x-1.5 gap-y-1">
+            {traceroute ? (
+              <>
+                <Link
+                  to={`/nodes/${traceroute.source_node.node_id}`}
+                  onClick={(e) => e.stopPropagation()}
+                  className="font-medium text-primary underline-offset-4 hover:underline"
+                >
+                  {traceroute.source_node?.short_name ?? traceroute.source_node?.node_id_str}
+                </Link>
+                <span aria-hidden>→</span>
+                <Link
+                  to={`/nodes/${traceroute.target_node.node_id}`}
+                  onClick={(e) => e.stopPropagation()}
+                  className="font-medium text-primary underline-offset-4 hover:underline"
+                >
+                  {traceroute.target_node?.short_name ?? traceroute.target_node?.node_id_str}
+                </Link>
+              </>
+            ) : (
+              'Loading...'
+            )}
           </DialogDescription>
         </DialogHeader>
 
@@ -57,11 +76,25 @@ export function TracerouteDetailModal({ tracerouteId, open, onOpenChange }: Trac
         {traceroute && !isLoading && !error && (
           <div className="mt-6 space-y-6">
             <div className="flex flex-wrap gap-2">
-              <Badge variant="outline">
-                Source: {traceroute.source_node?.short_name ?? traceroute.source_node?.node_id_str}
+              <Badge variant="outline" className="gap-1">
+                <span className="text-muted-foreground">Source:</span>
+                <Link
+                  to={`/nodes/${traceroute.source_node.node_id}`}
+                  onClick={(e) => e.stopPropagation()}
+                  className="text-primary underline-offset-4 hover:underline"
+                >
+                  {traceroute.source_node?.short_name ?? traceroute.source_node?.node_id_str}
+                </Link>
               </Badge>
-              <Badge variant="outline">
-                Target: {traceroute.target_node?.short_name ?? traceroute.target_node?.node_id_str}
+              <Badge variant="outline" className="gap-1">
+                <span className="text-muted-foreground">Target:</span>
+                <Link
+                  to={`/nodes/${traceroute.target_node.node_id}`}
+                  onClick={(e) => e.stopPropagation()}
+                  className="text-primary underline-offset-4 hover:underline"
+                >
+                  {traceroute.target_node?.short_name ?? traceroute.target_node?.node_id_str}
+                </Link>
               </Badge>
               <Badge>{displayStatus(traceroute)}</Badge>
               <span className="text-sm text-muted-foreground">

--- a/src/pages/traceroutes/TracerouteDetailModal.tsx
+++ b/src/pages/traceroutes/TracerouteDetailModal.tsx
@@ -18,10 +18,15 @@ interface TracerouteDetailModalProps {
 export function TracerouteDetailModal({ tracerouteId, open, onOpenChange }: TracerouteDetailModalProps) {
   const { data: traceroute, isLoading, error } = useTraceroute(open ? tracerouteId : null);
 
+  const isEmptyRouteArrays =
+    traceroute &&
+    (!traceroute.route || traceroute.route.length === 0) &&
+    (!traceroute.route_back || traceroute.route_back.length === 0);
   const hasRouteData =
     traceroute &&
     ((traceroute.route_nodes && traceroute.route_nodes.length > 0) ||
-      (traceroute.route_back_nodes && traceroute.route_back_nodes.length > 0));
+      (traceroute.route_back_nodes && traceroute.route_back_nodes.length > 0) ||
+      (traceroute.status === 'completed' && isEmptyRouteArrays));
 
   const hasSourceOrTargetPosition =
     traceroute &&

--- a/src/pages/traceroutes/TracerouteHistory.tsx
+++ b/src/pages/traceroutes/TracerouteHistory.tsx
@@ -45,9 +45,13 @@ function getTracerouteErrorMessage(error: unknown): string {
 function routeSummary(tr: AutoTraceRoute): string {
   const route = tr.route;
   const routeBack = tr.route_back;
-  if ((!route || route.length === 0) && (!routeBack || routeBack.length === 0)) return '—';
-  const outStr = !route || route.length === 0 ? 'direct' : `${route.length} hops`;
-  const backStr = !routeBack || routeBack.length === 0 ? 'direct' : `${routeBack.length} hops`;
+  const outEmpty = !route || route.length === 0;
+  const backEmpty = !routeBack || routeBack.length === 0;
+  if (outEmpty && backEmpty) {
+    return tr.status === 'completed' ? 'Direct' : '—';
+  }
+  const outStr = outEmpty ? 'Direct' : `${route.length} hops`;
+  const backStr = backEmpty ? 'Direct' : `${routeBack.length} hops`;
   return `${outStr} out, ${backStr} back`;
 }
 


### PR DESCRIPTION
# Summary

- **Direct path:** Route column shows `Direct` for completed empty-hop traceroutes; flow + map treat direct RF paths explicitly; pending/sent map line is solid blue (failed stays dashed red).
- **Node links:** Traceroute detail modal — subtitle names, Source/Target badge names, and every flow hop (except unknown `0xffffffff` placeholders) link to `/nodes/:nodeId`.

Pairs with the meshflow-api traceroute completion behaviour for empty routes: **pskillen/meshflow-api#158**.

## Testing performed

- `npm run format`, `eslint`, `vitest run` (via pre-commit)
- `npm run build`