### PR TITLE
feat(nodes): show traceroute history and trigger on Node Details

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -79,3 +79,7 @@ npm test             # Vitest
 
 When asked to create a pull request description, follow the template at
 .github/pull_request_template.md, and output a markdown file named `tmp/PR.md`
+
+## Plan mode
+
+When creating a plan, Include that we should branch from the latest origin/main, do the work, commit, push, and open a PR. Use the github-personal MCP. the gh command is not available.

--- a/src/components/nodes/NodeDetailContent.tsx
+++ b/src/components/nodes/NodeDetailContent.tsx
@@ -13,7 +13,7 @@ import { BatteryGauge } from '@/components/nodes/BatteryGauge';
 import { MetricsCard } from '@/components/nodes/MetricsCard';
 import { PercentGauge } from '@/components/nodes/PercentGauge';
 import { Card, CardHeader, CardTitle, CardContent, CardDescription } from '@/components/ui/card';
-import { useState, useEffect, useMemo } from 'react';
+import { Suspense, useEffect, useMemo, useState } from 'react';
 import { Button } from '@/components/ui/button';
 import { CheckCircle, Clock, Copy, Settings } from 'lucide-react';
 import { Badge } from '@/components/ui/badge';
@@ -23,6 +23,7 @@ import { getRoleLabel } from '@/lib/meshtastic';
 import type { EnvironmentExposureSlug, LatestEnvironmentMetrics, WeatherUseSlug } from '@/lib/models';
 import { NodeEnvironmentSettingsDialog } from '@/components/nodes/NodeEnvironmentSettingsDialog';
 import { NodeMeshMonitoringSection } from '@/components/nodes/NodeMeshMonitoringSection';
+import { NodeTracerouteHistorySection } from '@/components/nodes/NodeTracerouteHistorySection';
 
 interface NodeDetailContentProps {
   nodeId: number;
@@ -481,6 +482,15 @@ export function NodeDetailContent({ nodeId, compact = false }: NodeDetailContent
         <>
           <NodeMeshMonitoringSection node={node} />
           <TracerouteLinksSection nodeId={nodeId} />
+          <Suspense
+            fallback={
+              <div className="mb-6 flex min-h-[120px] items-center justify-center text-muted-foreground">
+                <div className="animate-spin rounded-full h-8 w-8 border-t-2 border-b-2 border-teal-500" />
+              </div>
+            }
+          >
+            <NodeTracerouteHistorySection nodeId={nodeId} observedNode={node} />
+          </Suspense>
           <NodeStatsSection nodeId={nodeId} node={node} isManagedNode={isManagedNode} />
         </>
       )}

