### PR TITLE
feat(nodes): rework My Nodes page layout (#146)

### DIFF
--- a/src/components/nodes/MyNodeCard.tsx
+++ b/src/components/nodes/MyNodeCard.tsx
@@ -1,0 +1,162 @@
+import { Link } from 'react-router-dom';
+import { formatDistanceToNow, subDays } from 'date-fns';
+import { MoreVertical, Radio, Settings, ChevronRight, FileText } from 'lucide-react';
+import type { UseQueryResult } from '@tanstack/react-query';
+
+import { MeshWatchControls } from '@/components/nodes/MeshWatchControls';
+import { BatteryGauge } from '@/components/nodes/BatteryGauge';
+import { Badge } from '@/components/ui/badge';
+import { Button } from '@/components/ui/button';
+import { Card, CardContent, CardFooter, CardHeader } from '@/components/ui/card';
+import {
+  DropdownMenu,
+  DropdownMenuContent,
+  DropdownMenuItem,
+  DropdownMenuTrigger,
+} from '@/components/ui/dropdown-menu';
+import { Tooltip, TooltipContent, TooltipProvider, TooltipTrigger } from '@/components/ui/tooltip';
+import type { ObservedNode, NodeWatch, PaginatedResponse } from '@/lib/models';
+
+const POSITION_STALE_DAYS = 7;
+
+function getPositionHint(node: ObservedNode): string {
+  const pos = node.latest_position as {
+    latitude?: number;
+    longitude?: number;
+    reported_time?: Date | string;
+  } | null;
+  if (!pos) return 'No fix';
+  const lat = pos.latitude;
+  const lon = pos.longitude;
+  if (lat == null || lon == null || lat === 0 || lon === 0) return 'No fix';
+  const reported = pos.reported_time ? new Date(pos.reported_time) : null;
+  if (!reported) return 'Has fix';
+  const cutoff = subDays(new Date(), POSITION_STALE_DAYS);
+  return reported >= cutoff ? 'Recent fix' : 'Stale fix';
+}
+
+export interface MyNodeCardProps {
+  node: ObservedNode;
+  isManaged: boolean;
+  isClaimed: boolean;
+  watch: NodeWatch | undefined;
+  watchesQuery: Pick<UseQueryResult<PaginatedResponse<NodeWatch>>, 'isLoading' | 'isError'>;
+  onConvert: () => void;
+  onShowSetupInstructions: () => void;
+}
+
+export function MyNodeCard({
+  node,
+  isManaged,
+  isClaimed,
+  watch,
+  watchesQuery,
+  onConvert,
+  onShowSetupInstructions,
+}: MyNodeCardProps) {
+  const metrics = node.latest_device_metrics;
+  const batteryLevel = metrics?.battery_level != null ? metrics.battery_level : null;
+  const voltage = metrics?.voltage != null ? metrics.voltage : null;
+  const metricsReported = metrics?.reported_time ? new Date(metrics.reported_time) : null;
+  const positionHint = getPositionHint(node);
+  const displayName = node.short_name || node.node_id_str;
+
+  return (
+    <Card className="min-w-0 flex flex-col h-full border bg-card shadow-sm">
+      <CardHeader className="pb-2 space-y-0">
+        <div className="flex items-start justify-between gap-2">
+          <div className="min-w-0 flex-1">
+            <h2 className="text-base font-semibold leading-tight truncate">{displayName}</h2>
+            {node.long_name ? <p className="text-sm text-muted-foreground truncate mt-0.5">{node.long_name}</p> : null}
+            <p className="text-xs font-mono text-muted-foreground mt-1 truncate">{node.node_id_str}</p>
+          </div>
+          <DropdownMenu>
+            <DropdownMenuTrigger asChild>
+              <Button
+                type="button"
+                variant="ghost"
+                size="icon"
+                className="h-8 w-8 shrink-0"
+                aria-label={`More actions for ${displayName}`}
+              >
+                <MoreVertical className="h-4 w-4" />
+              </Button>
+            </DropdownMenuTrigger>
+            <DropdownMenuContent align="end" className="w-48">
+              {!isManaged ? (
+                <DropdownMenuItem onSelect={() => onConvert()}>
+                  <Radio className="mr-2 h-4 w-4" />
+                  Convert to managed
+                </DropdownMenuItem>
+              ) : null}
+              {isManaged ? (
+                <DropdownMenuItem onSelect={() => onShowSetupInstructions()}>
+                  <FileText className="mr-2 h-4 w-4" />
+                  Setup instructions
+                </DropdownMenuItem>
+              ) : null}
+            </DropdownMenuContent>
+          </DropdownMenu>
+        </div>
+      </CardHeader>
+      <CardContent className="flex-1 space-y-3 pt-0">
+        <div className="flex flex-wrap gap-1.5">
+          {isManaged ? (
+            <Badge variant="outline" className="text-xs">
+              Managed
+            </Badge>
+          ) : null}
+          {isClaimed ? (
+            <Badge variant="outline" className="text-xs">
+              Claimed
+            </Badge>
+          ) : null}
+          <Badge variant="secondary" className="text-xs">
+            {positionHint}
+          </Badge>
+        </div>
+        <p className="text-sm text-muted-foreground">
+          Last heard{' '}
+          <span className="text-foreground tabular-nums">
+            {node.last_heard ? formatDistanceToNow(new Date(node.last_heard), { addSuffix: true }) : 'never'}
+          </span>
+        </p>
+        <TooltipProvider delayDuration={300}>
+          <Tooltip>
+            <TooltipTrigger asChild>
+              <div className="cursor-default">
+                <BatteryGauge batteryLevel={batteryLevel} voltage={voltage} />
+              </div>
+            </TooltipTrigger>
+            {metricsReported ? (
+              <TooltipContent side="bottom" className="max-w-xs">
+                Metrics updated {formatDistanceToNow(metricsReported, { addSuffix: true })}
+              </TooltipContent>
+            ) : (
+              <TooltipContent side="bottom">No recent telemetry timestamp</TooltipContent>
+            )}
+          </Tooltip>
+        </TooltipProvider>
+      </CardContent>
+      <CardFooter className="flex flex-col items-stretch gap-3 border-t pt-4 mt-auto">
+        <div>
+          <p className="text-xs font-medium text-muted-foreground mb-2">Mesh monitoring</p>
+          <MeshWatchControls
+            node={node}
+            watch={watch}
+            watchesQuery={watchesQuery}
+            idPrefix={`my-nodes-card-${node.node_id}`}
+            compact
+          />
+        </div>
+        <Button asChild className="w-full">
+          <Link to={`/nodes/${node.node_id}`} className="inline-flex items-center justify-center gap-1.5">
+            <Settings className="h-4 w-4 shrink-0" aria-hidden />
+            Node details
+            <ChevronRight className="h-4 w-4 shrink-0 opacity-70" aria-hidden />
+          </Link>
+        </Button>
+      </CardFooter>
+    </Card>
+  );
+}

--- a/src/pages/nodes/MyNodes.tsx
+++ b/src/pages/nodes/MyNodes.tsx
@@ -5,17 +5,15 @@ import { useNodeWatches } from '@/hooks/api/useNodeWatches';
 import { Card, CardHeader, CardTitle, CardContent, CardDescription } from '@/components/ui/card';
 import { Button } from '@/components/ui/button';
 import { Alert, AlertDescription, AlertTitle } from '@/components/ui/alert';
-import { Loader2, AlertCircle, Radio, Settings, CheckCircle2 } from 'lucide-react';
+import { Loader2, AlertCircle, Settings, CheckCircle2 } from 'lucide-react';
 import { useConfig } from '@/providers/ConfigProvider';
 import { BotSetupInstructions, type BotDefaults } from '@/components/nodes/BotSetupInstructions';
 import { ObservedNode, type NodeWatch } from '@/lib/models';
-import { MeshWatchControls } from '@/components/nodes/MeshWatchControls';
 import type { NodeApiKeyConstellation } from '@/lib/models';
-import { Badge } from '@/components/ui/badge';
-import { Table, TableBody, TableCell, TableHead, TableHeader, TableRow } from '@/components/ui/table';
 import { SetupManagedNode } from '@/components/nodes/SetupManagedNode';
 import { NodesAndConstellationsMap } from '@/components/nodes/NodesAndConstellationsMap';
 import { MonitoredNodesBatteryChart } from '@/components/nodes/MonitoredNodesBatteryChart';
+import { MyNodeCard } from '@/components/nodes/MyNodeCard';
 import { useQuery } from '@tanstack/react-query';
 import { useMeshtasticApi } from '@/hooks/api/useApi';
 import {
@@ -52,7 +50,6 @@ function MyNodesContent() {
     return m;
   }, [watchesQuery.data]);
 
-  // Create a Set of managed node IDs for quick lookup
   const managedNodeIds = new Set(myManagedNodes.map((n) => n.node_id));
 
   const handleRunAsManagedNode = (node: ObservedNode) => {
@@ -65,154 +62,14 @@ function MyNodesContent() {
     setSelectedNode(null);
   };
 
-  // Combine claimed and managed nodes into a unified list
   const allNodes = [...myClaimedNodes];
 
-  // Add managed nodes that aren't already in the claimed nodes list
   myManagedNodes.forEach((managedNode) => {
     if (!allNodes.some((node) => node.node_id === managedNode.node_id)) {
       allNodes.push(managedNode as unknown as ObservedNode);
     }
   });
 
-  // Custom table component that extends MonitoredNodesTable to include claim/manage status
-  const MyNodesTable = () => {
-    return (
-      <Card>
-        <CardHeader>
-          <CardTitle>My Nodes</CardTitle>
-          <CardDescription>
-            These are your observed and managed nodes. You can view details and manage them from here.
-          </CardDescription>
-        </CardHeader>
-        <CardContent>
-          <Table>
-            <TableHeader>
-              <TableRow>
-                <TableHead>Short Name</TableHead>
-                <TableHead>Long Name</TableHead>
-                <TableHead>Status</TableHead>
-                <TableHead>Last Heard</TableHead>
-                <TableHead>Battery</TableHead>
-                <TableHead>Position</TableHead>
-                <TableHead>Mesh watch</TableHead>
-                <TableHead></TableHead>
-              </TableRow>
-            </TableHeader>
-            <TableBody>
-              {allNodes.map((node) => {
-                const isManaged = managedNodeIds.has(node.node_id);
-                const isClaimed = node.owner?.id !== undefined;
-                const watch = watchesByNodeIdStr.get(node.node_id_str);
-
-                return (
-                  <TableRow key={node.node_id}>
-                    <TableCell>
-                      <div>
-                        {node.short_name || node.node_id_str}
-                        <div className="text-xs text-muted-foreground">{node.node_id_str}</div>
-                      </div>
-                    </TableCell>
-                    <TableCell>{node.long_name || '-'}</TableCell>
-                    <TableCell>
-                      <div className="flex flex-wrap gap-2">
-                        {isManaged && <Badge variant="outline">Managed</Badge>}
-                        {isClaimed && <Badge variant="outline">Claimed</Badge>}
-                      </div>
-                    </TableCell>
-                    <TableCell>{node.last_heard ? new Date(node.last_heard).toLocaleString() : 'Never'}</TableCell>
-                    <TableCell>
-                      <div className="space-y-1">
-                        <div>
-                          {node.latest_device_metrics?.battery_level
-                            ? `${node.latest_device_metrics.battery_level}%`
-                            : '-'}
-                        </div>
-                        <div className="text-xs text-muted-foreground">
-                          {node.latest_device_metrics?.voltage
-                            ? `${node.latest_device_metrics.voltage.toFixed(2)}V`
-                            : '-'}
-                        </div>
-                        {node.latest_device_metrics?.reported_time && (
-                          <div className="text-xs text-muted-foreground">
-                            Updated: {new Date(node.latest_device_metrics.reported_time).toLocaleString()}
-                          </div>
-                        )}
-                      </div>
-                    </TableCell>
-                    <TableCell>
-                      {node.latest_position &&
-                      typeof node.latest_position.latitude === 'number' &&
-                      typeof node.latest_position.longitude === 'number' ? (
-                        <div className="space-y-1">
-                          <div>
-                            {node.latest_position.latitude.toFixed(6)}, {node.latest_position.longitude.toFixed(6)}
-                          </div>
-                          {node.latest_position.reported_time && (
-                            <div className="text-xs text-muted-foreground">
-                              Updated: {new Date(node.latest_position.reported_time).toLocaleString()}
-                            </div>
-                          )}
-                        </div>
-                      ) : (
-                        '-'
-                      )}
-                    </TableCell>
-                    <TableCell>
-                      <MeshWatchControls
-                        node={node}
-                        watch={watch}
-                        watchesQuery={watchesQuery}
-                        idPrefix={`my-nodes-${node.node_id}`}
-                      />
-                    </TableCell>
-                    <TableCell>
-                      <div className="flex gap-2">
-                        {!isManaged && (
-                          <Button
-                            onClick={() => handleRunAsManagedNode(node)}
-                            size="sm"
-                            variant="outline"
-                            className="flex items-center text-xs"
-                          >
-                            <Radio className="mr-1 h-3 w-3" />
-                            Convert
-                          </Button>
-                        )}
-                        <Button
-                          onClick={() => navigate(`/nodes/${node.node_id}`)}
-                          size="sm"
-                          variant="outline"
-                          className="flex items-center"
-                        >
-                          <Settings className="mr-2 h-4 w-4" />
-                          Details
-                        </Button>
-                        {isManaged && (
-                          <Button
-                            size="sm"
-                            variant="default"
-                            onClick={() => {
-                              setShowInstructionsNode(node);
-                              setInstructionsModalOpen(true);
-                            }}
-                          >
-                            Show Setup Instructions
-                          </Button>
-                        )}
-                      </div>
-                    </TableCell>
-                  </TableRow>
-                );
-              })}
-            </TableBody>
-          </Table>
-        </CardContent>
-      </Card>
-    );
-  };
-
-  // Setup Instructions Modal
   const renderInstructionsModal = () => {
     if (!showInstructionsNode) return null;
     const nodeApiKeys = apiKeys?.filter((key) => key.nodes.includes(showInstructionsNode.node_id)) || [];
@@ -286,7 +143,7 @@ function MyNodesContent() {
 
   return (
     <div className="container mx-auto p-4 space-y-6">
-      <div className="flex justify-between items-center">
+      <div className="flex justify-between items-center gap-4 flex-wrap">
         <h1 className="text-2xl font-bold">My Nodes</h1>
         <Button variant="outline" onClick={() => navigate('/user/nodes')} className="flex items-center">
           <Settings className="mr-2 h-4 w-4" />
@@ -310,11 +167,45 @@ function MyNodesContent() {
 
       {allNodes.length > 0 ? (
         <>
-          <div className="mb-6">
-            <h2 className="text-lg font-semibold mb-2">Nodes and Constellations</h2>
-            {/* Collapsible map section */}
-            <CollapsibleSection title="Nodes and Constellations" defaultOpen>
-              <div className="h-[600px] bg-background rounded-lg border">
+          <Card>
+            <CardHeader>
+              <CardTitle>Your nodes</CardTitle>
+              <CardDescription>
+                Claimed and managed radios in a compact layout. Open a node for full telemetry, position, and settings.
+              </CardDescription>
+            </CardHeader>
+            <CardContent>
+              <div className="grid grid-cols-1 sm:grid-cols-2 xl:grid-cols-3 gap-4">
+                {allNodes.map((node) => {
+                  const isManaged = managedNodeIds.has(node.node_id);
+                  const isClaimed = node.owner?.id !== undefined;
+                  const watch = watchesByNodeIdStr.get(node.node_id_str);
+                  return (
+                    <MyNodeCard
+                      key={node.node_id}
+                      node={node}
+                      isManaged={isManaged}
+                      isClaimed={isClaimed}
+                      watch={watch}
+                      watchesQuery={watchesQuery}
+                      onConvert={() => handleRunAsManagedNode(node)}
+                      onShowSetupInstructions={() => {
+                        setShowInstructionsNode(node);
+                        setInstructionsModalOpen(true);
+                      }}
+                    />
+                  );
+                })}
+              </div>
+            </CardContent>
+          </Card>
+
+          <section className="space-y-2" aria-labelledby="my-nodes-map-heading">
+            <h2 id="my-nodes-map-heading" className="text-lg font-semibold">
+              Constellation map
+            </h2>
+            <CollapsibleSection title="Map" defaultOpen={false}>
+              <div className="h-[min(600px,70vh)] min-h-[320px] bg-background rounded-lg border">
                 <NodesAndConstellationsMap
                   managedNodes={myManagedNodes}
                   observedNodes={myClaimedNodes}
@@ -323,19 +214,18 @@ function MyNodesContent() {
                 />
               </div>
             </CollapsibleSection>
-          </div>
-          <div className="mb-6">
-            <h2 className="text-lg font-semibold mb-2">Battery Levels</h2>
-            {/* Collapsible battery chart section */}
-            <CollapsibleSection title="Battery Levels" defaultOpen>
+          </section>
+
+          <section className="space-y-2" aria-labelledby="my-nodes-battery-heading">
+            <h2 id="my-nodes-battery-heading" className="text-lg font-semibold">
+              Battery trend
+            </h2>
+            <CollapsibleSection title="Battery chart" defaultOpen={false}>
               <div className="bg-background rounded-lg border">
                 <MonitoredNodesBatteryChart nodes={allNodes} />
               </div>
             </CollapsibleSection>
-          </div>
-          <div className="bg-background rounded-lg border">
-            <MyNodesTable />
-          </div>
+          </section>
         </>
       ) : (
         <Alert>
@@ -368,7 +258,6 @@ export function MyNodes() {
   );
 }
 
-// CollapsibleSection component (add at the bottom of the file)
 function CollapsibleSection({
   title,
   defaultOpen = false,
@@ -381,7 +270,7 @@ function CollapsibleSection({
   const [open, setOpen] = useState(defaultOpen);
   return (
     <div>
-      <Button variant="ghost" size="sm" onClick={() => setOpen((v) => !v)} className="mb-2">
+      <Button variant="ghost" size="sm" onClick={() => setOpen((v) => !v)} className="mb-2" aria-expanded={open}>
         {open ? 'Hide' : 'Show'} {title}
       </Button>
       {open && children}


### PR DESCRIPTION
## Summary

Replaces the wide multi-column **My Nodes** table with a **responsive card grid** so the page matches the rest of the app’s calmer density.

- New **`MyNodeCard`**: short/long name + mono node id, Managed/Claimed badges, **relative** last heard (`formatDistanceToNow`), **position hint** (No fix / Recent fix / Stale fix, 7-day cutoff) instead of inline coordinates, **`BatteryGauge`** with tooltip for metric age.
- **Primary action**: full-width **Node details** button linking to `/nodes/:id`.
- **Secondary actions**: kebab menu — **Convert to managed** (unmanaged only), **Setup instructions** (managed only).
- **Mesh monitoring**: same `MeshWatchControls` with **`compact`** in a footer strip (parity with Infrastructure cards).
- **Page hierarchy**: **Your nodes** card grid is **first**; constellation map and battery chart move **below** with clearer section titles; both stay **collapsed by default** so the list is the main path (no horizontal table scroll).

Closes #146

### Before / after (for reviewers)

- **Before**: dense table with many columns, raw timestamps, lat/long per row, multiple inline buttons.
- **After**: scannable cards, relative times, details on the node page; map/chart available via **Show Map** / **Show Battery chart**.

## Testing performed

- `npm run format`, `npm run lint`, `npm test`, `npm run build`
- Manual: keyboard focus on kebab and dropdown items; watch checkbox/labels unchanged