### PR TITLE
feat(nodes): mesh monitoring on node details + offline threshold (closes #148)

### DIFF
--- a/src/components/nodes/MeshWatchControls.tsx
+++ b/src/components/nodes/MeshWatchControls.tsx
@@ -107,7 +107,7 @@ export function MeshWatchControls({ node, watch, watchesQuery, idPrefix, compact
       disabled={createWatch.isPending}
       onClick={() =>
         createWatch.mutate(
-          { observed_node_id: String(node.internal_id), offline_after: 7200, enabled: true },
+          { observed_node_id: String(node.internal_id), enabled: true },
           {
             onError: (e) => toast.error(e instanceof Error ? e.message : 'Could not add watch'),
           }

--- a/src/components/nodes/MeshWatchControls.tsx
+++ b/src/components/nodes/MeshWatchControls.tsx
@@ -10,6 +10,8 @@ import {
   useDeleteNodeWatchMutation,
 } from '@/hooks/api/useNodeWatches';
 import type { UseQueryResult } from '@tanstack/react-query';
+import { authService } from '@/lib/auth/authService';
+import { userCanMeshWatchNode } from '@/lib/meshtastic';
 
 export interface MeshWatchControlsProps {
   node: ObservedNode;
@@ -37,6 +39,18 @@ export function MeshWatchControls({ node, watch, watchesQuery, idPrefix, compact
   }
   if (watchesQuery.isError) {
     return <span className="text-muted-foreground text-sm">—</span>;
+  }
+
+  const currentUser = authService.getCurrentUser();
+  const canAddWatch = userCanMeshWatchNode(node, currentUser?.id);
+
+  if (!watch && !canAddWatch) {
+    return (
+      <p className="text-sm text-muted-foreground max-w-md">
+        Watches are only available for nodes you have claimed or for shared infrastructure roles (router, repeater,
+        etc.).
+      </p>
+    );
   }
 
   if (watch) {

--- a/src/components/nodes/MetricsCard.tsx
+++ b/src/components/nodes/MetricsCard.tsx
@@ -1,3 +1,4 @@
+import type { ReactNode } from 'react';
 import { formatDistanceToNow } from 'date-fns';
 import { Card, CardContent, CardDescription, CardHeader, CardTitle } from '@/components/ui/card';
 
@@ -11,12 +12,14 @@ interface MetricsCardProps {
   title: string;
   reportedTime?: Date | string | null;
   metrics: MetricItem[];
+  /** Shown on the right of the title row (e.g. settings). */
+  headerActions?: ReactNode;
 }
 
 /**
  * Renders a Card with metric key-value pairs. Only displays metrics with non-null values.
  */
-export function MetricsCard({ title, reportedTime, metrics }: MetricsCardProps) {
+export function MetricsCard({ title, reportedTime, metrics, headerActions }: MetricsCardProps) {
   const validMetrics = metrics.filter((m) => m.value != null && m.value !== '');
   if (validMetrics.length === 0) {
     return null;
@@ -24,11 +27,14 @@ export function MetricsCard({ title, reportedTime, metrics }: MetricsCardProps) 
 
   return (
     <Card>
-      <CardHeader>
-        <CardTitle>{title}</CardTitle>
-        <CardDescription>
-          {reportedTime ? formatDistanceToNow(new Date(reportedTime), { addSuffix: true }) : '—'}
-        </CardDescription>
+      <CardHeader className={headerActions ? 'flex flex-row items-start justify-between gap-3 space-y-0' : undefined}>
+        <div className="min-w-0 flex-1 space-y-1.5">
+          <CardTitle>{title}</CardTitle>
+          <CardDescription>
+            {reportedTime ? formatDistanceToNow(new Date(reportedTime), { addSuffix: true }) : '—'}
+          </CardDescription>
+        </div>
+        {headerActions ? <div className="shrink-0 pt-0.5">{headerActions}</div> : null}
       </CardHeader>
       <CardContent>
         <div className="space-y-2">

--- a/src/components/nodes/NodeDetailContent.tsx
+++ b/src/components/nodes/NodeDetailContent.tsx
@@ -22,6 +22,7 @@ import { authService } from '@/lib/auth/authService';
 import { getRoleLabel } from '@/lib/meshtastic';
 import type { EnvironmentExposureSlug, WeatherUseSlug } from '@/lib/models';
 import { NodeEnvironmentSettingsDialog } from '@/components/nodes/NodeEnvironmentSettingsDialog';
+import { NodeMeshMonitoringSection } from '@/components/nodes/NodeMeshMonitoringSection';
 
 interface NodeDetailContentProps {
   nodeId: number;
@@ -452,6 +453,7 @@ export function NodeDetailContent({ nodeId, compact = false }: NodeDetailContent
 
       {!compact && (
         <>
+          <NodeMeshMonitoringSection node={node} />
           <TracerouteLinksSection nodeId={nodeId} />
           <NodeStatsSection nodeId={nodeId} node={node} isManagedNode={isManagedNode} />
         </>

--- a/src/components/nodes/NodeDetailContent.tsx
+++ b/src/components/nodes/NodeDetailContent.tsx
@@ -20,7 +20,7 @@ import { Badge } from '@/components/ui/badge';
 import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from '@/components/ui/select';
 import { authService } from '@/lib/auth/authService';
 import { getRoleLabel } from '@/lib/meshtastic';
-import type { EnvironmentExposureSlug, WeatherUseSlug } from '@/lib/models';
+import type { EnvironmentExposureSlug, LatestEnvironmentMetrics, WeatherUseSlug } from '@/lib/models';
 import { NodeEnvironmentSettingsDialog } from '@/components/nodes/NodeEnvironmentSettingsDialog';
 import { NodeMeshMonitoringSection } from '@/components/nodes/NodeMeshMonitoringSection';
 
@@ -31,6 +31,28 @@ interface NodeDetailContentProps {
 }
 
 type TracerouteTimeRange = '24h' | '7d' | '30d';
+
+/** True when the node has at least one environment *sensor* reading (not placement/weather alone). */
+function hasEnvironmentSensorMetrics(env: LatestEnvironmentMetrics | null | undefined): boolean {
+  if (!env) return false;
+  const keys: (keyof LatestEnvironmentMetrics)[] = [
+    'temperature',
+    'relative_humidity',
+    'barometric_pressure',
+    'gas_resistance',
+    'iaq',
+    'lux',
+    'wind_direction',
+    'wind_speed',
+    'radiation',
+    'rainfall_1h',
+    'rainfall_24h',
+  ];
+  return keys.some((k) => {
+    const v = env[k];
+    return v != null;
+  });
+}
 
 function TracerouteLinksSection({ nodeId }: { nodeId: number }) {
   const [timeRange, setTimeRange] = useState<TracerouteTimeRange>('7d');
@@ -182,26 +204,6 @@ export function NodeDetailContent({ nodeId, compact = false }: NodeDetailContent
           )}
         </div>
         <div className="flex flex-shrink-0 items-start gap-2">
-          {node.environment_settings_editable && (
-            <>
-              <Button
-                type="button"
-                variant="outline"
-                size="icon"
-                aria-label="Node settings"
-                onClick={() => setSettingsOpen(true)}
-              >
-                <Settings className="h-4 w-4" />
-              </Button>
-              <NodeEnvironmentSettingsDialog
-                open={settingsOpen}
-                onOpenChange={setSettingsOpen}
-                nodeId={nodeId}
-                initialEnvironmentExposure={(node.environment_exposure ?? 'unknown') as EnvironmentExposureSlug}
-                initialWeatherUse={(node.weather_use ?? 'unknown') as WeatherUseSlug}
-              />
-            </>
-          )}
           {(!node.owner || hasPendingClaim) && (
             <Link
               to={`/nodes/${nodeId}/claim`}
@@ -337,38 +339,62 @@ export function NodeDetailContent({ nodeId, compact = false }: NodeDetailContent
           </Card>
         )}
 
-        {(node.latest_environment_metrics || node.environment_exposure != null || node.weather_use != null) && (
-          <MetricsCard
-            title="Environment Metrics"
-            reportedTime={node.latest_environment_metrics?.reported_time}
-            metrics={[
-              { label: 'Sensor placement', value: node.environment_exposure },
-              { label: 'Use for weather', value: node.weather_use },
-              ...(node.latest_environment_metrics
-                ? [
-                    { label: 'Temperature', value: node.latest_environment_metrics.temperature, unit: '°C' },
-                    {
-                      label: 'Relative Humidity',
-                      value: node.latest_environment_metrics.relative_humidity,
-                      unit: '%',
-                    },
-                    {
-                      label: 'Barometric Pressure',
-                      value: node.latest_environment_metrics.barometric_pressure,
-                      unit: 'hPa',
-                    },
-                    { label: 'Gas Resistance', value: node.latest_environment_metrics.gas_resistance, unit: 'Ω' },
-                    { label: 'IAQ', value: node.latest_environment_metrics.iaq },
-                    { label: 'Lux', value: node.latest_environment_metrics.lux, unit: 'lx' },
-                    { label: 'Wind Direction', value: node.latest_environment_metrics.wind_direction, unit: '°' },
-                    { label: 'Wind Speed', value: node.latest_environment_metrics.wind_speed, unit: 'm/s' },
-                    { label: 'Radiation', value: node.latest_environment_metrics.radiation },
-                    { label: 'Rainfall 1h', value: node.latest_environment_metrics.rainfall_1h, unit: 'mm' },
-                    { label: 'Rainfall 24h', value: node.latest_environment_metrics.rainfall_24h, unit: 'mm' },
-                  ]
-                : []),
-            ]}
-          />
+        {hasEnvironmentSensorMetrics(node.latest_environment_metrics) && (
+          <>
+            <MetricsCard
+              title="Environment Metrics"
+              reportedTime={node.latest_environment_metrics?.reported_time}
+              headerActions={
+                node.environment_settings_editable ? (
+                  <Button
+                    type="button"
+                    variant="outline"
+                    size="icon"
+                    aria-label="Environment metrics settings"
+                    onClick={() => setSettingsOpen(true)}
+                  >
+                    <Settings className="h-4 w-4" />
+                  </Button>
+                ) : undefined
+              }
+              metrics={[
+                { label: 'Sensor placement', value: node.environment_exposure },
+                { label: 'Use for weather', value: node.weather_use },
+                ...(node.latest_environment_metrics
+                  ? [
+                      { label: 'Temperature', value: node.latest_environment_metrics.temperature, unit: '°C' },
+                      {
+                        label: 'Relative Humidity',
+                        value: node.latest_environment_metrics.relative_humidity,
+                        unit: '%',
+                      },
+                      {
+                        label: 'Barometric Pressure',
+                        value: node.latest_environment_metrics.barometric_pressure,
+                        unit: 'hPa',
+                      },
+                      { label: 'Gas Resistance', value: node.latest_environment_metrics.gas_resistance, unit: 'Ω' },
+                      { label: 'IAQ', value: node.latest_environment_metrics.iaq },
+                      { label: 'Lux', value: node.latest_environment_metrics.lux, unit: 'lx' },
+                      { label: 'Wind Direction', value: node.latest_environment_metrics.wind_direction, unit: '°' },
+                      { label: 'Wind Speed', value: node.latest_environment_metrics.wind_speed, unit: 'm/s' },
+                      { label: 'Radiation', value: node.latest_environment_metrics.radiation },
+                      { label: 'Rainfall 1h', value: node.latest_environment_metrics.rainfall_1h, unit: 'mm' },
+                      { label: 'Rainfall 24h', value: node.latest_environment_metrics.rainfall_24h, unit: 'mm' },
+                    ]
+                  : []),
+              ]}
+            />
+            {node.environment_settings_editable && (
+              <NodeEnvironmentSettingsDialog
+                open={settingsOpen}
+                onOpenChange={setSettingsOpen}
+                nodeId={nodeId}
+                initialEnvironmentExposure={(node.environment_exposure ?? 'unknown') as EnvironmentExposureSlug}
+                initialWeatherUse={(node.weather_use ?? 'unknown') as WeatherUseSlug}
+              />
+            )}
+          </>
         )}
 
         {node.latest_power_metrics &&

--- a/src/components/nodes/NodeMeshMonitoringSection.tsx
+++ b/src/components/nodes/NodeMeshMonitoringSection.tsx
@@ -1,30 +1,25 @@
+import { useState } from 'react';
 import { MeshWatchControls } from '@/components/nodes/MeshWatchControls';
-import {
-  useMonitoringOfflineAfter,
-  useNodeWatches,
-  usePatchMonitoringOfflineAfterMutation,
-} from '@/hooks/api/useNodeWatches';
+import { NodeMeshMonitoringSettingsDialog } from '@/components/nodes/NodeMeshMonitoringSettingsDialog';
+import { useMonitoringOfflineAfter, useNodeWatches } from '@/hooks/api/useNodeWatches';
 import type { ObservedNode } from '@/lib/models';
 import { authService } from '@/lib/auth/authService';
 import { Card, CardContent, CardDescription, CardHeader, CardTitle } from '@/components/ui/card';
-import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from '@/components/ui/select';
-import { Loader2 } from 'lucide-react';
-import { toast } from 'sonner';
+import { Button } from '@/components/ui/button';
+import { Loader2, Settings } from 'lucide-react';
 
-const SILENCE_PRESETS: { label: string; seconds: number }[] = [
-  { label: '1 hour', seconds: 3600 },
-  { label: '2 hours', seconds: 7200 },
-  { label: '6 hours', seconds: 21600 },
-  { label: '12 hours', seconds: 43200 },
-  { label: '24 hours', seconds: 86400 },
-];
+function formatSilenceSummary(seconds: number): string {
+  if (seconds % 3600 === 0) return `${seconds / 3600} hour${seconds === 3600 ? '' : 's'}`;
+  if (seconds % 60 === 0) return `${seconds / 60} minutes`;
+  return `${seconds.toLocaleString()} seconds`;
+}
 
 export function NodeMeshMonitoringSection({ node }: { node: ObservedNode }) {
   const currentUser = authService.getCurrentUser();
   const watchesQuery = useNodeWatches();
   const observedUuid = String(node.internal_id);
   const offlineAfterQuery = useMonitoringOfflineAfter(observedUuid, Boolean(currentUser));
-  const patchOfflineAfter = usePatchMonitoringOfflineAfterMutation();
+  const [settingsOpen, setSettingsOpen] = useState(false);
 
   const watch = watchesQuery.data?.results.find((w) => w.observed_node.node_id_str === node.node_id_str);
 
@@ -33,24 +28,33 @@ export function NodeMeshMonitoringSection({ node }: { node: ObservedNode }) {
   }
 
   const currentSeconds = offlineAfterQuery.data?.offline_after;
-  const editable = offlineAfterQuery.data?.editable ?? false;
-  const presetValues = new Set(SILENCE_PRESETS.map((p) => p.seconds));
-  const selectValue =
-    currentSeconds != null
-      ? presetValues.has(currentSeconds)
-        ? String(currentSeconds)
-        : `custom:${currentSeconds}`
-      : '';
+  const canEditThreshold = offlineAfterQuery.data?.editable ?? false;
 
   return (
     <div className="mb-6">
       <Card>
-        <CardHeader>
-          <CardTitle>Mesh monitoring</CardTitle>
-          <CardDescription>
-            Get alerts when this node is quiet long enough that we run a verification traceroute round, then confirm
-            offline if the mesh still cannot reach it. Discord notifications use your linked account settings.
-          </CardDescription>
+        <CardHeader className="space-y-0">
+          <div className="flex flex-row items-start justify-between gap-2">
+            <div className="min-w-0 flex-1">
+              <CardTitle>Mesh monitoring</CardTitle>
+              <CardDescription>
+                Get alerts when this node is quiet long enough that we run a verification traceroute round, then confirm
+                offline if the mesh still cannot reach it. Discord notifications use your linked account settings.
+              </CardDescription>
+            </div>
+            {canEditThreshold && (
+              <Button
+                type="button"
+                variant="outline"
+                size="icon"
+                className="shrink-0"
+                aria-label="Mesh monitoring settings"
+                onClick={() => setSettingsOpen(true)}
+              >
+                <Settings className="h-4 w-4" />
+              </Button>
+            )}
+          </div>
         </CardHeader>
         <CardContent className="space-y-6">
           <div>
@@ -63,12 +67,8 @@ export function NodeMeshMonitoringSection({ node }: { node: ObservedNode }) {
             />
           </div>
 
-          <div className="space-y-2">
+          <div className="space-y-1">
             <h3 className="text-sm font-medium text-foreground">Silence before verification</h3>
-            <p className="text-sm text-muted-foreground">
-              Consider the node silent if there are no packets for this long (based on last heard). Then monitoring may
-              start a verification traceroute round.
-            </p>
             {offlineAfterQuery.isLoading && (
               <div className="flex items-center gap-2 text-muted-foreground text-sm">
                 <Loader2 className="h-4 w-4 animate-spin" aria-hidden />
@@ -79,50 +79,23 @@ export function NodeMeshMonitoringSection({ node }: { node: ObservedNode }) {
               <p className="text-sm text-muted-foreground">Could not load silence threshold.</p>
             )}
             {!offlineAfterQuery.isLoading && !offlineAfterQuery.isError && currentSeconds != null && (
-              <>
-                {editable ? (
-                  <Select
-                    value={selectValue}
-                    disabled={patchOfflineAfter.isPending}
-                    onValueChange={(v) => {
-                      const sec = v.startsWith('custom:') ? parseInt(v.slice('custom:'.length), 10) : parseInt(v, 10);
-                      if (!Number.isFinite(sec) || sec < 1) return;
-                      patchOfflineAfter.mutate(
-                        { observedNodeId: observedUuid, offline_after: sec, nodeId: node.node_id },
-                        {
-                          onError: (e) =>
-                            toast.error(e instanceof Error ? e.message : 'Could not update silence threshold'),
-                        }
-                      );
-                    }}
-                  >
-                    <SelectTrigger className="max-w-xs">
-                      <SelectValue placeholder="Choose duration" />
-                    </SelectTrigger>
-                    <SelectContent>
-                      {SILENCE_PRESETS.map((p) => (
-                        <SelectItem key={p.seconds} value={String(p.seconds)}>
-                          {p.label} ({p.seconds.toLocaleString()}s)
-                        </SelectItem>
-                      ))}
-                      {currentSeconds != null && !presetValues.has(currentSeconds) && (
-                        <SelectItem value={`custom:${currentSeconds}`}>
-                          Current: {currentSeconds.toLocaleString()}s
-                        </SelectItem>
-                      )}
-                    </SelectContent>
-                  </Select>
-                ) : (
-                  <p className="text-sm text-muted-foreground">
-                    Threshold: {currentSeconds.toLocaleString()} seconds (only the claim owner or staff can change
-                    this.)
-                  </p>
-                )}
-              </>
+              <p className="text-sm text-muted-foreground">
+                Current threshold:{' '}
+                <span className="text-foreground font-medium">{formatSilenceSummary(currentSeconds)}</span> (
+                {currentSeconds.toLocaleString()}s).
+                {canEditThreshold ? ' Use the settings button above to change it.' : ''}
+              </p>
             )}
           </div>
         </CardContent>
       </Card>
+
+      <NodeMeshMonitoringSettingsDialog
+        open={settingsOpen}
+        onOpenChange={setSettingsOpen}
+        observedNodeId={observedUuid}
+        nodeId={node.node_id}
+      />
     </div>
   );
 }

--- a/src/components/nodes/NodeMeshMonitoringSection.tsx
+++ b/src/components/nodes/NodeMeshMonitoringSection.tsx
@@ -1,0 +1,128 @@
+import { MeshWatchControls } from '@/components/nodes/MeshWatchControls';
+import {
+  useMonitoringOfflineAfter,
+  useNodeWatches,
+  usePatchMonitoringOfflineAfterMutation,
+} from '@/hooks/api/useNodeWatches';
+import type { ObservedNode } from '@/lib/models';
+import { authService } from '@/lib/auth/authService';
+import { Card, CardContent, CardDescription, CardHeader, CardTitle } from '@/components/ui/card';
+import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from '@/components/ui/select';
+import { Loader2 } from 'lucide-react';
+import { toast } from 'sonner';
+
+const SILENCE_PRESETS: { label: string; seconds: number }[] = [
+  { label: '1 hour', seconds: 3600 },
+  { label: '2 hours', seconds: 7200 },
+  { label: '6 hours', seconds: 21600 },
+  { label: '12 hours', seconds: 43200 },
+  { label: '24 hours', seconds: 86400 },
+];
+
+export function NodeMeshMonitoringSection({ node }: { node: ObservedNode }) {
+  const currentUser = authService.getCurrentUser();
+  const watchesQuery = useNodeWatches();
+  const observedUuid = String(node.internal_id);
+  const offlineAfterQuery = useMonitoringOfflineAfter(observedUuid, Boolean(currentUser));
+  const patchOfflineAfter = usePatchMonitoringOfflineAfterMutation();
+
+  const watch = watchesQuery.data?.results.find((w) => w.observed_node.node_id_str === node.node_id_str);
+
+  if (!currentUser) {
+    return null;
+  }
+
+  const currentSeconds = offlineAfterQuery.data?.offline_after;
+  const editable = offlineAfterQuery.data?.editable ?? false;
+  const presetValues = new Set(SILENCE_PRESETS.map((p) => p.seconds));
+  const selectValue =
+    currentSeconds != null
+      ? presetValues.has(currentSeconds)
+        ? String(currentSeconds)
+        : `custom:${currentSeconds}`
+      : '';
+
+  return (
+    <div className="mb-6">
+      <Card>
+        <CardHeader>
+          <CardTitle>Mesh monitoring</CardTitle>
+          <CardDescription>
+            Get alerts when this node is quiet long enough that we run a verification traceroute round, then confirm
+            offline if the mesh still cannot reach it. Discord notifications use your linked account settings.
+          </CardDescription>
+        </CardHeader>
+        <CardContent className="space-y-6">
+          <div>
+            <h3 className="text-sm font-medium text-foreground mb-2">Your watch</h3>
+            <MeshWatchControls
+              node={node}
+              watch={watch}
+              watchesQuery={watchesQuery}
+              idPrefix={`detail-${node.node_id}`}
+            />
+          </div>
+
+          <div className="space-y-2">
+            <h3 className="text-sm font-medium text-foreground">Silence before verification</h3>
+            <p className="text-sm text-muted-foreground">
+              Consider the node silent if there are no packets for this long (based on last heard). Then monitoring may
+              start a verification traceroute round.
+            </p>
+            {offlineAfterQuery.isLoading && (
+              <div className="flex items-center gap-2 text-muted-foreground text-sm">
+                <Loader2 className="h-4 w-4 animate-spin" aria-hidden />
+                Loading threshold…
+              </div>
+            )}
+            {offlineAfterQuery.isError && (
+              <p className="text-sm text-muted-foreground">Could not load silence threshold.</p>
+            )}
+            {!offlineAfterQuery.isLoading && !offlineAfterQuery.isError && currentSeconds != null && (
+              <>
+                {editable ? (
+                  <Select
+                    value={selectValue}
+                    disabled={patchOfflineAfter.isPending}
+                    onValueChange={(v) => {
+                      const sec = v.startsWith('custom:') ? parseInt(v.slice('custom:'.length), 10) : parseInt(v, 10);
+                      if (!Number.isFinite(sec) || sec < 1) return;
+                      patchOfflineAfter.mutate(
+                        { observedNodeId: observedUuid, offline_after: sec, nodeId: node.node_id },
+                        {
+                          onError: (e) =>
+                            toast.error(e instanceof Error ? e.message : 'Could not update silence threshold'),
+                        }
+                      );
+                    }}
+                  >
+                    <SelectTrigger className="max-w-xs">
+                      <SelectValue placeholder="Choose duration" />
+                    </SelectTrigger>
+                    <SelectContent>
+                      {SILENCE_PRESETS.map((p) => (
+                        <SelectItem key={p.seconds} value={String(p.seconds)}>
+                          {p.label} ({p.seconds.toLocaleString()}s)
+                        </SelectItem>
+                      ))}
+                      {currentSeconds != null && !presetValues.has(currentSeconds) && (
+                        <SelectItem value={`custom:${currentSeconds}`}>
+                          Current: {currentSeconds.toLocaleString()}s
+                        </SelectItem>
+                      )}
+                    </SelectContent>
+                  </Select>
+                ) : (
+                  <p className="text-sm text-muted-foreground">
+                    Threshold: {currentSeconds.toLocaleString()} seconds (only the claim owner or staff can change
+                    this.)
+                  </p>
+                )}
+              </>
+            )}
+          </div>
+        </CardContent>
+      </Card>
+    </div>
+  );
+}

--- a/src/components/nodes/NodeMeshMonitoringSection.tsx
+++ b/src/components/nodes/NodeMeshMonitoringSection.tsx
@@ -7,12 +7,7 @@ import { authService } from '@/lib/auth/authService';
 import { Card, CardContent, CardDescription, CardHeader, CardTitle } from '@/components/ui/card';
 import { Button } from '@/components/ui/button';
 import { Loader2, Settings } from 'lucide-react';
-
-function formatSilenceSummary(seconds: number): string {
-  if (seconds % 3600 === 0) return `${seconds / 3600} hour${seconds === 3600 ? '' : 's'}`;
-  if (seconds % 60 === 0) return `${seconds / 60} minutes`;
-  return `${seconds.toLocaleString()} seconds`;
-}
+import { formatUptimeSeconds } from '@/lib/utils';
 
 export function NodeMeshMonitoringSection({ node }: { node: ObservedNode }) {
   const currentUser = authService.getCurrentUser();
@@ -80,9 +75,8 @@ export function NodeMeshMonitoringSection({ node }: { node: ObservedNode }) {
             )}
             {!offlineAfterQuery.isLoading && !offlineAfterQuery.isError && currentSeconds != null && (
               <p className="text-sm text-muted-foreground">
-                Current threshold:{' '}
-                <span className="text-foreground font-medium">{formatSilenceSummary(currentSeconds)}</span> (
-                {currentSeconds.toLocaleString()}s).
+                Current silence before verification:{' '}
+                <span className="text-foreground font-medium">{formatUptimeSeconds(currentSeconds)}</span>.
                 {canEditThreshold ? ' Use the settings button above to change it.' : ''}
               </p>
             )}

--- a/src/components/nodes/NodeMeshMonitoringSettingsDialog.tsx
+++ b/src/components/nodes/NodeMeshMonitoringSettingsDialog.tsx
@@ -1,0 +1,130 @@
+import { useEffect, useState } from 'react';
+import { toast } from 'sonner';
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
+} from '@/components/ui/dialog';
+import { Button } from '@/components/ui/button';
+import { Label } from '@/components/ui/label';
+import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from '@/components/ui/select';
+import { useMonitoringOfflineAfter, usePatchMonitoringOfflineAfterMutation } from '@/hooks/api/useNodeWatches';
+import { Loader2 } from 'lucide-react';
+
+const SILENCE_PRESETS: { label: string; seconds: number }[] = [
+  { label: '1 hour', seconds: 3600 },
+  { label: '2 hours', seconds: 7200 },
+  { label: '6 hours', seconds: 21600 },
+  { label: '12 hours', seconds: 43200 },
+  { label: '24 hours', seconds: 86400 },
+];
+
+export interface NodeMeshMonitoringSettingsDialogProps {
+  open: boolean;
+  onOpenChange: (open: boolean) => void;
+  observedNodeId: string;
+  nodeId: number;
+}
+
+/**
+ * Admin-style silence threshold (NodePresence.offline_after). Parent should only open when the user can edit
+ * (API `editable: true`); PATCH still enforces permissions server-side.
+ */
+export function NodeMeshMonitoringSettingsDialog({
+  open,
+  onOpenChange,
+  observedNodeId,
+  nodeId,
+}: NodeMeshMonitoringSettingsDialogProps) {
+  const offlineAfterQuery = useMonitoringOfflineAfter(observedNodeId, open);
+  const patchOfflineAfter = usePatchMonitoringOfflineAfterMutation();
+  const [seconds, setSeconds] = useState(21600);
+
+  useEffect(() => {
+    if (open && offlineAfterQuery.data?.offline_after != null) {
+      setSeconds(offlineAfterQuery.data.offline_after);
+    }
+  }, [open, offlineAfterQuery.data?.offline_after]);
+
+  const presetValues = new Set(SILENCE_PRESETS.map((p) => p.seconds));
+  const selectValue = presetValues.has(seconds) ? String(seconds) : `custom:${seconds}`;
+  const initialSeconds = offlineAfterQuery.data?.offline_after;
+  const unchanged = initialSeconds != null && seconds === initialSeconds;
+
+  const handleSave = () => {
+    patchOfflineAfter.mutate(
+      { observedNodeId, offline_after: seconds, nodeId },
+      {
+        onSuccess: () => {
+          toast.success('Silence threshold saved');
+          onOpenChange(false);
+        },
+        onError: (e) => toast.error(e instanceof Error ? e.message : 'Could not save threshold'),
+      }
+    );
+  };
+
+  return (
+    <Dialog open={open} onOpenChange={onOpenChange}>
+      <DialogContent className="sm:max-w-md">
+        <DialogHeader>
+          <DialogTitle>Mesh monitoring settings</DialogTitle>
+          <DialogDescription>
+            Silence before verification: how long the node can go without packets (last heard) before monitoring may
+            start a verification traceroute round. Claim owners and staff can change this value.
+          </DialogDescription>
+        </DialogHeader>
+        {offlineAfterQuery.isLoading && (
+          <div className="flex items-center gap-2 py-6 text-muted-foreground text-sm">
+            <Loader2 className="h-4 w-4 animate-spin" aria-hidden />
+            Loading…
+          </div>
+        )}
+        {offlineAfterQuery.isError && (
+          <p className="text-sm text-destructive py-4">Could not load monitoring settings.</p>
+        )}
+        {!offlineAfterQuery.isLoading && !offlineAfterQuery.isError && offlineAfterQuery.data?.editable && (
+          <div className="grid gap-4 py-2">
+            <div className="grid gap-2">
+              <Label htmlFor="mesh-offline-after-trigger">Silence before verification</Label>
+              <Select
+                value={selectValue}
+                onValueChange={(v) => {
+                  const sec = v.startsWith('custom:') ? parseInt(v.slice('custom:'.length), 10) : parseInt(v, 10);
+                  if (Number.isFinite(sec) && sec >= 1) setSeconds(sec);
+                }}
+              >
+                <SelectTrigger id="mesh-offline-after-trigger">
+                  <SelectValue />
+                </SelectTrigger>
+                <SelectContent>
+                  {SILENCE_PRESETS.map((p) => (
+                    <SelectItem key={p.seconds} value={String(p.seconds)}>
+                      {p.label} ({p.seconds.toLocaleString()}s)
+                    </SelectItem>
+                  ))}
+                  {!presetValues.has(seconds) && (
+                    <SelectItem value={`custom:${seconds}`}>Current: {seconds.toLocaleString()}s</SelectItem>
+                  )}
+                </SelectContent>
+              </Select>
+            </div>
+          </div>
+        )}
+        <DialogFooter>
+          <Button type="button" variant="outline" onClick={() => onOpenChange(false)}>
+            Cancel
+          </Button>
+          {offlineAfterQuery.data?.editable && (
+            <Button type="button" onClick={handleSave} disabled={patchOfflineAfter.isPending || unchanged}>
+              {patchOfflineAfter.isPending ? 'Saving…' : 'Save'}
+            </Button>
+          )}
+        </DialogFooter>
+      </DialogContent>
+    </Dialog>
+  );
+}

--- a/src/components/nodes/NodeMeshMonitoringSettingsDialog.tsx
+++ b/src/components/nodes/NodeMeshMonitoringSettingsDialog.tsx
@@ -12,6 +12,7 @@ import { Button } from '@/components/ui/button';
 import { Label } from '@/components/ui/label';
 import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from '@/components/ui/select';
 import { useMonitoringOfflineAfter, usePatchMonitoringOfflineAfterMutation } from '@/hooks/api/useNodeWatches';
+import { formatUptimeSeconds } from '@/lib/utils';
 import { Loader2 } from 'lucide-react';
 
 const SILENCE_PRESETS: { label: string; seconds: number }[] = [
@@ -103,11 +104,11 @@ export function NodeMeshMonitoringSettingsDialog({
                 <SelectContent>
                   {SILENCE_PRESETS.map((p) => (
                     <SelectItem key={p.seconds} value={String(p.seconds)}>
-                      {p.label} ({p.seconds.toLocaleString()}s)
+                      {p.label}
                     </SelectItem>
                   ))}
                   {!presetValues.has(seconds) && (
-                    <SelectItem value={`custom:${seconds}`}>Current: {seconds.toLocaleString()}s</SelectItem>
+                    <SelectItem value={`custom:${seconds}`}>Current: {formatUptimeSeconds(seconds)}</SelectItem>
                   )}
                 </SelectContent>
               </Select>

--- a/src/hooks/api/useNodeWatches.ts
+++ b/src/hooks/api/useNodeWatches.ts
@@ -1,8 +1,11 @@
 import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query';
 import { useMeshtasticApi } from './useApi';
-import type { NodeWatch, PaginatedResponse } from '@/lib/models';
+import type { MonitoringOfflineAfterResponse, NodeWatch, PaginatedResponse } from '@/lib/models';
 
 const watchesKey = ['monitoring', 'watches'] as const;
+
+export const monitoringOfflineAfterQueryKey = (observedNodeId: string) =>
+  ['monitoring', 'offline-after', observedNodeId] as const;
 
 function mergeWatchIntoWatchesCache(
   old: PaginatedResponse<NodeWatch> | undefined,
@@ -44,12 +47,43 @@ export function useNodeWatches(pageSize = 500) {
   });
 }
 
+export function useMonitoringOfflineAfter(observedNodeId: string | undefined, enabled = true) {
+  const api = useMeshtasticApi();
+  return useQuery<MonitoringOfflineAfterResponse>({
+    queryKey: monitoringOfflineAfterQueryKey(observedNodeId ?? ''),
+    queryFn: () => api.getMonitoringOfflineAfter(observedNodeId!),
+    enabled: Boolean(enabled && observedNodeId),
+  });
+}
+
+export function usePatchMonitoringOfflineAfterMutation() {
+  const api = useMeshtasticApi();
+  const queryClient = useQueryClient();
+  return useMutation({
+    mutationFn: ({
+      observedNodeId,
+      offline_after,
+    }: {
+      observedNodeId: string;
+      offline_after: number;
+      /** When set, invalidates single-node detail cache after threshold change. */
+      nodeId?: number;
+    }) => api.patchMonitoringOfflineAfter(observedNodeId, { offline_after }),
+    onSuccess: (data, variables) => {
+      queryClient.setQueryData(monitoringOfflineAfterQueryKey(variables.observedNodeId), data);
+      queryClient.invalidateQueries({ queryKey: watchesKey });
+      if (variables.nodeId != null) {
+        queryClient.invalidateQueries({ queryKey: ['nodes', variables.nodeId] });
+      }
+    },
+  });
+}
+
 export function useCreateNodeWatchMutation() {
   const api = useMeshtasticApi();
   const queryClient = useQueryClient();
   return useMutation({
-    mutationFn: (body: { observed_node_id: string; offline_after?: number; enabled?: boolean }) =>
-      api.createNodeWatch(body),
+    mutationFn: (body: { observed_node_id: string; enabled?: boolean }) => api.createNodeWatch(body),
     onSuccess: (newWatch) => {
       queryClient.setQueriesData<PaginatedResponse<NodeWatch>>({ queryKey: watchesKey }, (old) =>
         mergeWatchIntoWatchesCache(old, newWatch)
@@ -64,8 +98,7 @@ export function usePatchNodeWatchMutation() {
   const api = useMeshtasticApi();
   const queryClient = useQueryClient();
   return useMutation({
-    mutationFn: ({ id, ...body }: { id: number; offline_after?: number; enabled?: boolean }) =>
-      api.patchNodeWatch(id, body),
+    mutationFn: ({ id, ...body }: { id: number; enabled?: boolean }) => api.patchNodeWatch(id, body),
     onSuccess: (updated) => {
       queryClient.setQueriesData<PaginatedResponse<NodeWatch>>({ queryKey: watchesKey }, (old) =>
         mergeWatchIntoWatchesCache(old, updated)

--- a/src/lib/api/meshtastic-api.ts
+++ b/src/lib/api/meshtastic-api.ts
@@ -23,6 +23,7 @@ import {
   AutoTraceRoute,
   DiscordNotificationPrefs,
   NodeWatch,
+  MonitoringOfflineAfterResponse,
 } from '../models';
 import {
   ApiConfig,
@@ -807,19 +808,26 @@ export class MeshtasticApi extends BaseApi {
     return this.get<PaginatedResponse<NodeWatch>>('/monitoring/watches/', searchParams);
   }
 
-  async createNodeWatch(body: {
-    observed_node_id: string;
-    offline_after?: number;
-    enabled?: boolean;
-  }): Promise<NodeWatch> {
+  async createNodeWatch(body: { observed_node_id: string; enabled?: boolean }): Promise<NodeWatch> {
     return this.post<NodeWatch>('/monitoring/watches/', body);
   }
 
-  async patchNodeWatch(id: number, body: { offline_after?: number; enabled?: boolean }): Promise<NodeWatch> {
+  async patchNodeWatch(id: number, body: { enabled?: boolean }): Promise<NodeWatch> {
     return this.patch<NodeWatch>(`/monitoring/watches/${id}/`, body);
   }
 
   async deleteNodeWatch(id: number): Promise<void> {
     await this.delete<unknown>(`/monitoring/watches/${id}/`);
+  }
+
+  async getMonitoringOfflineAfter(observedNodeId: string): Promise<MonitoringOfflineAfterResponse> {
+    return this.get<MonitoringOfflineAfterResponse>(`/monitoring/nodes/${observedNodeId}/offline-after/`);
+  }
+
+  async patchMonitoringOfflineAfter(
+    observedNodeId: string,
+    body: { offline_after: number }
+  ): Promise<MonitoringOfflineAfterResponse> {
+    return this.patch<MonitoringOfflineAfterResponse>(`/monitoring/nodes/${observedNodeId}/offline-after/`, body);
   }
 }

--- a/src/lib/meshtastic.ts
+++ b/src/lib/meshtastic.ts
@@ -2,6 +2,23 @@
  * Meshtastic role IDs and labels.
  * @see https://meshtastic.org/docs/development/protobufs/api/#radioconfig-userpreferences
  */
+/**
+ * Integer role values that may be watched by any authenticated user (shared infrastructure).
+ * Keep in sync with meshflow-api `nodes.constants.INFRASTRUCTURE_ROLES` / `RoleSource`.
+ */
+export const INFRASTRUCTURE_ROLE_IDS: ReadonlySet<number> = new Set([2, 3, 4, 11]); // ROUTER, ROUTER_CLIENT, REPEATER, ROUTER_LATE
+
+/** Matches mesh monitoring `user_can_watch` for UI gating (claim owner or infra role). */
+export function userCanMeshWatchNode(
+  node: { role?: number | null; owner?: { id: number } | null },
+  currentUserId: number | null | undefined
+): boolean {
+  if (currentUserId == null) return false;
+  if (node.owner?.id === currentUserId) return true;
+  if (node.role != null && INFRASTRUCTURE_ROLE_IDS.has(node.role)) return true;
+  return false;
+}
+
 export const ROLE_LABELS: Record<number, string> = {
   0: 'CLIENT',
   1: 'CLIENT_MUTE',

--- a/src/lib/models.ts
+++ b/src/lib/models.ts
@@ -428,8 +428,16 @@ export interface ObservedNodeWatchSummary {
   node_id_str: string;
   long_name: string | null;
   last_heard: string | null;
+  /** Node-level silence threshold (seconds); same as NodeWatch.offline_after on responses. */
+  offline_after?: number;
   monitoring_verification_started_at?: string | null;
   monitoring_offline_confirmed_at?: string | null;
+}
+
+/** GET/PATCH `/api/monitoring/nodes/{internal_id}/offline-after/` */
+export interface MonitoringOfflineAfterResponse {
+  offline_after: number;
+  editable: boolean;
 }
 
 /** User watch on an observed node (`GET/POST /monitoring/watches/`). */


### PR DESCRIPTION
## Summary

Implements [UI #148](https://github.com/pskillen/meshtastic-bot-ui/issues/148): **Mesh monitoring** on full **Node Details** (watch controls, silence-before-verification copy, and offline threshold via a settings dialog on the monitoring card when the user can edit).

**API contract:** watch create/patch no longer sends **`offline_after`**. Threshold is read/updated with **`GET/PATCH /api/monitoring/nodes/{internal_id}/offline-after/`**.

**Also on this branch:**
- **Add watch** is shown only when the current user may mesh-watch the node (claimed owner path + infrastructure role list aligned with the API). Otherwise the section explains why adding a watch is not available.
- **Silence / preset durations** use the same humanized duration style as elsewhere (e.g. “6h”, “1d”) in the monitoring section and preset labels.
- **Environment metrics:** placement/weather settings (**cog**) moved from the page header into the **Environment Metrics** card header. The entire Environment Metrics block is **hidden** unless `latest_environment_metrics` includes at least one real sensor value (temperature, humidity, pressure, etc.); placement/weather alone no longer shows an empty-looking card.
- **`MetricsCard`** supports an optional **`headerActions`** slot for title-row controls.

## API dependency

Requires meshflow-api PR (deploy API first): https://github.com/pskillen/meshflow-api/pull/170

Closes #148

## Testing performed

- `npm run format`, `npm run build`
- Pre-commit `npm test` (Vitest)