--- a/src/components/nodes/NodeTracerouteHistorySection.test.tsx
+++ b/src/components/nodes/NodeTracerouteHistorySection.test.tsx
@@ -1,0 +1,231 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { render, screen, fireEvent } from '@testing-library/react';
+import { MemoryRouter } from 'react-router-dom';
+import type { AutoTraceRoute, ManagedNode, ObservedNode } from '@/lib/models';
+
+vi.mock('@/hooks/useTraceroutesWithWebSocket', () => ({
+  useTraceroutesWithWebSocket: vi.fn(),
+}));
+vi.mock('@/hooks/api/useTraceroutes', () => ({
+  useTracerouteTriggerableNodesSuspense: vi.fn(),
+  useTriggerTraceroute: vi.fn(),
+}));
+
+vi.mock('@/pages/traceroutes/TracerouteDetailModal', () => ({
+  TracerouteDetailModal: ({
+    tracerouteId,
+    open,
+  }: {
+    tracerouteId: number | null;
+    open: boolean;
+    onOpenChange: (open: boolean) => void;
+  }) =>
+    open ? (
+      <div role="dialog" data-testid="detail-modal">
+        Detail for {tracerouteId}
+      </div>
+    ) : null,
+}));
+
+vi.mock('@/pages/traceroutes/TriggerTracerouteModal', () => ({
+  TriggerTracerouteModal: ({
+    open,
+    fixedTargetNode,
+  }: {
+    open: boolean;
+    fixedTargetNode?: ObservedNode;
+    onOpenChange: (open: boolean) => void;
+    mode: 'user' | 'auto';
+    managedNodes: ManagedNode[];
+    observedNodes: ObservedNode[];
+    onTrigger: (managedNodeId: number, targetNodeId?: number) => Promise<void>;
+    isSubmitting: boolean;
+  }) =>
+    open ? (
+      <div role="dialog" data-testid="trigger-modal">
+        Trigger modal; fixed target = {fixedTargetNode?.node_id_str}
+      </div>
+    ) : null,
+}));
+
+import { useTraceroutesWithWebSocket } from '@/hooks/useTraceroutesWithWebSocket';
+import { useTracerouteTriggerableNodesSuspense, useTriggerTraceroute } from '@/hooks/api/useTraceroutes';
+import { NodeTracerouteHistorySection } from './NodeTracerouteHistorySection';
+
+const mockedUseTraceroutesWithWebSocket = vi.mocked(useTraceroutesWithWebSocket);
+const mockedUseTriggerableNodes = vi.mocked(useTracerouteTriggerableNodesSuspense);
+const mockedUseTriggerTraceroute = vi.mocked(useTriggerTraceroute);
+
+function makeObservedNode(overrides: Partial<ObservedNode> = {}): ObservedNode {
+  return {
+    internal_id: 1,
+    node_id: 100,
+    node_id_str: '!00000064',
+    mac_addr: null,
+    long_name: 'Target node',
+    short_name: 'TGT',
+    hw_model: null,
+    public_key: null,
+    ...overrides,
+  };
+}
+
+function makeManagedNode(overrides: Partial<ManagedNode> = {}): ManagedNode {
+  return {
+    node_id: 200,
+    long_name: 'Source node',
+    short_name: 'SRC',
+    last_heard: null,
+    node_id_str: '!000000c8',
+    owner: { id: 1, username: 'me' },
+    constellation: { id: 1, name: 'C1' },
+    allow_auto_traceroute: true,
+    position: { latitude: null, longitude: null },
+    ...overrides,
+  };
+}
+
+function makeTraceroute(overrides: Partial<AutoTraceRoute> = {}): AutoTraceRoute {
+  return {
+    id: 1,
+    source_node: makeManagedNode(),
+    target_node: makeObservedNode(),
+    trigger_type: 'user',
+    triggered_by: 1,
+    triggered_by_username: 'me',
+    trigger_source: 'ui',
+    triggered_at: '2026-04-17T10:00:00Z',
+    status: 'completed',
+    route: [],
+    route_back: [],
+    raw_packet: null,
+    completed_at: '2026-04-17T10:00:05Z',
+    error_message: null,
+    ...overrides,
+  };
+}
+
+interface UseTraceroutesReturn {
+  data?: { results: AutoTraceRoute[] };
+  isLoading: boolean;
+  error: Error | null;
+}
+
+function setupHooks(options: {
+  traceroutes?: AutoTraceRoute[];
+  triggerableNodes?: ManagedNode[];
+  isLoading?: boolean;
+  error?: Error | null;
+  mutate?: ReturnType<typeof vi.fn>;
+  isPending?: boolean;
+}) {
+  const result: UseTraceroutesReturn = {
+    data: options.isLoading ? undefined : { results: options.traceroutes ?? [] },
+    isLoading: options.isLoading ?? false,
+    error: options.error ?? null,
+  };
+  // The real hook returns a UseQueryResult with many fields, but the component
+  // only reads data/isLoading/error; cast keeps the type happy for the mock.
+  mockedUseTraceroutesWithWebSocket.mockReturnValue(result as ReturnType<typeof useTraceroutesWithWebSocket>);
+  mockedUseTriggerableNodes.mockReturnValue({ triggerableNodes: options.triggerableNodes ?? [] });
+  mockedUseTriggerTraceroute.mockReturnValue({
+    mutate: options.mutate ?? vi.fn(),
+    mutateAsync: vi.fn(),
+    isPending: options.isPending ?? false,
+  } as unknown as ReturnType<typeof useTriggerTraceroute>);
+}
+
+function renderSection(observedNode: ObservedNode = makeObservedNode()) {
+  return render(
+    <MemoryRouter>
+      <NodeTracerouteHistorySection nodeId={observedNode.node_id} observedNode={observedNode} />
+    </MemoryRouter>
+  );
+}
+
+describe('NodeTracerouteHistorySection', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('shows the empty state when there are no traceroutes', () => {
+    setupHooks({ traceroutes: [], triggerableNodes: [] });
+    renderSection();
+    expect(screen.getByText(/no traceroutes to this node yet/i)).toBeInTheDocument();
+  });
+
+  it('hides the trigger button and repeat column when the user has no triggerable nodes', () => {
+    setupHooks({ traceroutes: [makeTraceroute()], triggerableNodes: [] });
+    renderSection();
+    expect(screen.queryByRole('button', { name: /trigger traceroute to this node/i })).not.toBeInTheDocument();
+    expect(screen.queryByRole('button', { name: /repeat traceroute/i })).not.toBeInTheDocument();
+  });
+
+  it('shows the trigger button and a repeat button when the user can trigger from the row source', () => {
+    const managed = makeManagedNode();
+    setupHooks({
+      traceroutes: [makeTraceroute({ source_node: managed })],
+      triggerableNodes: [managed],
+    });
+    renderSection();
+    expect(screen.getByRole('button', { name: /trigger traceroute to this node/i })).toBeInTheDocument();
+    expect(screen.getByRole('button', { name: /repeat traceroute/i })).toBeInTheDocument();
+  });
+
+  it('disables the repeat button when the source does not allow auto traceroute', () => {
+    const managed = makeManagedNode({ allow_auto_traceroute: false });
+    setupHooks({
+      traceroutes: [makeTraceroute({ source_node: managed })],
+      triggerableNodes: [managed],
+    });
+    renderSection();
+    expect(screen.getByRole('button', { name: /repeat traceroute/i })).toBeDisabled();
+  });
+
+  it('opens the detail modal when a row is clicked', () => {
+    const managed = makeManagedNode();
+    setupHooks({
+      traceroutes: [makeTraceroute({ id: 42, source_node: managed })],
+      triggerableNodes: [managed],
+    });
+    renderSection();
+    // The row contains the source short name
+    fireEvent.click(screen.getByText('SRC'));
+    expect(screen.getByTestId('detail-modal')).toHaveTextContent('Detail for 42');
+  });
+
+  it('opens the trigger modal with fixedTargetNode when the header button is clicked', () => {
+    const managed = makeManagedNode();
+    const observed = makeObservedNode({ node_id: 555, node_id_str: '!0000022b' });
+    setupHooks({ traceroutes: [], triggerableNodes: [managed] });
+    renderSection(observed);
+    fireEvent.click(screen.getByRole('button', { name: /trigger traceroute to this node/i }));
+    expect(screen.getByTestId('trigger-modal')).toHaveTextContent('fixed target = !0000022b');
+  });
+
+  it('calls the trigger mutation with source + target when the repeat button is clicked', () => {
+    const managed = makeManagedNode({ node_id: 777 });
+    const observed = makeObservedNode({ node_id: 888 });
+    const mutate = vi.fn();
+    setupHooks({
+      traceroutes: [makeTraceroute({ source_node: managed, target_node: observed })],
+      triggerableNodes: [managed],
+      mutate,
+    });
+    renderSection(observed);
+    fireEvent.click(screen.getByRole('button', { name: /repeat traceroute/i }));
+    expect(mutate).toHaveBeenCalledWith(
+      { managedNodeId: 777, targetNodeId: 888 },
+      expect.objectContaining({ onError: expect.any(Function) })
+    );
+  });
+
+  it('renders a View all link pointing at the traceroute history filtered by target', () => {
+    const managed = makeManagedNode();
+    const observed = makeObservedNode({ node_id: 100 });
+    setupHooks({ traceroutes: [makeTraceroute({ source_node: managed })], triggerableNodes: [managed] });
+    renderSection(observed);
+    const link = screen.getByRole('link', { name: /view all traceroutes to this node/i });
+    expect(link).toHaveAttribute('href', '/traceroutes?target_node=100');
+  });
+});

--- a/src/components/nodes/NodeTracerouteHistorySection.tsx
+++ b/src/components/nodes/NodeTracerouteHistorySection.tsx
@@ -1,0 +1,203 @@
+import { useState } from 'react';
+import { format } from 'date-fns';
+import { Link } from 'react-router-dom';
+import { toast } from 'sonner';
+import { RouteIcon, RotateCw } from 'lucide-react';
+import { Card, CardContent, CardDescription, CardHeader, CardTitle } from '@/components/ui/card';
+import { Button } from '@/components/ui/button';
+import { Badge } from '@/components/ui/badge';
+import { Table, TableBody, TableCell, TableHead, TableHeader, TableRow } from '@/components/ui/table';
+import { useTracerouteTriggerableNodesSuspense, useTriggerTraceroute } from '@/hooks/api/useTraceroutes';
+import { useTraceroutesWithWebSocket } from '@/hooks/useTraceroutesWithWebSocket';
+import { TracerouteDetailModal } from '@/pages/traceroutes/TracerouteDetailModal';
+import { TriggerTracerouteModal } from '@/pages/traceroutes/TriggerTracerouteModal';
+import { getTracerouteErrorMessage } from '@/pages/traceroutes/tracerouteErrors';
+import type { AutoTraceRoute, ObservedNode } from '@/lib/models';
+
+const PAGE_SIZE = 10;
+
+function routeSummary(tr: AutoTraceRoute): string {
+  const outEmpty = !tr.route || tr.route.length === 0;
+  const backEmpty = !tr.route_back || tr.route_back.length === 0;
+  if (outEmpty && backEmpty) {
+    return tr.status === 'completed' ? 'Direct' : '—';
+  }
+  const outStr = outEmpty ? 'Direct' : `${tr.route?.length ?? 0} hops`;
+  const backStr = backEmpty ? 'Direct' : `${tr.route_back?.length ?? 0} hops`;
+  return `${outStr} out, ${backStr} back`;
+}
+
+function StatusBadge({ status }: { status: string }) {
+  const variant =
+    status === 'completed'
+      ? 'default'
+      : status === 'failed'
+        ? 'destructive'
+        : status === 'pending' || status === 'sent'
+          ? 'secondary'
+          : 'outline';
+  return <Badge variant={variant}>{status}</Badge>;
+}
+
+interface NodeTracerouteHistorySectionProps {
+  nodeId: number;
+  observedNode: ObservedNode;
+}
+
+export function NodeTracerouteHistorySection({ nodeId, observedNode }: NodeTracerouteHistorySectionProps) {
+  const [selectedTracerouteId, setSelectedTracerouteId] = useState<number | null>(null);
+  const [triggerModalOpen, setTriggerModalOpen] = useState(false);
+
+  const { data, isLoading, error } = useTraceroutesWithWebSocket({
+    target_node: nodeId,
+    page_size: PAGE_SIZE,
+  });
+  const { triggerableNodes } = useTracerouteTriggerableNodesSuspense();
+  const canTrigger = triggerableNodes.length > 0;
+  const triggerMutation = useTriggerTraceroute();
+
+  const traceroutes = data?.results ?? [];
+
+  const handleRepeat = (tr: AutoTraceRoute) => {
+    triggerMutation.mutate(
+      { managedNodeId: tr.source_node.node_id, targetNodeId: tr.target_node.node_id },
+      {
+        onError: (err) => {
+          toast.error('Traceroute failed', {
+            description: getTracerouteErrorMessage(err),
+          });
+        },
+      }
+    );
+  };
+
+  return (
+    <div className="mb-6">
+      <Card>
+        <CardHeader className="flex flex-row flex-wrap items-start justify-between gap-4">
+          <div>
+            <CardTitle className="flex items-center gap-2">
+              <RouteIcon className="h-5 w-5" />
+              Traceroutes to this node
+            </CardTitle>
+            <CardDescription>
+              Traceroutes where this node is the target. Click a row for the full path and map.
+            </CardDescription>
+          </div>
+          {canTrigger && (
+            <Button variant="outline" size="sm" onClick={() => setTriggerModalOpen(true)}>
+              Trigger traceroute to this node
+            </Button>
+          )}
+        </CardHeader>
+        <CardContent>
+          {isLoading && <div className="py-8 text-center text-muted-foreground">Loading...</div>}
+          {error && (
+            <div className="py-8 text-center text-destructive">
+              Failed to load traceroutes: {error instanceof Error ? error.message : 'Unknown error'}
+            </div>
+          )}
+          {!isLoading && !error && traceroutes.length === 0 && (
+            <div className="py-8 text-center text-muted-foreground">
+              <p>No traceroutes to this node yet.</p>
+              {canTrigger && <p className="mt-1 text-sm">Trigger one above to populate this list.</p>}
+            </div>
+          )}
+          {!isLoading && !error && traceroutes.length > 0 && (
+            <>
+              <Table>
+                <TableHeader>
+                  <TableRow>
+                    <TableHead>Source</TableHead>
+                    <TableHead>Type</TableHead>
+                    <TableHead>Triggered by</TableHead>
+                    <TableHead>Status</TableHead>
+                    <TableHead>Route</TableHead>
+                    <TableHead>Triggered</TableHead>
+                    <TableHead>Completed</TableHead>
+                    {canTrigger && <TableHead className="w-12"></TableHead>}
+                  </TableRow>
+                </TableHeader>
+                <TableBody>
+                  {traceroutes.map((tr) => {
+                    const canRepeat = triggerableNodes.some((n) => n.node_id === tr.source_node.node_id);
+                    return (
+                      <TableRow
+                        key={tr.id}
+                        className="cursor-pointer hover:bg-muted/50"
+                        onClick={() => setSelectedTracerouteId(tr.id)}
+                      >
+                        <TableCell>{tr.source_node?.short_name ?? tr.source_node?.node_id_str ?? '—'}</TableCell>
+                        <TableCell>{tr.trigger_type}</TableCell>
+                        <TableCell>{tr.triggered_by_username ?? '—'}</TableCell>
+                        <TableCell>
+                          <StatusBadge status={tr.status} />
+                        </TableCell>
+                        <TableCell className="max-w-[200px]" title={routeSummary(tr)}>
+                          {routeSummary(tr)}
+                        </TableCell>
+                        <TableCell>{tr.triggered_at ? format(new Date(tr.triggered_at), 'PPp') : '—'}</TableCell>
+                        <TableCell>{tr.completed_at ? format(new Date(tr.completed_at), 'PPp') : '—'}</TableCell>
+                        {canTrigger && (
+                          <TableCell onClick={(e) => e.stopPropagation()}>
+                            {canRepeat ? (
+                              <Button
+                                variant="ghost"
+                                size="icon"
+                                className="h-8 w-8"
+                                onClick={() => handleRepeat(tr)}
+                                disabled={triggerMutation.isPending || tr.source_node.allow_auto_traceroute === false}
+                                title="Repeat this traceroute"
+                                aria-label="Repeat traceroute"
+                              >
+                                <RotateCw className="h-4 w-4" />
+                              </Button>
+                            ) : null}
+                          </TableCell>
+                        )}
+                      </TableRow>
+                    );
+                  })}
+                </TableBody>
+              </Table>
+              <div className="mt-4 text-right">
+                <Link
+                  to={`/traceroutes?target_node=${nodeId}`}
+                  className="text-sm text-teal-600 dark:text-teal-400 hover:underline"
+                >
+                  View all traceroutes to this node →
+                </Link>
+              </div>
+            </>
+          )}
+        </CardContent>
+      </Card>
+
+      <TracerouteDetailModal
+        tracerouteId={selectedTracerouteId}
+        open={selectedTracerouteId != null}
+        onOpenChange={(open) => !open && setSelectedTracerouteId(null)}
+      />
+
+      <TriggerTracerouteModal
+        open={triggerModalOpen}
+        onOpenChange={setTriggerModalOpen}
+        mode="user"
+        managedNodes={triggerableNodes}
+        observedNodes={[observedNode]}
+        fixedTargetNode={observedNode}
+        onTrigger={async (managedNodeId, targetNodeId) => {
+          try {
+            await triggerMutation.mutateAsync({ managedNodeId, targetNodeId });
+            setTriggerModalOpen(false);
+          } catch (err) {
+            toast.error('Traceroute failed', {
+              description: getTracerouteErrorMessage(err),
+            });
+          }
+        }}
+        isSubmitting={triggerMutation.isPending}
+      />
+    </div>
+  );
+}

--- a/src/components/traceroutes/TracerouteMap.test.tsx
+++ b/src/components/traceroutes/TracerouteMap.test.tsx
@@ -1,0 +1,127 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { render } from '@testing-library/react';
+import L from 'leaflet';
+import { TracerouteMap } from './TracerouteMap';
+import type { AutoTraceRoute, ManagedNode, ObservedNode } from '@/lib/models';
+
+function makeSource(): ManagedNode {
+  return {
+    node_id: 1,
+    long_name: 'Source',
+    short_name: 'SRC',
+    last_heard: null,
+    node_id_str: '!00000001',
+    owner: { id: 1, username: 'me' },
+    constellation: { id: 1, name: 'C1' },
+    allow_auto_traceroute: true,
+    position: { latitude: 55.86, longitude: -4.25 },
+  };
+}
+
+function makeTarget(): ObservedNode {
+  return {
+    internal_id: 2,
+    node_id: 2,
+    node_id_str: '!00000002',
+    mac_addr: null,
+    long_name: 'Target',
+    short_name: 'TGT',
+    hw_model: null,
+    public_key: null,
+    latest_position: { latitude: 55.87, longitude: -4.26 },
+  } as ObservedNode;
+}
+
+function makeTraceroute(
+  status: AutoTraceRoute['status'],
+  overrides: Partial<AutoTraceRoute> = {}
+): AutoTraceRoute {
+  return {
+    id: 1,
+    source_node: makeSource(),
+    target_node: makeTarget(),
+    trigger_type: 'user',
+    triggered_by: 1,
+    triggered_by_username: 'me',
+    trigger_source: null,
+    triggered_at: new Date().toISOString(),
+    status,
+    route: null,
+    route_back: null,
+    route_nodes: [],
+    route_back_nodes: [],
+    raw_packet: null,
+    completed_at: status === 'completed' ? new Date().toISOString() : null,
+    error_message: null,
+    ...overrides,
+  };
+}
+
+type PolylineArgs = [L.LatLngExpression[], L.PolylineOptions | undefined];
+
+describe('TracerouteMap polyline styling by status', () => {
+  const polylineCalls: PolylineArgs[] = [];
+  let polylineSpy: { mockRestore: () => void };
+
+  beforeEach(() => {
+    polylineCalls.length = 0;
+    // L.polyline returns a Leaflet layer; for these tests we only need to
+    // capture the options argument, so we stub out the return value.
+    polylineSpy = vi
+      .spyOn(L, 'polyline')
+      .mockImplementation(((latlngs: L.LatLngExpression[], options?: L.PolylineOptions) => {
+        polylineCalls.push([latlngs, options]);
+        return {
+          addTo: () => ({ remove: () => {} }),
+          remove: () => {},
+        } as unknown as L.Polyline;
+      }) as unknown as typeof L.polyline);
+  });
+
+  afterEach(() => {
+    polylineSpy.mockRestore();
+  });
+
+  function polylineOptionsForClass(className: string): L.PolylineOptions | undefined {
+    const call = polylineCalls.find(([, opts]) => opts?.className === className);
+    return call?.[1];
+  }
+
+  it('pending TR draws a dashed blue direct line (distinct from completed direct)', () => {
+    render(<TracerouteMap traceroute={makeTraceroute('pending')} />);
+    const opts = polylineOptionsForClass('traceroute-pending');
+    expect(opts).toBeDefined();
+    expect(opts?.color).toBe('#2563eb');
+    expect(opts?.dashArray).toBe('4, 8');
+    // Completed-direct line must not also be drawn when status is pending.
+    expect(polylineOptionsForClass('traceroute-direct-completed')).toBeUndefined();
+  });
+
+  it('sent TR uses the same pending style (dashed blue)', () => {
+    render(<TracerouteMap traceroute={makeTraceroute('sent')} />);
+    const opts = polylineOptionsForClass('traceroute-pending');
+    expect(opts).toBeDefined();
+    expect(opts?.dashArray).toBe('4, 8');
+    expect(opts?.color).toBe('#2563eb');
+  });
+
+  it('failed TR draws a dashed red direct line (unchanged)', () => {
+    render(<TracerouteMap traceroute={makeTraceroute('failed')} />);
+    const opts = polylineOptionsForClass('traceroute-failed');
+    expect(opts).toBeDefined();
+    expect(opts?.color).toBe('#dc2626');
+    expect(opts?.dashArray).toBe('10, 8');
+  });
+
+  it('completed direct (0-hop) TR draws a SOLID blue line (unchanged)', () => {
+    render(<TracerouteMap traceroute={makeTraceroute('completed')} />);
+    const opts = polylineOptionsForClass('traceroute-direct-completed');
+    expect(opts).toBeDefined();
+    expect(opts?.color).toBe('#2563eb');
+    // Solid = no dashArray set
+    expect(opts?.dashArray).toBeUndefined();
+    // Pending/failed direct lines must not be drawn when completed.
+    expect(polylineOptionsForClass('traceroute-pending')).toBeUndefined();
+    expect(polylineOptionsForClass('traceroute-failed')).toBeUndefined();
+  });
+});

--- a/src/components/traceroutes/TracerouteMap.tsx
+++ b/src/components/traceroutes/TracerouteMap.tsx
@@ -174,14 +174,17 @@ export function TracerouteMap({ traceroute }: { traceroute: AutoTraceRoute }) {
     }
 
     const statusLower = traceroute.status?.toLowerCase();
-    // Pending/sent: solid blue (same weight/style as completed outbound). Failed: dashed red.
+    // Pending/sent: dashed blue (in-flight, path unknown). Failed: dashed red.
+    // Keeping them both dashed distinguishes them from completed TRs, where solid
+    // blue specifically means "completed direct (0-hop)" (see isDirectPathCompleted
+    // branch below). Different dash patterns distinguish pending from failed.
     const needsDirectLine = statusLower === 'pending' || statusLower === 'sent' || statusLower === 'failed';
     if (needsDirectLine && sourcePos && targetPos) {
       const isFailed = statusLower === 'failed';
       const directLine = L.polyline([sourcePos, targetPos], {
         color: isFailed ? FAILED_LINE_COLOR : SOURCE_COLOR,
         weight: 4,
-        ...(isFailed ? { dashArray: '10, 8' as const } : {}),
+        dashArray: isFailed ? '10, 8' : '4, 8',
         className: isFailed ? 'traceroute-failed' : 'traceroute-pending',
       }).addTo(map);
       layersRef.current.push(directLine);

--- a/src/pages/traceroutes/TracerouteHistory.tsx
+++ b/src/pages/traceroutes/TracerouteHistory.tsx
@@ -1,7 +1,6 @@
 import { useState } from 'react';
 import { format } from 'date-fns';
 import { subDays } from 'date-fns';
-import { AxiosError } from 'axios';
 import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card';
 import { Button } from '@/components/ui/button';
 import { Table, TableBody, TableCell, TableHead, TableHeader, TableRow } from '@/components/ui/table';
@@ -13,34 +12,10 @@ import { useTracerouteTriggerableNodesSuspense, useTriggerTraceroute } from '@/h
 import { useNodesSuspense } from '@/hooks/api/useNodes';
 import { TriggerTracerouteModal } from './TriggerTracerouteModal';
 import { TracerouteDetailModal } from './TracerouteDetailModal';
+import { getTracerouteErrorMessage } from './tracerouteErrors';
 import { TracerouteStatsSection } from '@/components/traceroutes/TracerouteStatsSection';
 import { AutoTraceRoute } from '@/lib/models';
 import { RouteIcon, RotateCw } from 'lucide-react';
-
-function getTracerouteErrorMessage(error: unknown): string {
-  // API client transforms errors: throws { message, status, data } with data = response body
-  const err = error as { status?: number; data?: { detail?: string }; message?: string };
-  const detail =
-    err.data?.detail ??
-    (error instanceof AxiosError ? (error.response?.data as { detail?: string })?.detail : undefined);
-  const status = err.status ?? (error instanceof AxiosError ? error.response?.status : undefined);
-
-  if (typeof detail === 'string') {
-    if (status === 429 || detail.toLowerCase().includes('rate limited')) {
-      return detail.includes('Try again in')
-        ? detail
-        : 'Traceroute rate limited. The radio needs at least 30 seconds between traceroutes. Please try again shortly.';
-    }
-    if (detail.toLowerCase().includes('allow_auto_traceroute')) {
-      return "This node doesn't allow traceroutes. Enable it in the node settings.";
-    }
-    if (detail.toLowerCase().includes('no recent packet ingestion')) {
-      return 'That source is not reporting packets right now (monitor offline or quiet). Pick another source or wait for the bot to ingest again.';
-    }
-    return detail;
-  }
-  return err.message ?? (error instanceof Error ? error.message : 'Failed to trigger traceroute. Please try again.');
-}
 
 function routeSummary(tr: AutoTraceRoute): string {
   const route = tr.route;

--- a/src/pages/traceroutes/TriggerTracerouteModal.test.tsx
+++ b/src/pages/traceroutes/TriggerTracerouteModal.test.tsx
@@ -33,7 +33,7 @@ function makeManagedNode(overrides: Partial<ManagedNode> = {}): ManagedNode {
 }
 
 describe('TriggerTracerouteModal with fixedTargetNode', () => {
-  it('renders a read-only target row instead of the search/map pickers', () => {
+  it('renders a read-only target row and source-selection map (no NodeSearch) when fixedTargetNode is set', () => {
     const fixed = makeObservedNode();
     render(
       <TriggerTracerouteModal
@@ -51,6 +51,9 @@ describe('TriggerTracerouteModal with fixedTargetNode', () => {
     const readOnly = screen.getByTestId('trigger-traceroute-fixed-target');
     expect(readOnly).toHaveTextContent('FIX (!0000002a)');
     expect(screen.queryByPlaceholderText(/search.*node/i)).not.toBeInTheDocument();
+    expect(screen.getByText(/pick a source on the map/i)).toBeInTheDocument();
+    // Dialog renders via a Radix portal, so query the whole document.
+    expect(document.querySelector('.leaflet-container')).not.toBeNull();
   });
 
   it('uses the fixed-target variant of the description and shows a Trigger button', () => {

--- a/src/pages/traceroutes/TriggerTracerouteModal.test.tsx
+++ b/src/pages/traceroutes/TriggerTracerouteModal.test.tsx
@@ -1,0 +1,94 @@
+import { describe, it, expect, vi } from 'vitest';
+import { render, screen } from '@testing-library/react';
+import { TriggerTracerouteModal } from './TriggerTracerouteModal';
+import type { ManagedNode, ObservedNode } from '@/lib/models';
+
+function makeObservedNode(overrides: Partial<ObservedNode> = {}): ObservedNode {
+  return {
+    internal_id: 1,
+    node_id: 42,
+    node_id_str: '!0000002a',
+    mac_addr: null,
+    long_name: 'Fixed target',
+    short_name: 'FIX',
+    hw_model: null,
+    public_key: null,
+    ...overrides,
+  };
+}
+
+function makeManagedNode(overrides: Partial<ManagedNode> = {}): ManagedNode {
+  return {
+    node_id: 7,
+    long_name: 'Source',
+    short_name: 'SRC',
+    last_heard: null,
+    node_id_str: '!00000007',
+    owner: { id: 1, username: 'me' },
+    constellation: { id: 1, name: 'C1' },
+    allow_auto_traceroute: true,
+    position: { latitude: null, longitude: null },
+    ...overrides,
+  };
+}
+
+describe('TriggerTracerouteModal with fixedTargetNode', () => {
+  it('renders a read-only target row instead of the search/map pickers', () => {
+    const fixed = makeObservedNode();
+    render(
+      <TriggerTracerouteModal
+        open={true}
+        onOpenChange={vi.fn()}
+        mode="user"
+        managedNodes={[makeManagedNode()]}
+        observedNodes={[fixed]}
+        onTrigger={vi.fn().mockResolvedValue(undefined)}
+        isSubmitting={false}
+        fixedTargetNode={fixed}
+      />
+    );
+
+    const readOnly = screen.getByTestId('trigger-traceroute-fixed-target');
+    expect(readOnly).toHaveTextContent('FIX (!0000002a)');
+    expect(screen.queryByPlaceholderText(/search.*node/i)).not.toBeInTheDocument();
+  });
+
+  it('uses the fixed-target variant of the description and shows a Trigger button', () => {
+    const fixed = makeObservedNode();
+    render(
+      <TriggerTracerouteModal
+        open={true}
+        onOpenChange={vi.fn()}
+        mode="user"
+        managedNodes={[makeManagedNode()]}
+        observedNodes={[fixed]}
+        onTrigger={vi.fn().mockResolvedValue(undefined)}
+        isSubmitting={false}
+        fixedTargetNode={fixed}
+      />
+    );
+
+    expect(screen.getByText(/target is fixed to the node you are viewing/i)).toBeInTheDocument();
+    // The Trigger button is disabled until a source is chosen, proving the
+    // target is pre-populated (otherwise it would be disabled on two conditions).
+    const trigger = screen.getByRole('button', { name: /^trigger$/i });
+    expect(trigger).toBeDisabled();
+  });
+
+  it('does not render the fixed-target row when fixedTargetNode is omitted', () => {
+    // NodeSearch pulls in the nodes API; render the auto mode to avoid that
+    // while still verifying the fixed-target UI is absent.
+    render(
+      <TriggerTracerouteModal
+        open={true}
+        onOpenChange={vi.fn()}
+        mode="auto"
+        managedNodes={[makeManagedNode()]}
+        observedNodes={[]}
+        onTrigger={vi.fn().mockResolvedValue(undefined)}
+        isSubmitting={false}
+      />
+    );
+    expect(screen.queryByTestId('trigger-traceroute-fixed-target')).not.toBeInTheDocument();
+  });
+});

--- a/src/pages/traceroutes/TriggerTracerouteModal.tsx
+++ b/src/pages/traceroutes/TriggerTracerouteModal.tsx
@@ -1,4 +1,4 @@
-import { useState } from 'react';
+import { useEffect, useState } from 'react';
 import {
   Dialog,
   DialogContent,
@@ -22,6 +22,16 @@ interface TriggerTracerouteModalProps {
   observedNodes: ObservedNode[];
   onTrigger: (managedNodeId: number, targetNodeId?: number) => Promise<void>;
   isSubmitting: boolean;
+  /**
+   * When set in `user` mode, the target is locked to this ObservedNode: the
+   * target picker/map is hidden and a read-only row is shown instead. Ignored
+   * in `auto` mode.
+   */
+  fixedTargetNode?: ObservedNode;
+}
+
+function formatNodeLabel(node: { short_name: string | null; node_id_str: string }): string {
+  return `${node.short_name ?? node.node_id_str} (${node.node_id_str})`;
 }
 
 export function TriggerTracerouteModal({
@@ -32,18 +42,29 @@ export function TriggerTracerouteModal({
   observedNodes,
   onTrigger,
   isSubmitting,
+  fixedTargetNode,
 }: TriggerTracerouteModalProps) {
   const [managedNodeId, setManagedNodeId] = useState<number | null>(null);
   const [targetNodeId, setTargetNodeId] = useState<number | null>(null);
   const [targetNodeLabel, setTargetNodeLabel] = useState<string | null>(null);
+
+  const hasFixedTarget = mode === 'user' && fixedTargetNode != null;
+
+  useEffect(() => {
+    if (!hasFixedTarget || !fixedTargetNode) return;
+    setTargetNodeId(fixedTargetNode.node_id);
+    setTargetNodeLabel(formatNodeLabel(fixedTargetNode));
+  }, [hasFixedTarget, fixedTargetNode]);
 
   const handleSubmit = async () => {
     if (!managedNodeId) return;
     if (mode === 'user' && !targetNodeId) return;
     await onTrigger(managedNodeId, mode === 'user' ? (targetNodeId ?? undefined) : undefined);
     setManagedNodeId(null);
-    setTargetNodeId(null);
-    setTargetNodeLabel(null);
+    if (!hasFixedTarget) {
+      setTargetNodeId(null);
+      setTargetNodeLabel(null);
+    }
   };
 
   const canSubmit = managedNodeId != null && (mode === 'auto' || targetNodeId != null);
@@ -59,16 +80,19 @@ export function TriggerTracerouteModal({
     return true;
   };
 
+  const dialogDescription =
+    mode === 'auto'
+      ? 'Select the source node. The target will be auto-selected (most recently heard).'
+      : hasFixedTarget
+        ? 'Select the source node. The target is fixed to the node you are viewing.'
+        : 'Select the source node and target node for the traceroute.';
+
   return (
     <Dialog open={open} onOpenChange={onOpenChange}>
-      <DialogContent className={mode === 'user' ? 'max-w-4xl' : undefined}>
+      <DialogContent className={mode === 'user' && !hasFixedTarget ? 'max-w-4xl' : undefined}>
         <DialogHeader>
           <DialogTitle>{mode === 'user' ? 'Trigger Traceroute (target)' : 'Trigger Traceroute (auto)'}</DialogTitle>
-          <DialogDescription>
-            {mode === 'user'
-              ? 'Select the source node and target node for the traceroute.'
-              : 'Select the source node. The target will be auto-selected (most recently heard).'}
-          </DialogDescription>
+          <DialogDescription>{dialogDescription}</DialogDescription>
         </DialogHeader>
 
         <div className="grid gap-4 py-4">
@@ -91,7 +115,19 @@ export function TriggerTracerouteModal({
             </Select>
           </div>
 
-          {mode === 'user' && (
+          {mode === 'user' && hasFixedTarget && fixedTargetNode && (
+            <div className="grid gap-2">
+              <Label>Target node</Label>
+              <div
+                className="rounded-md border bg-muted/40 px-3 py-2 text-sm"
+                data-testid="trigger-traceroute-fixed-target"
+              >
+                {formatNodeLabel(fixedTargetNode)}
+              </div>
+            </div>
+          )}
+
+          {mode === 'user' && !hasFixedTarget && (
             <>
               <div className="grid gap-2">
                 <Label htmlFor="target-node">Target node</Label>

--- a/src/pages/traceroutes/TriggerTracerouteModal.tsx
+++ b/src/pages/traceroutes/TriggerTracerouteModal.tsx
@@ -80,6 +80,16 @@ export function TriggerTracerouteModal({
     return true;
   };
 
+  // In the fixed-target variant, clicking a managed marker picks it as source.
+  // Clicking anything else (e.g. the fixed target itself) is a no-op.
+  const handleFixedTargetMapNodeSelect = (node: MapNode | null) => {
+    if (!node) return false;
+    const isManaged = managedNodes.some((m) => m.node_id === node.node_id);
+    if (!isManaged) return false;
+    setManagedNodeId(node.node_id);
+    return true;
+  };
+
   const dialogDescription =
     mode === 'auto'
       ? 'Select the source node. The target will be auto-selected (most recently heard).'
@@ -89,7 +99,7 @@ export function TriggerTracerouteModal({
 
   return (
     <Dialog open={open} onOpenChange={onOpenChange}>
-      <DialogContent className={mode === 'user' && !hasFixedTarget ? 'max-w-4xl' : undefined}>
+      <DialogContent className={mode === 'user' ? 'max-w-4xl' : undefined}>
         <DialogHeader>
           <DialogTitle>{mode === 'user' ? 'Trigger Traceroute (target)' : 'Trigger Traceroute (auto)'}</DialogTitle>
           <DialogDescription>{dialogDescription}</DialogDescription>
@@ -116,15 +126,35 @@ export function TriggerTracerouteModal({
           </div>
 
           {mode === 'user' && hasFixedTarget && fixedTargetNode && (
-            <div className="grid gap-2">
-              <Label>Target node</Label>
-              <div
-                className="rounded-md border bg-muted/40 px-3 py-2 text-sm"
-                data-testid="trigger-traceroute-fixed-target"
-              >
-                {formatNodeLabel(fixedTargetNode)}
+            <>
+              <div className="grid gap-2">
+                <Label>Target node</Label>
+                <div
+                  className="rounded-md border bg-muted/40 px-3 py-2 text-sm"
+                  data-testid="trigger-traceroute-fixed-target"
+                >
+                  {formatNodeLabel(fixedTargetNode)}
+                </div>
               </div>
-            </div>
+              <div className="grid gap-2">
+                <Label>Pick a source on the map</Label>
+                <p className="text-xs text-muted-foreground">
+                  Target is highlighted. Click an available source to select it.
+                </p>
+                <div className="h-[300px] rounded-md border overflow-hidden">
+                  <NodesAndConstellationsMap
+                    managedNodes={managedNodes}
+                    observedNodes={[fixedTargetNode]}
+                    showConstellation={true}
+                    showUnmanagedNodes={true}
+                    drawBoundingBox={false}
+                    enableBubbles={false}
+                    selectedNodeId={managedNodeId ?? fixedTargetNode.node_id}
+                    onNodeSelect={handleFixedTargetMapNodeSelect}
+                  />
+                </div>
+              </div>
+            </>
           )}
 
           {mode === 'user' && !hasFixedTarget && (

--- a/src/pages/traceroutes/tracerouteErrors.ts
+++ b/src/pages/traceroutes/tracerouteErrors.ts
@@ -1,0 +1,32 @@
+import { AxiosError } from 'axios';
+
+/**
+ * Turn a traceroute trigger API error into a user-facing message.
+ *
+ * The API client transforms errors into `{ message, status, data }` shape where
+ * `data` is the response body; this helper falls back to AxiosError fields so
+ * it works regardless of which layer throws.
+ */
+export function getTracerouteErrorMessage(error: unknown): string {
+  const err = error as { status?: number; data?: { detail?: string }; message?: string };
+  const detail =
+    err.data?.detail ??
+    (error instanceof AxiosError ? (error.response?.data as { detail?: string })?.detail : undefined);
+  const status = err.status ?? (error instanceof AxiosError ? error.response?.status : undefined);
+
+  if (typeof detail === 'string') {
+    if (status === 429 || detail.toLowerCase().includes('rate limited')) {
+      return detail.includes('Try again in')
+        ? detail
+        : 'Traceroute rate limited. The radio needs at least 30 seconds between traceroutes. Please try again shortly.';
+    }
+    if (detail.toLowerCase().includes('allow_auto_traceroute')) {
+      return "This node doesn't allow traceroutes. Enable it in the node settings.";
+    }
+    if (detail.toLowerCase().includes('no recent packet ingestion')) {
+      return 'That source is not reporting packets right now (monitor offline or quiet). Pick another source or wait for the bot to ingest again.';
+    }
+    return detail;
+  }
+  return err.message ?? (error instanceof Error ? error.message : 'Failed to trigger traceroute. Please try again.');
+}


### PR DESCRIPTION
# Summary

Adds a **Traceroutes to this node** section to the Node Details page (closes #134) and, while we're in the traceroute map code, fixes a visual collision where a pending TR looked identical to a completed direct (0-hop) TR (closes #167).

## Node Details traceroute section (#134)

- Lists recent traceroutes where the current node is the `target_node`, backed by `useTraceroutesWithWebSocket({ target_node, page_size: 10 })` so the list invalidates on status updates just like the full Traceroute History page.
- Clicking a row opens the existing `TracerouteDetailModal` (same map/flow experience as the full history page).
- Per-row repeat button, gated the same way as Traceroute History: shown only when the user can trigger from the row's source; disabled when the source has `allow_auto_traceroute=false` or a mutation is in-flight.
- Header button **Trigger traceroute to this node** opens `TriggerTracerouteModal` with the new `fixedTargetNode` prop, so the user only picks a source (target is locked to the current node).
- Empty state and a **View all traceroutes to this node** link that points to `/traceroutes?target_node=<id>`.

### Fixed-target Trigger modal map

In addition to the read-only target row, the fixed-target variant renders the existing `NodesAndConstellationsMap` with:

- The target `ObservedNode` highlighted.
- All triggerable `ManagedNodes` (sources) shown as markers.
- Click a source marker to select it; the source `Select` dropdown stays as the primary input.

This requires the companion API PR (pskillen/meshflow-api#172) which adds `position` to the `/api/traceroutes/triggerable-nodes/` response — without it, sources have no lat/lng and the map silently skips them.

## Pending TR map style fix (#167)

Previously, a traceroute with `status = pending` (or `sent`) was drawn as a **solid blue line** between source and target — identical to the solid blue line used for a completed direct-path (0-hop) TR. Users couldn't tell "in flight, path unknown" from "completed, route is direct". Introduced in `005b800` (`feat(traceroutes): direct-path UI for empty-hop traceroutes`).

Fix (single-line change in `src/components/traceroutes/TracerouteMap.tsx`):

- Pending / sent → **dashed blue** (`dashArray: '4, 8'`). Still blue (outbound identity) but clearly distinct from the solid completed-direct line.
- Failed → **dashed red** (`'10, 8'`), unchanged. Different dash pattern from pending so the three states read differently at a glance.
- Completed direct (0 hops) → **solid blue**, unchanged.
- Completed with hops → existing segment-based rendering, unchanged.

## Background

- Permissions mirror the Traceroute History page: the UI hides trigger affordances when `GET /api/traceroutes/triggerable-nodes/` returns an empty list, and the API remains authoritative. Canonical permission rules are documented in the companion meshflow-api PR.
- `TriggerTracerouteModal` gains an optional `fixedTargetNode: ObservedNode` prop. In `user` mode, when set, the NodeSearch picker is replaced with a read-only row and a source-selection map; the target id is pre-populated and `canSubmit` becomes "source selected". No change to `auto` mode; no server contract change in this repo.
- `getTracerouteErrorMessage` is extracted from `TracerouteHistory.tsx` into `src/pages/traceroutes/tracerouteErrors.ts` so the new section and the existing page share the error translation.

## Testing performed

- New Vitest/RTL tests:
  - `src/components/nodes/NodeTracerouteHistorySection.test.tsx` — empty state, hidden trigger/repeat when no triggerable nodes, enabled repeat when source is triggerable, disabled repeat when `allow_auto_traceroute=false`, row click opens detail modal, header button opens trigger modal with `fixedTargetNode`, mutation is called with `{ managedNodeId, targetNodeId }`, and the `View all` link URL.
  - `src/pages/traceroutes/TriggerTracerouteModal.test.tsx` — read-only target row rendered with `fixedTargetNode`, fixed-target description copy, `.leaflet-container` mounts for source selection, and `Trigger` disabled until a source is picked (proving the target is pre-populated).
  - `src/components/traceroutes/TracerouteMap.test.tsx` — stubs `L.polyline` and asserts the options passed for each status (pending/sent: dashed blue; failed: dashed red; completed-direct: solid blue, no dashArray). Locks the visual contract against regressions.
- `npm run format`, `npm run lint` (0 errors; pre-existing warnings only), `npm test` (24 passed), `npm run build` all green locally.

## Related

- Closes #134
- Closes #167
- Depends on (canonical permissions doc + triggerable-nodes `position` field): pskillen/meshflow-api#172
- Supersedes (closed): #168
