### PR TITLE
feat(traceroutes): improve Traceroute History page

### DIFF
--- a/src/components/traceroutes/TracerouteStatsSection.tsx
+++ b/src/components/traceroutes/TracerouteStatsSection.tsx
@@ -42,6 +42,9 @@ const SOURCE_LABELS: Record<string, string> = {
 // One-off 1/1 perfect runs would otherwise dominate the "top" list.
 const TOP_TARGETS_MIN_ATTEMPTS = 5;
 
+// Max distinct slices to show in "by node" pie charts before grouping into "Other".
+const PIE_TOP_N = 7;
+
 export function TracerouteStatsSection() {
   const [timeframe, setTimeframe] = useState<TimeframeKey>('7d');
   const triggeredAtAfter = useMemo(() => getTriggeredAtAfter(timeframe), [timeframe]);
@@ -56,6 +59,28 @@ export function TracerouteStatsSection() {
       fill: CHART_COLORS[idx % CHART_COLORS.length],
     }));
   }, [data?.sources]);
+
+  const sentByNodeChartData = useMemo(() => {
+    const rows = data?.by_source ?? [];
+    if (rows.length === 0) return [];
+    const sorted = [...rows].sort((a, b) => b.total - a.total).filter((r) => r.total > 0);
+    const top = sorted.slice(0, PIE_TOP_N);
+    const rest = sorted.slice(PIE_TOP_N);
+    const otherTotal = rest.reduce((acc, r) => acc + r.total, 0);
+    const slices = top.map((r, idx) => ({
+      name: r.short_name ?? r.node_id_str ?? `Node ${r.managed_node_id}`,
+      value: r.total,
+      fill: CHART_COLORS[idx % CHART_COLORS.length],
+    }));
+    if (otherTotal > 0) {
+      slices.push({
+        name: `Other (${rest.length})`,
+        value: otherTotal,
+        fill: '#9ca3af',
+      });
+    }
+    return slices;
+  }, [data?.by_source]);
 
   const successFailureChartData = useMemo(() => {
     if (!data?.success_failure?.length) return [];
@@ -300,81 +325,123 @@ export function TracerouteStatsSection() {
           />
         </div>
 
-        <Card>
-          <CardHeader className="pb-2">
-            <CardTitle className="text-sm">By source node</CardTitle>
-            <CardDescription className="text-xs text-muted-foreground">
-              Managed nodes that initiated traceroutes in this period. Success rate uses only completed and failed runs;
-              pending and sent count toward Total only.
-            </CardDescription>
-          </CardHeader>
-          <CardContent>
-            {isLoading ? (
-              <div className="min-h-[120px] flex items-center justify-center text-muted-foreground text-sm">
-                Loading…
-              </div>
-            ) : data?.by_source?.length ? (
-              <div className="rounded-md border overflow-x-auto">
-                <Table>
-                  <TableHeader>
-                    <TableRow>
-                      <TableHead>Source</TableHead>
-                      <TableHead className="text-right tabular-nums">Total</TableHead>
-                      <TableHead className="text-right tabular-nums">Completed</TableHead>
-                      <TableHead className="text-right tabular-nums">Failed</TableHead>
-                      <TableHead className="text-right">
-                        <span className="inline-flex items-center justify-end gap-1">
-                          Success rate
-                          <Tooltip>
-                            <TooltipTrigger asChild>
-                              <button
-                                type="button"
-                                className="text-muted-foreground hover:text-foreground inline-flex"
-                                aria-label="Success rate definition"
-                              >
-                                <HelpCircle className="h-3.5 w-3.5" />
-                              </button>
-                            </TooltipTrigger>
-                            <TooltipContent className="max-w-xs text-left" side="top">
-                              Completed ÷ (completed + failed) for this period. If there are no finished runs, rate is
-                              shown as —.
-                            </TooltipContent>
-                          </Tooltip>
-                        </span>
-                      </TableHead>
-                    </TableRow>
-                  </TableHeader>
-                  <TableBody>
-                    {data.by_source.map((row) => (
-                      <TableRow key={row.managed_node_id}>
-                        <TableCell>
-                          <div className="flex flex-col gap-0.5 min-w-0">
-                            <span className="font-medium truncate" title={row.short_name}>
-                              {row.short_name}
-                            </span>
-                            <span className="text-xs text-muted-foreground font-mono truncate" title={row.node_id_str}>
-                              {row.node_id_str}
-                            </span>
-                          </div>
-                        </TableCell>
-                        <TableCell className="text-right tabular-nums">{row.total}</TableCell>
-                        <TableCell className="text-right tabular-nums">{row.completed}</TableCell>
-                        <TableCell className="text-right tabular-nums">{row.failed}</TableCell>
-                        <TableCell className="text-right tabular-nums">
-                          {row.success_rate != null ? `${(row.success_rate * 100).toFixed(0)}%` : '—'}
-                        </TableCell>
+        <div className="grid gap-4 lg:grid-cols-3">
+          <Card className="lg:col-span-2">
+            <CardHeader className="pb-2">
+              <CardTitle className="text-sm">By source node</CardTitle>
+              <CardDescription className="text-xs text-muted-foreground">
+                Managed nodes that initiated traceroutes in this period. Success rate uses only completed and failed
+                runs; pending and sent count toward Total only.
+              </CardDescription>
+            </CardHeader>
+            <CardContent>
+              {isLoading ? (
+                <div className="min-h-[120px] flex items-center justify-center text-muted-foreground text-sm">
+                  Loading…
+                </div>
+              ) : data?.by_source?.length ? (
+                <div className="rounded-md border overflow-x-auto">
+                  <Table>
+                    <TableHeader>
+                      <TableRow>
+                        <TableHead>Source</TableHead>
+                        <TableHead className="text-right tabular-nums">Total</TableHead>
+                        <TableHead className="text-right tabular-nums">Completed</TableHead>
+                        <TableHead className="text-right tabular-nums">Failed</TableHead>
+                        <TableHead className="text-right">
+                          <span className="inline-flex items-center justify-end gap-1">
+                            Success rate
+                            <Tooltip>
+                              <TooltipTrigger asChild>
+                                <button
+                                  type="button"
+                                  className="text-muted-foreground hover:text-foreground inline-flex"
+                                  aria-label="Success rate definition"
+                                >
+                                  <HelpCircle className="h-3.5 w-3.5" />
+                                </button>
+                              </TooltipTrigger>
+                              <TooltipContent className="max-w-xs text-left" side="top">
+                                Completed ÷ (completed + failed) for this period. If there are no finished runs, rate is
+                                shown as —.
+                              </TooltipContent>
+                            </Tooltip>
+                          </span>
+                        </TableHead>
                       </TableRow>
-                    ))}
-                  </TableBody>
-                </Table>
-              </div>
-            ) : (
-              <div className="min-h-[120px] flex items-center justify-center text-muted-foreground text-sm">
-                No data
-              </div>
-            )}
-          </CardContent>
-        </Card>
+                    </TableHeader>
+                    <TableBody>
+                      {data.by_source.map((row) => (
+                        <TableRow key={row.managed_node_id}>
+                          <TableCell>
+                            <div className="flex flex-col gap-0.5 min-w-0">
+                              <span className="font-medium truncate" title={row.short_name}>
+                                {row.short_name}
+                              </span>
+                              <span
+                                className="text-xs text-muted-foreground font-mono truncate"
+                                title={row.node_id_str}
+                              >
+                                {row.node_id_str}
+                              </span>
+                            </div>
+                          </TableCell>
+                          <TableCell className="text-right tabular-nums">{row.total}</TableCell>
+                          <TableCell className="text-right tabular-nums">{row.completed}</TableCell>
+                          <TableCell className="text-right tabular-nums">{row.failed}</TableCell>
+                          <TableCell className="text-right tabular-nums">
+                            {row.success_rate != null ? `${(row.success_rate * 100).toFixed(0)}%` : '—'}
+                          </TableCell>
+                        </TableRow>
+                      ))}
+                    </TableBody>
+                  </Table>
+                </div>
+              ) : (
+                <div className="min-h-[120px] flex items-center justify-center text-muted-foreground text-sm">
+                  No data
+                </div>
+              )}
+            </CardContent>
+          </Card>
+
+          <Card>
+            <CardHeader className="pb-2">
+              <CardTitle className="text-sm">TRs Sent by Node</CardTitle>
+              <CardDescription className="text-xs text-muted-foreground">
+                Share of total runs per source node (top {PIE_TOP_N}, remainder grouped as “Other”).
+              </CardDescription>
+            </CardHeader>
+            <CardContent>
+              {isLoading ? (
+                <div className="h-[260px] flex items-center justify-center text-muted-foreground text-sm">Loading…</div>
+              ) : sentByNodeChartData.length > 0 ? (
+                <ChartContainer config={{}} className="aspect-auto h-[260px] w-full">
+                  <PieChart>
+                    <Pie
+                      data={sentByNodeChartData}
+                      dataKey="value"
+                      nameKey="name"
+                      cx="50%"
+                      cy="50%"
+                      innerRadius={50}
+                      outerRadius={85}
+                      paddingAngle={2}
+                      label={({ name, percent }) => `${name} ${(percent * 100).toFixed(0)}%`}
+                    >
+                      {sentByNodeChartData.map((entry, idx) => (
+                        <Cell key={idx} fill={entry.fill} />
+                      ))}
+                    </Pie>
+                    <RechartsTooltip content={<ChartTooltipContent formatter={(v) => [v, '']} />} />
+                  </PieChart>
+                </ChartContainer>
+              ) : (
+                <div className="h-[260px] flex items-center justify-center text-muted-foreground text-sm">No data</div>
+              )}
+            </CardContent>
+          </Card>
+        </div>
       </TooltipProvider>
     </div>
   );

--- a/src/components/traceroutes/TracerouteStatsSection.tsx
+++ b/src/components/traceroutes/TracerouteStatsSection.tsx
@@ -1,4 +1,5 @@
 import { useMemo, useState } from 'react';
+import { Link } from 'react-router-dom';
 import { subHours, subDays } from 'date-fns';
 import { Cell, Legend, Line, LineChart, Pie, PieChart, XAxis, YAxis, Tooltip as RechartsTooltip } from 'recharts';
 import { Card, CardContent, CardDescription, CardHeader, CardTitle } from '@/components/ui/card';
@@ -34,7 +35,12 @@ const SOURCE_LABELS: Record<string, string> = {
   auto: 'Auto',
   user: 'User',
   external: 'External',
+  monitor: 'Monitor',
 };
+
+// Min number of attempts before a target is included in top/least success rankings.
+// One-off 1/1 perfect runs would otherwise dominate the "top" list.
+const TOP_TARGETS_MIN_ATTEMPTS = 5;
 
 export function TracerouteStatsSection() {
   const [timeframe, setTimeframe] = useState<TimeframeKey>('7d');
@@ -60,10 +66,33 @@ export function TracerouteStatsSection() {
     }));
   }, [data?.success_failure]);
 
+  const successOverTimeData = useMemo(() => {
+    if (!data?.success_over_time?.length) return [];
+    return data.success_over_time.map((d) => {
+      const finished = d.completed + d.failed;
+      const success_pct = finished > 0 ? (d.completed / finished) * 100 : null;
+      return { ...d, success_pct };
+    });
+  }, [data?.success_over_time]);
+
   const lineChartConfig: ChartConfig = {
     completed: { color: '#22c55e', label: 'Completed' },
     failed: { color: '#ef4444', label: 'Failed' },
+    success_pct: { color: '#3b82f6', label: 'Success %' },
   };
+
+  const eligibleTargets = useMemo(
+    () => (data?.by_target ?? []).filter((t) => t.total >= TOP_TARGETS_MIN_ATTEMPTS && t.success_rate != null),
+    [data?.by_target]
+  );
+  const topSuccessTargets = useMemo(
+    () => [...eligibleTargets].sort((a, b) => (b.success_rate ?? 0) - (a.success_rate ?? 0)).slice(0, 5),
+    [eligibleTargets]
+  );
+  const leastSuccessTargets = useMemo(
+    () => [...eligibleTargets].sort((a, b) => (a.success_rate ?? 0) - (b.success_rate ?? 0)).slice(0, 5),
+    [eligibleTargets]
+  );
 
   if (error) {
     return (
@@ -95,7 +124,7 @@ export function TracerouteStatsSection() {
         </Select>
       </div>
 
-      <div className="grid gap-4 md:grid-cols-2 lg:grid-cols-4">
+      <div className="grid gap-4 md:grid-cols-2 lg:grid-cols-3">
         {/* TR sources pie */}
         <Card>
           <CardHeader className="pb-2">
@@ -166,42 +195,20 @@ export function TracerouteStatsSection() {
           </CardContent>
         </Card>
 
-        {/* Top routers */}
+        {/* Success over time (14d line) */}
         <Card>
           <CardHeader className="pb-2">
-            <CardTitle className="text-sm">Top Routers</CardTitle>
-          </CardHeader>
-          <CardContent>
-            {isLoading ? (
-              <div className="h-[180px] flex items-center justify-center text-muted-foreground text-sm">Loading…</div>
-            ) : data?.top_routers?.length ? (
-              <div className="space-y-2 max-h-[180px] overflow-y-auto">
-                {data.top_routers.slice(0, 8).map((r) => (
-                  <div key={r.node_id} className="flex justify-between items-center gap-2 text-sm">
-                    <span className="truncate font-mono" title={r.short_name}>
-                      {r.short_name || r.node_id_str}
-                    </span>
-                    <span className="text-muted-foreground tabular-nums">{r.count}</span>
-                  </div>
-                ))}
-              </div>
-            ) : (
-              <div className="h-[180px] flex items-center justify-center text-muted-foreground text-sm">No data</div>
-            )}
-          </CardContent>
-        </Card>
-
-        {/* Success over time (14d line) */}
-        <Card className="md:col-span-2 lg:col-span-1">
-          <CardHeader className="pb-2">
             <CardTitle className="text-sm">Success Over Time (14d)</CardTitle>
+            <CardDescription className="text-xs text-muted-foreground">
+              Daily completed / failed counts (left axis) and success rate (right axis, dashed).
+            </CardDescription>
           </CardHeader>
           <CardContent>
             {isLoading ? (
               <div className="h-[180px] flex items-center justify-center text-muted-foreground text-sm">Loading…</div>
-            ) : data?.success_over_time?.length ? (
+            ) : successOverTimeData.length ? (
               <ChartContainer config={lineChartConfig} className="aspect-auto h-[180px] w-full">
-                <LineChart data={data.success_over_time} margin={{ top: 4, right: 4, bottom: 20, left: 4 }}>
+                <LineChart data={successOverTimeData} margin={{ top: 4, right: 4, bottom: 20, left: 4 }}>
                   <XAxis
                     dataKey="date"
                     tickLine={false}
@@ -213,16 +220,32 @@ export function TracerouteStatsSection() {
                     }}
                     tick={{ fontSize: 10 }}
                   />
-                  <YAxis tickLine={false} axisLine={false} width={28} tick={{ fontSize: 10 }} />
+                  <YAxis yAxisId="left" tickLine={false} axisLine={false} width={28} tick={{ fontSize: 10 }} />
+                  <YAxis
+                    yAxisId="right"
+                    orientation="right"
+                    tickLine={false}
+                    axisLine={false}
+                    width={32}
+                    domain={[0, 100]}
+                    tickFormatter={(v: number) => `${v}%`}
+                    tick={{ fontSize: 10 }}
+                  />
                   <RechartsTooltip
                     content={
                       <ChartTooltipContent
-                        formatter={(v) => [v, '']}
+                        formatter={(value, name) => {
+                          if (name === 'success_pct') {
+                            return [value == null ? '—' : `${(value as number).toFixed(0)}%`, ' Success rate'];
+                          }
+                          return [value, ` ${name === 'completed' ? 'Completed' : 'Failed'}`];
+                        }}
                         labelFormatter={(l) => new Date(l).toLocaleDateString()}
                       />
                     }
                   />
                   <Line
+                    yAxisId="left"
                     type="monotone"
                     dataKey="completed"
                     stroke="#22c55e"
@@ -230,7 +253,25 @@ export function TracerouteStatsSection() {
                     dot={{ r: 2 }}
                     connectNulls
                   />
-                  <Line type="monotone" dataKey="failed" stroke="#ef4444" strokeWidth={2} dot={{ r: 2 }} connectNulls />
+                  <Line
+                    yAxisId="left"
+                    type="monotone"
+                    dataKey="failed"
+                    stroke="#ef4444"
+                    strokeWidth={2}
+                    dot={{ r: 2 }}
+                    connectNulls
+                  />
+                  <Line
+                    yAxisId="right"
+                    type="monotone"
+                    dataKey="success_pct"
+                    stroke="#3b82f6"
+                    strokeWidth={2}
+                    strokeDasharray="4 4"
+                    dot={{ r: 2 }}
+                    connectNulls
+                  />
                   <Legend />
                 </LineChart>
               </ChartContainer>
@@ -242,6 +283,23 @@ export function TracerouteStatsSection() {
       </div>
 
       <TooltipProvider>
+        <div className="grid gap-4 md:grid-cols-2">
+          <TargetsRankingCard
+            title="Top success targets"
+            description={`Targets with the highest success rate in this period (min ${TOP_TARGETS_MIN_ATTEMPTS} attempts).`}
+            isLoading={isLoading}
+            rows={topSuccessTargets}
+            emptyMessage={`No targets with at least ${TOP_TARGETS_MIN_ATTEMPTS} finished attempts.`}
+          />
+          <TargetsRankingCard
+            title="Least successful targets"
+            description={`Targets with the lowest success rate in this period (min ${TOP_TARGETS_MIN_ATTEMPTS} attempts).`}
+            isLoading={isLoading}
+            rows={leastSuccessTargets}
+            emptyMessage={`No targets with at least ${TOP_TARGETS_MIN_ATTEMPTS} finished attempts.`}
+          />
+        </div>
+
         <Card>
           <CardHeader className="pb-2">
             <CardTitle className="text-sm">By source node</CardTitle>
@@ -319,5 +377,83 @@ export function TracerouteStatsSection() {
         </Card>
       </TooltipProvider>
     </div>
+  );
+}
+
+interface TargetRow {
+  node_id: number;
+  node_id_str: string;
+  short_name: string | null;
+  long_name: string | null;
+  total: number;
+  completed: number;
+  failed: number;
+  success_rate: number | null;
+}
+
+function TargetsRankingCard({
+  title,
+  description,
+  isLoading,
+  rows,
+  emptyMessage,
+}: {
+  title: string;
+  description: string;
+  isLoading: boolean;
+  rows: TargetRow[];
+  emptyMessage: string;
+}) {
+  return (
+    <Card>
+      <CardHeader className="pb-2">
+        <CardTitle className="text-sm">{title}</CardTitle>
+        <CardDescription className="text-xs text-muted-foreground">{description}</CardDescription>
+      </CardHeader>
+      <CardContent>
+        {isLoading ? (
+          <div className="min-h-[120px] flex items-center justify-center text-muted-foreground text-sm">Loading…</div>
+        ) : rows.length === 0 ? (
+          <div className="min-h-[120px] flex items-center justify-center text-muted-foreground text-sm">
+            {emptyMessage}
+          </div>
+        ) : (
+          <div className="rounded-md border overflow-x-auto">
+            <Table>
+              <TableHeader>
+                <TableRow>
+                  <TableHead>Target</TableHead>
+                  <TableHead className="text-right tabular-nums">Attempts</TableHead>
+                  <TableHead className="text-right tabular-nums">Success rate</TableHead>
+                </TableRow>
+              </TableHeader>
+              <TableBody>
+                {rows.map((row) => (
+                  <TableRow key={row.node_id}>
+                    <TableCell>
+                      <Link
+                        to={`/traceroutes?target_node=${row.node_id}`}
+                        className="flex flex-col gap-0.5 min-w-0 hover:underline"
+                      >
+                        <span className="font-medium truncate" title={row.short_name ?? row.node_id_str}>
+                          {row.short_name ?? row.node_id_str}
+                        </span>
+                        <span className="text-xs text-muted-foreground font-mono truncate" title={row.node_id_str}>
+                          {row.node_id_str}
+                        </span>
+                      </Link>
+                    </TableCell>
+                    <TableCell className="text-right tabular-nums">{row.completed + row.failed}</TableCell>
+                    <TableCell className="text-right tabular-nums">
+                      {row.success_rate != null ? `${(row.success_rate * 100).toFixed(0)}%` : '—'}
+                    </TableCell>
+                  </TableRow>
+                ))}
+              </TableBody>
+            </Table>
+          </div>
+        )}
+      </CardContent>
+    </Card>
   );
 }

--- a/src/hooks/api/useTraceroutes.ts
+++ b/src/hooks/api/useTraceroutes.ts
@@ -1,4 +1,4 @@
-import { useQuery, useMutation, useQueryClient, useSuspenseQuery } from '@tanstack/react-query';
+import { useQuery, useMutation, useQueryClient, useSuspenseQuery, useInfiniteQuery } from '@tanstack/react-query';
 import { useMeshtasticApi } from './useApi';
 
 export interface UseTraceroutesParams {
@@ -18,6 +18,18 @@ export function useTraceroutes(params?: UseTraceroutesParams) {
   return useQuery({
     queryKey: ['traceroutes', params],
     queryFn: () => api.getTraceroutes(params),
+  });
+}
+
+export type UseTraceroutesInfiniteParams = Omit<UseTraceroutesParams, 'page'>;
+
+export function useTraceroutesInfinite(params?: UseTraceroutesInfiniteParams) {
+  const api = useMeshtasticApi();
+  return useInfiniteQuery({
+    queryKey: ['traceroutes', 'infinite', params],
+    queryFn: ({ pageParam = 1 }) => api.getTraceroutes({ ...params, page: pageParam as number }),
+    initialPageParam: 1,
+    getNextPageParam: (lastPage, allPages) => (lastPage.next ? allPages.length + 1 : undefined),
   });
 }
 

--- a/src/hooks/useTraceroutesWithWebSocket.ts
+++ b/src/hooks/useTraceroutesWithWebSocket.ts
@@ -2,18 +2,22 @@ import { useEffect, useRef } from 'react';
 import { useQueryClient } from '@tanstack/react-query';
 import { useConfig } from '@/providers/ConfigProvider';
 import { authService } from '@/lib/auth/authService';
-import { useTraceroutes, UseTraceroutesParams } from '@/hooks/api/useTraceroutes';
+import {
+  useTraceroutes,
+  useTraceroutesInfinite,
+  UseTraceroutesParams,
+  UseTraceroutesInfiniteParams,
+} from '@/hooks/api/useTraceroutes';
 
 /**
- * Hook to fetch traceroutes and subscribe to real-time status updates via WebSocket.
- * Connects to ws/traceroutes/ when mounted; invalidates traceroutes query on status updates.
+ * Subscribe to live traceroute status updates via WebSocket and invalidate the
+ * shared `['traceroutes']` query cache when one arrives. Used by both the
+ * page-level history and embedded sections.
  */
-export function useTraceroutesWithWebSocket(params?: UseTraceroutesParams) {
+function useTraceroutesWebSocketInvalidator() {
   const queryClient = useQueryClient();
   const config = useConfig();
   const socketRef = useRef<WebSocket | null>(null);
-
-  const result = useTraceroutes(params);
 
   useEffect(() => {
     const token = authService.getAccessToken();
@@ -41,6 +45,24 @@ export function useTraceroutesWithWebSocket(params?: UseTraceroutesParams) {
       socketRef.current = null;
     };
   }, [config.apis.meshBot.baseUrl, queryClient]);
+}
 
-  return result;
+/**
+ * Hook to fetch traceroutes (single page) and subscribe to real-time status updates.
+ */
+export function useTraceroutesWithWebSocket(params?: UseTraceroutesParams) {
+  useTraceroutesWebSocketInvalidator();
+  return useTraceroutes(params);
+}
+
+/**
+ * Hook to fetch traceroutes paginated via useInfiniteQuery, with real-time updates.
+ * The full row list is exposed as `traceroutes` (flattened across pages).
+ */
+export function useTraceroutesInfiniteWithWebSocket(params?: UseTraceroutesInfiniteParams) {
+  useTraceroutesWebSocketInvalidator();
+  const query = useTraceroutesInfinite(params);
+  const traceroutes = query.data?.pages.flatMap((p) => p.results) ?? [];
+  const totalCount = query.data?.pages[0]?.count ?? null;
+  return { ...query, traceroutes, totalCount };
 }

--- a/src/lib/api/meshtastic-api.ts
+++ b/src/lib/api/meshtastic-api.ts
@@ -685,6 +685,16 @@ export class MeshtasticApi extends BaseApi {
       failed: number;
       success_rate: number | null;
     }>;
+    by_target?: Array<{
+      node_id: number;
+      node_id_str: string;
+      short_name: string | null;
+      long_name: string | null;
+      total: number;
+      completed: number;
+      failed: number;
+      success_rate: number | null;
+    }>;
     success_over_time: Array<{ date: string; completed: number; failed: number }>;
   }> {
     const searchParams = new URLSearchParams();

--- a/src/pages/traceroutes/TracerouteHistory.test.tsx
+++ b/src/pages/traceroutes/TracerouteHistory.test.tsx
@@ -91,7 +91,25 @@ interface InfiniteOptions {
   fetchNextPage?: ReturnType<typeof vi.fn>;
 }
 
-function setupHooks(infinite: InfiniteOptions = {}, triggerable: ManagedNode[] = []) {
+function makeObservedNode(overrides: Partial<ObservedNode> = {}): ObservedNode {
+  return {
+    internal_id: 1,
+    node_id: 100,
+    node_id_str: '!00000064',
+    mac_addr: null,
+    long_name: 'Target',
+    short_name: 'TGT',
+    hw_model: null,
+    public_key: null,
+    ...overrides,
+  } as ObservedNode;
+}
+
+function setupHooks(
+  infinite: InfiniteOptions = {},
+  triggerable: ManagedNode[] = [],
+  observed: ObservedNode[] = []
+) {
   const fetchNextPage = infinite.fetchNextPage ?? vi.fn();
   mockedUseInfinite.mockReturnValue({
     traceroutes: infinite.traceroutes ?? [],
@@ -109,8 +127,8 @@ function setupHooks(infinite: InfiniteOptions = {}, triggerable: ManagedNode[] =
     isPending: false,
   } as unknown as ReturnType<typeof useTriggerTraceroute>);
   mockedUseNodes.mockReturnValue({
-    nodes: [],
-    totalCount: 0,
+    nodes: observed,
+    totalCount: observed.length,
   } as unknown as ReturnType<typeof useNodesSuspense>);
   return { fetchNextPage };
 }
@@ -205,5 +223,74 @@ describe('TracerouteHistory', () => {
     setupHooks({ traceroutes: [makeTraceroute()], totalCount: 73 });
     renderAt('/traceroutes');
     expect(screen.getByText('(73)')).toBeInTheDocument();
+  });
+
+  it('applies the "Show successful" preset to status filter when clicked', () => {
+    setupHooks();
+    renderAt('/traceroutes');
+    fireEvent.click(screen.getByRole('button', { name: /show successful/i }));
+    const lastCall = mockedUseInfinite.mock.calls.at(-1)?.[0];
+    expect(lastCall).toEqual(expect.objectContaining({ status: 'completed,pending,sent' }));
+  });
+
+  it('clears status when "Show successful" is clicked while already active', () => {
+    setupHooks();
+    renderAt('/traceroutes?status=completed,pending,sent');
+    fireEvent.click(screen.getByRole('button', { name: /show successful/i }));
+    const lastCall = mockedUseInfinite.mock.calls.at(-1)?.[0];
+    expect(lastCall?.status).toBeUndefined();
+  });
+
+  it('applies the "Monitoring TRs" preset to trigger_type when clicked', () => {
+    setupHooks();
+    renderAt('/traceroutes');
+    fireEvent.click(screen.getByRole('button', { name: /monitoring trs/i }));
+    const lastCall = mockedUseInfinite.mock.calls.at(-1)?.[0];
+    expect(lastCall).toEqual(expect.objectContaining({ trigger_type: 'monitor' }));
+  });
+
+  it('applies the "Manually triggered" preset to trigger_type when clicked', () => {
+    setupHooks();
+    renderAt('/traceroutes');
+    fireEvent.click(screen.getByRole('button', { name: /manually triggered/i }));
+    const lastCall = mockedUseInfinite.mock.calls.at(-1)?.[0];
+    expect(lastCall).toEqual(expect.objectContaining({ trigger_type: 'user' }));
+  });
+
+  it('opens the searchable target filter and filters options by query', () => {
+    const nodes = [
+      makeObservedNode({ node_id: 1, node_id_str: '!00000001', short_name: 'AAA', long_name: 'Alpha' }),
+      makeObservedNode({ node_id: 2, node_id_str: '!00000002', short_name: 'BBB', long_name: 'Bravo' }),
+      makeObservedNode({ node_id: 3, node_id_str: '!00000003', short_name: 'CCC', long_name: 'Charlie' }),
+    ];
+    setupHooks({}, [], nodes);
+    renderAt('/traceroutes');
+
+    fireEvent.click(screen.getByRole('button', { name: /target \(recipient\)/i }));
+
+    expect(screen.getAllByText('AAA').length).toBeGreaterThan(0);
+    expect(screen.getAllByText('BBB').length).toBeGreaterThan(0);
+    expect(screen.getAllByText('CCC').length).toBeGreaterThan(0);
+
+    const searchInput = screen.getByPlaceholderText('Search nodes...');
+    fireEvent.change(searchInput, { target: { value: 'brav' } });
+
+    expect(screen.queryByText('AAA')).not.toBeInTheDocument();
+    expect(screen.getAllByText('BBB').length).toBeGreaterThan(0);
+    expect(screen.queryByText('CCC')).not.toBeInTheDocument();
+  });
+
+  it('selecting a node from the searchable target filter updates the query', () => {
+    const nodes = [
+      makeObservedNode({ node_id: 555, node_id_str: '!0000022b', short_name: 'PICKME', long_name: 'Pick me' }),
+    ];
+    setupHooks({}, [], nodes);
+    renderAt('/traceroutes');
+
+    fireEvent.click(screen.getByRole('button', { name: /target \(recipient\)/i }));
+    fireEvent.click(screen.getByRole('button', { name: /pickme/i }));
+
+    const lastCall = mockedUseInfinite.mock.calls.at(-1)?.[0];
+    expect(lastCall).toEqual(expect.objectContaining({ target_node: 555 }));
   });
 });

--- a/src/pages/traceroutes/TracerouteHistory.test.tsx
+++ b/src/pages/traceroutes/TracerouteHistory.test.tsx
@@ -1,0 +1,209 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { render, screen, fireEvent } from '@testing-library/react';
+import { MemoryRouter } from 'react-router-dom';
+import type { AutoTraceRoute, ManagedNode, ObservedNode } from '@/lib/models';
+
+vi.mock('@/hooks/useTraceroutesWithWebSocket', () => ({
+  useTraceroutesInfiniteWithWebSocket: vi.fn(),
+}));
+vi.mock('@/hooks/api/useTraceroutes', () => ({
+  useTracerouteTriggerableNodesSuspense: vi.fn(),
+  useTriggerTraceroute: vi.fn(),
+}));
+vi.mock('@/hooks/api/useNodes', () => ({
+  useNodesSuspense: vi.fn(),
+}));
+
+vi.mock('@/components/traceroutes/TracerouteStatsSection', () => ({
+  TracerouteStatsSection: () => <div data-testid="stats-section" />,
+}));
+
+vi.mock('@/pages/traceroutes/TracerouteDetailModal', () => ({
+  TracerouteDetailModal: ({ tracerouteId, open }: { tracerouteId: number | null; open: boolean }) =>
+    open ? <div role="dialog" data-testid="detail-modal">Detail for {tracerouteId}</div> : null,
+}));
+
+vi.mock('@/pages/traceroutes/TriggerTracerouteModal', () => ({
+  TriggerTracerouteModal: ({ open }: { open: boolean }) =>
+    open ? <div role="dialog" data-testid="trigger-modal">Trigger modal</div> : null,
+}));
+
+import { useTraceroutesInfiniteWithWebSocket } from '@/hooks/useTraceroutesWithWebSocket';
+import { useTracerouteTriggerableNodesSuspense, useTriggerTraceroute } from '@/hooks/api/useTraceroutes';
+import { useNodesSuspense } from '@/hooks/api/useNodes';
+import { TracerouteHistory } from './TracerouteHistory';
+
+const mockedUseInfinite = vi.mocked(useTraceroutesInfiniteWithWebSocket);
+const mockedUseTriggerable = vi.mocked(useTracerouteTriggerableNodesSuspense);
+const mockedUseTrigger = vi.mocked(useTriggerTraceroute);
+const mockedUseNodes = vi.mocked(useNodesSuspense);
+
+function makeManagedNode(overrides: Partial<ManagedNode> = {}): ManagedNode {
+  return {
+    node_id: 200,
+    long_name: 'Source node',
+    short_name: 'SRC',
+    last_heard: null,
+    node_id_str: '!000000c8',
+    owner: { id: 1, username: 'me' },
+    constellation: { id: 1, name: 'C1' },
+    allow_auto_traceroute: true,
+    position: { latitude: null, longitude: null },
+    ...overrides,
+  };
+}
+
+function makeTraceroute(overrides: Partial<AutoTraceRoute> = {}): AutoTraceRoute {
+  return {
+    id: 1,
+    source_node: makeManagedNode(),
+    target_node: {
+      internal_id: 1,
+      node_id: 100,
+      node_id_str: '!00000064',
+      mac_addr: null,
+      long_name: 'Target',
+      short_name: 'TGT',
+      hw_model: null,
+      public_key: null,
+    } as ObservedNode,
+    trigger_type: 'user',
+    triggered_by: 1,
+    triggered_by_username: 'me',
+    trigger_source: 'ui',
+    triggered_at: '2026-04-17T10:00:00Z',
+    status: 'completed',
+    route: [],
+    route_back: [],
+    raw_packet: null,
+    completed_at: '2026-04-17T10:00:05Z',
+    error_message: null,
+    ...overrides,
+  };
+}
+
+interface InfiniteOptions {
+  traceroutes?: AutoTraceRoute[];
+  totalCount?: number | null;
+  isLoading?: boolean;
+  hasNextPage?: boolean;
+  isFetchingNextPage?: boolean;
+  fetchNextPage?: ReturnType<typeof vi.fn>;
+}
+
+function setupHooks(infinite: InfiniteOptions = {}, triggerable: ManagedNode[] = []) {
+  const fetchNextPage = infinite.fetchNextPage ?? vi.fn();
+  mockedUseInfinite.mockReturnValue({
+    traceroutes: infinite.traceroutes ?? [],
+    totalCount: infinite.totalCount ?? null,
+    isLoading: infinite.isLoading ?? false,
+    error: null,
+    fetchNextPage,
+    hasNextPage: infinite.hasNextPage ?? false,
+    isFetchingNextPage: infinite.isFetchingNextPage ?? false,
+  } as unknown as ReturnType<typeof useTraceroutesInfiniteWithWebSocket>);
+  mockedUseTriggerable.mockReturnValue({ triggerableNodes: triggerable });
+  mockedUseTrigger.mockReturnValue({
+    mutate: vi.fn(),
+    mutateAsync: vi.fn(),
+    isPending: false,
+  } as unknown as ReturnType<typeof useTriggerTraceroute>);
+  mockedUseNodes.mockReturnValue({
+    nodes: [],
+    totalCount: 0,
+  } as unknown as ReturnType<typeof useNodesSuspense>);
+  return { fetchNextPage };
+}
+
+function renderAt(initialPath: string) {
+  return render(
+    <MemoryRouter initialEntries={[initialPath]}>
+      <TracerouteHistory />
+    </MemoryRouter>
+  );
+}
+
+describe('TracerouteHistory', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('hydrates target_node from the URL into the query params', () => {
+    setupHooks();
+    renderAt('/traceroutes?target_node=1127903080');
+    expect(mockedUseInfinite).toHaveBeenCalledWith(
+      expect.objectContaining({ target_node: 1127903080 })
+    );
+  });
+
+  it('hydrates target_node and status (CSV) from the URL', () => {
+    setupHooks();
+    renderAt('/traceroutes?target_node=42&status=completed,failed');
+    expect(mockedUseInfinite).toHaveBeenCalledWith(
+      expect.objectContaining({ target_node: 42, status: 'completed,failed' })
+    );
+  });
+
+  it('hydrates trigger_type CSV from the URL', () => {
+    setupHooks();
+    renderAt('/traceroutes?trigger_type=user,monitor');
+    expect(mockedUseInfinite).toHaveBeenCalledWith(
+      expect.objectContaining({ trigger_type: 'user,monitor' })
+    );
+  });
+
+  it('passes unknown filter values through to the API (graceful)', () => {
+    setupHooks();
+    renderAt('/traceroutes?status=bogus_value&target_node=999999999');
+    expect(mockedUseInfinite).toHaveBeenCalledWith(
+      expect.objectContaining({ status: 'bogus_value', target_node: 999999999 })
+    );
+  });
+
+  it('shows the Trigger CTA when the user has triggerable nodes', () => {
+    setupHooks({}, [makeManagedNode()]);
+    renderAt('/traceroutes');
+    expect(screen.getByRole('button', { name: /trigger traceroute/i })).toBeInTheDocument();
+  });
+
+  it('hides the Trigger CTA when the user has no triggerable nodes', () => {
+    setupHooks({}, []);
+    renderAt('/traceroutes');
+    expect(screen.queryByRole('button', { name: /^trigger traceroute$/i })).not.toBeInTheDocument();
+  });
+
+  it('shows a "Clear filters" button only when at least one filter is set', () => {
+    setupHooks();
+    const { unmount } = renderAt('/traceroutes');
+    expect(screen.queryByRole('button', { name: /clear filters/i })).not.toBeInTheDocument();
+    unmount();
+
+    renderAt('/traceroutes?target_node=42');
+    expect(screen.getByRole('button', { name: /clear filters/i })).toBeInTheDocument();
+  });
+
+  it('renders Load more disabled when there is no next page', () => {
+    setupHooks({ traceroutes: [makeTraceroute()], hasNextPage: false });
+    renderAt('/traceroutes');
+    const btn = screen.getByRole('button', { name: /no more results/i });
+    expect(btn).toBeDisabled();
+  });
+
+  it('calls fetchNextPage when Load more is clicked', () => {
+    const fetchNextPage = vi.fn();
+    setupHooks({
+      traceroutes: [makeTraceroute()],
+      hasNextPage: true,
+      fetchNextPage,
+    });
+    renderAt('/traceroutes');
+    fireEvent.click(screen.getByRole('button', { name: /load more/i }));
+    expect(fetchNextPage).toHaveBeenCalled();
+  });
+
+  it('shows the total count in the table title when available', () => {
+    setupHooks({ traceroutes: [makeTraceroute()], totalCount: 73 });
+    renderAt('/traceroutes');
+    expect(screen.getByText('(73)')).toBeInTheDocument();
+  });
+});

--- a/src/pages/traceroutes/TracerouteHistory.tsx
+++ b/src/pages/traceroutes/TracerouteHistory.tsx
@@ -1,8 +1,9 @@
-import { useMemo } from 'react';
+import { useEffect, useMemo, useRef, useState } from 'react';
 import { format, subDays } from 'date-fns';
 import { useSearchParams } from 'react-router-dom';
 import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card';
 import { Button } from '@/components/ui/button';
+import { Input } from '@/components/ui/input';
 import { Table, TableBody, TableCell, TableHead, TableHeader, TableRow } from '@/components/ui/table';
 import { Badge } from '@/components/ui/badge';
 import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from '@/components/ui/select';
@@ -22,8 +23,7 @@ import { TriggerTracerouteModal, TriggerMode } from './TriggerTracerouteModal';
 import { TracerouteDetailModal } from './TracerouteDetailModal';
 import { getTracerouteErrorMessage } from './tracerouteErrors';
 import { TracerouteStatsSection } from '@/components/traceroutes/TracerouteStatsSection';
-import { AutoTraceRoute } from '@/lib/models';
-import { useState } from 'react';
+import { AutoTraceRoute, ObservedNode } from '@/lib/models';
 import { ChevronDown, RotateCw, RouteIcon, X } from 'lucide-react';
 
 type StatusValue = 'completed' | 'failed' | 'pending' | 'sent';
@@ -142,6 +142,9 @@ export function TracerouteHistory() {
     return SUCCESS_STATUS_PRESET.every((s) => statusValues.includes(s));
   }, [statusValues]);
 
+  const isMonitorPreset = triggerTypeValues.length === 1 && triggerTypeValues[0] === 'monitor';
+  const isUserPreset = triggerTypeValues.length === 1 && triggerTypeValues[0] === 'user';
+
   const [triggerModalOpen, setTriggerModalOpen] = useState(false);
   const [selectedTracerouteId, setSelectedTracerouteId] = useState<number | null>(null);
 
@@ -191,15 +194,6 @@ export function TracerouteHistory() {
         </CardHeader>
         <CardContent>
           <div className="mb-4 flex flex-wrap gap-2 items-center">
-            <Button
-              variant={isSuccessPreset ? 'default' : 'outline'}
-              size="sm"
-              onClick={() => setStatusValues(isSuccessPreset ? [] : SUCCESS_STATUS_PRESET)}
-              title="Show traceroutes that succeeded or are still in flight"
-            >
-              Success preset
-            </Button>
-
             <Select
               value={sourceNodeId != null ? String(sourceNodeId) : 'all'}
               onValueChange={(v) => setSourceNode(v === 'all' ? null : parseInt(v, 10))}
@@ -217,22 +211,13 @@ export function TracerouteHistory() {
               </SelectContent>
             </Select>
 
-            <Select
-              value={targetNodeId != null ? String(targetNodeId) : 'all'}
-              onValueChange={(v) => setTargetNode(v === 'all' ? null : parseInt(v, 10))}
-            >
-              <SelectTrigger className="w-[180px]">
-                <SelectValue placeholder="Target (recipient)" />
-              </SelectTrigger>
-              <SelectContent>
-                <SelectItem value="all">All targets</SelectItem>
-                {observedNodes.map((n) => (
-                  <SelectItem key={n.node_id} value={String(n.node_id)}>
-                    {n.short_name ?? n.node_id_str ?? String(n.node_id)}
-                  </SelectItem>
-                ))}
-              </SelectContent>
-            </Select>
+            <SearchableNodeFilter
+              nodes={observedNodes}
+              value={targetNodeId}
+              onChange={setTargetNode}
+              placeholder="Target (recipient)"
+              allLabel="All targets"
+            />
 
             <DropdownMenu>
               <DropdownMenuTrigger asChild>
@@ -286,6 +271,34 @@ export function TracerouteHistory() {
                 Clear filters
               </Button>
             )}
+          </div>
+
+          <div className="mb-4 flex flex-wrap gap-2 items-center">
+            <span className="text-xs uppercase tracking-wide text-muted-foreground mr-1">Presets:</span>
+            <Button
+              variant={isSuccessPreset ? 'default' : 'outline'}
+              size="sm"
+              onClick={() => setStatusValues(isSuccessPreset ? [] : SUCCESS_STATUS_PRESET)}
+              title="Show traceroutes that succeeded or are still in flight"
+            >
+              Show successful
+            </Button>
+            <Button
+              variant={isMonitorPreset ? 'default' : 'outline'}
+              size="sm"
+              onClick={() => setTriggerTypeValues(isMonitorPreset ? [] : ['monitor'])}
+              title="Show only monitor-triggered traceroutes"
+            >
+              Monitoring TRs
+            </Button>
+            <Button
+              variant={isUserPreset ? 'default' : 'outline'}
+              size="sm"
+              onClick={() => setTriggerTypeValues(isUserPreset ? [] : ['user'])}
+              title="Show only user-triggered traceroutes"
+            >
+              Manually triggered
+            </Button>
           </div>
 
           {isLoading && <div className="py-8 text-center text-muted-foreground">Loading...</div>}
@@ -406,6 +419,131 @@ export function TracerouteHistory() {
         }}
         isSubmitting={triggerMutation.isPending}
       />
+    </div>
+  );
+}
+
+interface SearchableNodeFilterProps {
+  nodes: ObservedNode[];
+  value: number | null;
+  onChange: (value: number | null) => void;
+  placeholder: string;
+  allLabel: string;
+  className?: string;
+}
+
+function SearchableNodeFilter({ nodes, value, onChange, placeholder, allLabel, className }: SearchableNodeFilterProps) {
+  const [open, setOpen] = useState(false);
+  const [query, setQuery] = useState('');
+  const containerRef = useRef<HTMLDivElement>(null);
+  const inputRef = useRef<HTMLInputElement>(null);
+
+  useEffect(() => {
+    if (!open) return;
+    const handleClickOutside = (event: MouseEvent) => {
+      if (containerRef.current && !containerRef.current.contains(event.target as Node)) {
+        setOpen(false);
+      }
+    };
+    document.addEventListener('mousedown', handleClickOutside);
+    return () => document.removeEventListener('mousedown', handleClickOutside);
+  }, [open]);
+
+  useEffect(() => {
+    if (open) {
+      setQuery('');
+      // Defer focus until after the dropdown is rendered.
+      requestAnimationFrame(() => inputRef.current?.focus());
+    }
+  }, [open]);
+
+  const selected = value != null ? nodes.find((n) => n.node_id === value) : null;
+  const selectedLabel = selected
+    ? (selected.short_name ?? selected.node_id_str ?? String(selected.node_id))
+    : placeholder;
+
+  const filtered = useMemo(() => {
+    const q = query.trim().toLowerCase();
+    if (!q) return nodes.slice(0, 200);
+    return nodes
+      .filter((n) => {
+        const haystack = [n.short_name, n.long_name, n.node_id_str, String(n.node_id)]
+          .filter((s): s is string => !!s)
+          .join(' ')
+          .toLowerCase();
+        return haystack.includes(q);
+      })
+      .slice(0, 200);
+  }, [nodes, query]);
+
+  return (
+    <div ref={containerRef} className={`relative ${className ?? ''}`}>
+      <Button
+        type="button"
+        variant="outline"
+        size="sm"
+        className="w-[200px] justify-between font-normal h-9"
+        onClick={() => setOpen((o) => !o)}
+        aria-haspopup="listbox"
+        aria-expanded={open}
+      >
+        <span className={selected ? '' : 'text-muted-foreground'}>{selectedLabel}</span>
+        <ChevronDown className="h-4 w-4 opacity-50 shrink-0" />
+      </Button>
+      {open && (
+        <div className="absolute left-0 top-[calc(100%+0.25rem)] z-50 w-[260px] rounded-md border border-border bg-popover shadow-lg">
+          <div className="p-2 border-b border-border">
+            <Input
+              ref={inputRef}
+              type="text"
+              placeholder="Search nodes..."
+              className="h-8"
+              value={query}
+              onChange={(e) => setQuery(e.target.value)}
+            />
+          </div>
+          <ul role="listbox" className="max-h-64 overflow-y-auto py-1">
+            <li>
+              <button
+                type="button"
+                className={`w-full text-left px-3 py-1.5 text-sm hover:bg-accent ${value == null ? 'bg-accent/50 font-medium' : ''}`}
+                onClick={() => {
+                  onChange(null);
+                  setOpen(false);
+                }}
+              >
+                {allLabel}
+              </button>
+            </li>
+            {filtered.length === 0 && (
+              <li className="px-3 py-2 text-sm text-muted-foreground">No nodes match “{query}”</li>
+            )}
+            {filtered.map((n) => {
+              const label = n.short_name ?? n.node_id_str ?? String(n.node_id);
+              const isSelected = value === n.node_id;
+              return (
+                <li key={n.node_id}>
+                  <button
+                    type="button"
+                    className={`w-full text-left px-3 py-1.5 text-sm hover:bg-accent ${isSelected ? 'bg-accent/50 font-medium' : ''}`}
+                    onClick={() => {
+                      onChange(n.node_id);
+                      setOpen(false);
+                    }}
+                  >
+                    <div className="flex flex-col">
+                      <span>{label}</span>
+                      {n.long_name && n.long_name !== label && (
+                        <span className="text-xs text-muted-foreground">{n.long_name}</span>
+                      )}
+                    </div>
+                  </button>
+                </li>
+              );
+            })}
+          </ul>
+        </div>
+      )}
     </div>
   );
 }

--- a/src/pages/traceroutes/TracerouteHistory.tsx
+++ b/src/pages/traceroutes/TracerouteHistory.tsx
@@ -1,21 +1,47 @@
-import { useState } from 'react';
-import { format } from 'date-fns';
-import { subDays } from 'date-fns';
+import { useMemo } from 'react';
+import { format, subDays } from 'date-fns';
+import { useSearchParams } from 'react-router-dom';
 import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card';
 import { Button } from '@/components/ui/button';
 import { Table, TableBody, TableCell, TableHead, TableHeader, TableRow } from '@/components/ui/table';
 import { Badge } from '@/components/ui/badge';
 import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from '@/components/ui/select';
+import {
+  DropdownMenu,
+  DropdownMenuCheckboxItem,
+  DropdownMenuContent,
+  DropdownMenuLabel,
+  DropdownMenuSeparator,
+  DropdownMenuTrigger,
+} from '@/components/ui/dropdown-menu';
 import { toast } from 'sonner';
-import { useTraceroutesWithWebSocket } from '@/hooks/useTraceroutesWithWebSocket';
+import { useTraceroutesInfiniteWithWebSocket } from '@/hooks/useTraceroutesWithWebSocket';
 import { useTracerouteTriggerableNodesSuspense, useTriggerTraceroute } from '@/hooks/api/useTraceroutes';
 import { useNodesSuspense } from '@/hooks/api/useNodes';
-import { TriggerTracerouteModal } from './TriggerTracerouteModal';
+import { TriggerTracerouteModal, TriggerMode } from './TriggerTracerouteModal';
 import { TracerouteDetailModal } from './TracerouteDetailModal';
 import { getTracerouteErrorMessage } from './tracerouteErrors';
 import { TracerouteStatsSection } from '@/components/traceroutes/TracerouteStatsSection';
 import { AutoTraceRoute } from '@/lib/models';
-import { RouteIcon, RotateCw } from 'lucide-react';
+import { useState } from 'react';
+import { ChevronDown, RotateCw, RouteIcon, X } from 'lucide-react';
+
+type StatusValue = 'completed' | 'failed' | 'pending' | 'sent';
+const STATUS_OPTIONS: Array<{ value: StatusValue; label: string }> = [
+  { value: 'completed', label: 'Completed' },
+  { value: 'failed', label: 'Failed' },
+  { value: 'pending', label: 'Pending' },
+  { value: 'sent', label: 'Sent' },
+];
+const SUCCESS_STATUS_PRESET: StatusValue[] = ['completed', 'pending', 'sent'];
+
+type TriggerTypeValue = 'auto' | 'user' | 'external' | 'monitor';
+const TRIGGER_TYPE_OPTIONS: Array<{ value: TriggerTypeValue; label: string }> = [
+  { value: 'auto', label: 'Auto' },
+  { value: 'user', label: 'User' },
+  { value: 'external', label: 'External' },
+  { value: 'monitor', label: 'Monitor' },
+];
 
 function routeSummary(tr: AutoTraceRoute): string {
   const route = tr.route;
@@ -30,10 +56,6 @@ function routeSummary(tr: AutoTraceRoute): string {
   return `${outStr} out, ${backStr} back`;
 }
 
-function displayStatus(tr: AutoTraceRoute): string {
-  return tr.status;
-}
-
 function StatusBadge({ status }: { status: string }) {
   const variant =
     status === 'completed'
@@ -46,20 +68,94 @@ function StatusBadge({ status }: { status: string }) {
   return <Badge variant={variant}>{status}</Badge>;
 }
 
+function parseCsvParam<T extends string>(raw: string | null): T[] {
+  if (!raw) return [];
+  return raw
+    .split(',')
+    .map((s) => s.trim())
+    .filter(Boolean) as T[];
+}
+
+function parseNumberParam(raw: string | null): number | null {
+  if (!raw) return null;
+  const n = parseInt(raw, 10);
+  return Number.isFinite(n) ? n : null;
+}
+
+function multiSelectLabel<T extends string>(
+  values: T[],
+  options: Array<{ value: T; label: string }>,
+  fallback: string
+): string {
+  if (values.length === 0) return fallback;
+  if (values.length === 1) {
+    return options.find((o) => o.value === values[0])?.label ?? values[0];
+  }
+  return `${fallback} (${values.length})`;
+}
+
 export function TracerouteHistory() {
-  const [tabFilter, setTabFilter] = useState<'success' | 'all'>('success');
-  const [sourceNodeId, setSourceNodeId] = useState<number | null>(null);
-  const [targetNodeId, setTargetNodeId] = useState<number | null>(null);
+  const [searchParams, setSearchParams] = useSearchParams();
+
+  // Hydrate filters from URL search params (single source of truth).
+  const sourceNodeId = parseNumberParam(searchParams.get('source_node'));
+  const targetNodeId = parseNumberParam(searchParams.get('target_node'));
+  const statusValues = parseCsvParam<StatusValue>(searchParams.get('status'));
+  const triggerTypeValues = parseCsvParam<TriggerTypeValue>(searchParams.get('trigger_type'));
+
+  const updateParams = (patch: Record<string, string | null>) => {
+    const next = new URLSearchParams(searchParams);
+    for (const [key, value] of Object.entries(patch)) {
+      if (value == null || value === '') {
+        next.delete(key);
+      } else {
+        next.set(key, value);
+      }
+    }
+    setSearchParams(next, { replace: true });
+  };
+
+  const setSourceNode = (id: number | null) => updateParams({ source_node: id?.toString() ?? null });
+  const setTargetNode = (id: number | null) => updateParams({ target_node: id?.toString() ?? null });
+  const setStatusValues = (values: StatusValue[]) => updateParams({ status: values.length ? values.join(',') : null });
+  const setTriggerTypeValues = (values: TriggerTypeValue[]) =>
+    updateParams({ trigger_type: values.length ? values.join(',') : null });
+
+  const toggleValue = <T extends string>(current: T[], value: T): T[] =>
+    current.includes(value) ? current.filter((v) => v !== value) : [...current, value];
+
+  const hasAnyFilter =
+    sourceNodeId != null || targetNodeId != null || statusValues.length > 0 || triggerTypeValues.length > 0;
+
+  const clearFilters = () => {
+    const next = new URLSearchParams(searchParams);
+    next.delete('source_node');
+    next.delete('target_node');
+    next.delete('status');
+    next.delete('trigger_type');
+    setSearchParams(next, { replace: true });
+  };
+
+  // Successful preset = the status value set used by the old "Success" tab.
+  const isSuccessPreset = useMemo(() => {
+    if (statusValues.length !== SUCCESS_STATUS_PRESET.length) return false;
+    return SUCCESS_STATUS_PRESET.every((s) => statusValues.includes(s));
+  }, [statusValues]);
+
   const [triggerModalOpen, setTriggerModalOpen] = useState(false);
-  const [triggerMode, setTriggerMode] = useState<'user' | 'auto'>('user');
   const [selectedTracerouteId, setSelectedTracerouteId] = useState<number | null>(null);
 
-  const { data, isLoading, error } = useTraceroutesWithWebSocket({
-    status: tabFilter === 'success' ? 'completed,pending,sent' : undefined,
+  const queryParams = {
     source_node: sourceNodeId ?? undefined,
     target_node: targetNodeId ?? undefined,
+    status: statusValues.length ? statusValues.join(',') : undefined,
+    trigger_type: triggerTypeValues.length ? triggerTypeValues.join(',') : undefined,
     page_size: 50,
-  });
+  };
+
+  const { traceroutes, totalCount, isLoading, error, fetchNextPage, hasNextPage, isFetchingNextPage } =
+    useTraceroutesInfiniteWithWebSocket(queryParams);
+
   const { triggerableNodes } = useTracerouteTriggerableNodesSuspense();
   const canTrigger = triggerableNodes.length > 0;
   const { nodes: observedNodes } = useNodesSuspense({
@@ -68,48 +164,45 @@ export function TracerouteHistory() {
   });
   const triggerMutation = useTriggerTraceroute();
 
-  const handleOpenTrigger = (mode: 'user' | 'auto') => {
-    setTriggerMode(mode);
-    setTriggerModalOpen(true);
-  };
-
-  const traceroutes = data?.results ?? [];
-
   return (
     <div className="container mx-auto py-6 space-y-6">
+      <div className="flex flex-row items-center justify-between gap-4">
+        <h1 className="text-2xl font-semibold flex items-center gap-2">
+          <RouteIcon className="h-6 w-6" />
+          Traceroute history
+        </h1>
+        {canTrigger && (
+          <Button size="default" onClick={() => setTriggerModalOpen(true)}>
+            <RouteIcon className="mr-2 h-4 w-4" />
+            Trigger traceroute
+          </Button>
+        )}
+      </div>
+
       <TracerouteStatsSection />
+
       <Card>
-        <CardHeader className="flex flex-row items-center justify-between">
+        <CardHeader>
           <CardTitle className="flex items-center gap-2">
             <RouteIcon className="h-5 w-5" />
             Traceroutes
+            {totalCount != null && <span className="text-sm text-muted-foreground font-normal">({totalCount})</span>}
           </CardTitle>
-          {canTrigger && (
-            <div className="flex gap-2">
-              <Button variant="outline" size="sm" onClick={() => handleOpenTrigger('user')}>
-                Trigger TR (target)
-              </Button>
-              <Button variant="outline" size="sm" onClick={() => handleOpenTrigger('auto')}>
-                Trigger TR (auto)
-              </Button>
-            </div>
-          )}
         </CardHeader>
         <CardContent>
           <div className="mb-4 flex flex-wrap gap-2 items-center">
             <Button
-              variant={tabFilter === 'success' ? 'default' : 'outline'}
+              variant={isSuccessPreset ? 'default' : 'outline'}
               size="sm"
-              onClick={() => setTabFilter('success')}
+              onClick={() => setStatusValues(isSuccessPreset ? [] : SUCCESS_STATUS_PRESET)}
+              title="Show traceroutes that succeeded or are still in flight"
             >
-              Success
+              Success preset
             </Button>
-            <Button variant={tabFilter === 'all' ? 'default' : 'outline'} size="sm" onClick={() => setTabFilter('all')}>
-              All
-            </Button>
+
             <Select
               value={sourceNodeId != null ? String(sourceNodeId) : 'all'}
-              onValueChange={(v) => setSourceNodeId(v === 'all' ? null : parseInt(v, 10))}
+              onValueChange={(v) => setSourceNode(v === 'all' ? null : parseInt(v, 10))}
             >
               <SelectTrigger className="w-[180px]">
                 <SelectValue placeholder="Source (sender)" />
@@ -123,9 +216,10 @@ export function TracerouteHistory() {
                 ))}
               </SelectContent>
             </Select>
+
             <Select
               value={targetNodeId != null ? String(targetNodeId) : 'all'}
-              onValueChange={(v) => setTargetNodeId(v === 'all' ? null : parseInt(v, 10))}
+              onValueChange={(v) => setTargetNode(v === 'all' ? null : parseInt(v, 10))}
             >
               <SelectTrigger className="w-[180px]">
                 <SelectValue placeholder="Target (recipient)" />
@@ -139,6 +233,59 @@ export function TracerouteHistory() {
                 ))}
               </SelectContent>
             </Select>
+
+            <DropdownMenu>
+              <DropdownMenuTrigger asChild>
+                <Button variant="outline" size="sm" className="w-[160px] justify-between">
+                  {multiSelectLabel(statusValues, STATUS_OPTIONS, 'Status')}
+                  <ChevronDown className="h-4 w-4 opacity-50" />
+                </Button>
+              </DropdownMenuTrigger>
+              <DropdownMenuContent align="start">
+                <DropdownMenuLabel>Status</DropdownMenuLabel>
+                <DropdownMenuSeparator />
+                {STATUS_OPTIONS.map((opt) => (
+                  <DropdownMenuCheckboxItem
+                    key={opt.value}
+                    checked={statusValues.includes(opt.value)}
+                    onCheckedChange={() => setStatusValues(toggleValue(statusValues, opt.value))}
+                    onSelect={(e) => e.preventDefault()}
+                  >
+                    {opt.label}
+                  </DropdownMenuCheckboxItem>
+                ))}
+              </DropdownMenuContent>
+            </DropdownMenu>
+
+            <DropdownMenu>
+              <DropdownMenuTrigger asChild>
+                <Button variant="outline" size="sm" className="w-[180px] justify-between">
+                  {multiSelectLabel(triggerTypeValues, TRIGGER_TYPE_OPTIONS, 'Trigger type')}
+                  <ChevronDown className="h-4 w-4 opacity-50" />
+                </Button>
+              </DropdownMenuTrigger>
+              <DropdownMenuContent align="start">
+                <DropdownMenuLabel>Trigger type</DropdownMenuLabel>
+                <DropdownMenuSeparator />
+                {TRIGGER_TYPE_OPTIONS.map((opt) => (
+                  <DropdownMenuCheckboxItem
+                    key={opt.value}
+                    checked={triggerTypeValues.includes(opt.value)}
+                    onCheckedChange={() => setTriggerTypeValues(toggleValue(triggerTypeValues, opt.value))}
+                    onSelect={(e) => e.preventDefault()}
+                  >
+                    {opt.label}
+                  </DropdownMenuCheckboxItem>
+                ))}
+              </DropdownMenuContent>
+            </DropdownMenu>
+
+            {hasAnyFilter && (
+              <Button variant="ghost" size="sm" onClick={clearFilters} title="Clear all filters">
+                <X className="mr-1 h-4 w-4" />
+                Clear filters
+              </Button>
+            )}
           </div>
 
           {isLoading && <div className="py-8 text-center text-muted-foreground">Loading...</div>}
@@ -151,74 +298,86 @@ export function TracerouteHistory() {
             <div className="py-8 text-center text-muted-foreground">No traceroutes yet.</div>
           )}
           {!isLoading && !error && traceroutes.length > 0 && (
-            <Table>
-              <TableHeader>
-                <TableRow>
-                  <TableHead>Source</TableHead>
-                  <TableHead>Target</TableHead>
-                  <TableHead>Type</TableHead>
-                  <TableHead>Triggered by</TableHead>
-                  <TableHead>Status</TableHead>
-                  <TableHead>Route</TableHead>
-                  <TableHead>Triggered</TableHead>
-                  <TableHead>Completed</TableHead>
-                  {canTrigger && <TableHead className="w-12"></TableHead>}
-                </TableRow>
-              </TableHeader>
-              <TableBody>
-                {traceroutes.map((tr) => (
-                  <TableRow
-                    key={tr.id}
-                    className="cursor-pointer hover:bg-muted/50"
-                    onClick={() => setSelectedTracerouteId(tr.id)}
-                  >
-                    <TableCell>{tr.source_node?.short_name ?? tr.source_node?.node_id_str ?? '—'}</TableCell>
-                    <TableCell>{tr.target_node?.short_name ?? tr.target_node?.node_id_str ?? '—'}</TableCell>
-                    <TableCell>{tr.trigger_type}</TableCell>
-                    <TableCell>{tr.triggered_by_username ?? '—'}</TableCell>
-                    <TableCell>
-                      <StatusBadge status={displayStatus(tr)} />
-                    </TableCell>
-                    <TableCell className="max-w-[200px]" title={routeSummary(tr)}>
-                      {routeSummary(tr)}
-                    </TableCell>
-                    <TableCell>{tr.triggered_at ? format(new Date(tr.triggered_at), 'PPp') : '—'}</TableCell>
-                    <TableCell>{tr.completed_at ? format(new Date(tr.completed_at), 'PPp') : '—'}</TableCell>
-                    {canTrigger && (
-                      <TableCell onClick={(e) => e.stopPropagation()}>
-                        {triggerableNodes.some((n) => n.node_id === tr.source_node.node_id) ? (
-                          <Button
-                            variant="ghost"
-                            size="icon"
-                            className="h-8 w-8"
-                            onClick={() =>
-                              triggerMutation.mutate(
-                                {
-                                  managedNodeId: tr.source_node.node_id,
-                                  targetNodeId: tr.target_node.node_id,
-                                },
-                                {
-                                  onError: (err) => {
-                                    toast.error('Traceroute failed', {
-                                      description: getTracerouteErrorMessage(err),
-                                    });
-                                  },
-                                }
-                              )
-                            }
-                            disabled={triggerMutation.isPending || tr.source_node.allow_auto_traceroute === false}
-                            title="Repeat this traceroute"
-                            aria-label="Repeat traceroute"
-                          >
-                            <RotateCw className="h-4 w-4" />
-                          </Button>
-                        ) : null}
-                      </TableCell>
-                    )}
+            <>
+              <Table>
+                <TableHeader>
+                  <TableRow>
+                    <TableHead>Source</TableHead>
+                    <TableHead>Target</TableHead>
+                    <TableHead>Type</TableHead>
+                    <TableHead>Triggered by</TableHead>
+                    <TableHead>Status</TableHead>
+                    <TableHead>Route</TableHead>
+                    <TableHead>Triggered</TableHead>
+                    <TableHead>Completed</TableHead>
+                    {canTrigger && <TableHead className="w-12"></TableHead>}
                   </TableRow>
-                ))}
-              </TableBody>
-            </Table>
+                </TableHeader>
+                <TableBody>
+                  {traceroutes.map((tr) => (
+                    <TableRow
+                      key={tr.id}
+                      className="cursor-pointer hover:bg-muted/50"
+                      onClick={() => setSelectedTracerouteId(tr.id)}
+                    >
+                      <TableCell>{tr.source_node?.short_name ?? tr.source_node?.node_id_str ?? '—'}</TableCell>
+                      <TableCell>{tr.target_node?.short_name ?? tr.target_node?.node_id_str ?? '—'}</TableCell>
+                      <TableCell>{tr.trigger_type}</TableCell>
+                      <TableCell>{tr.triggered_by_username ?? '—'}</TableCell>
+                      <TableCell>
+                        <StatusBadge status={tr.status} />
+                      </TableCell>
+                      <TableCell className="max-w-[200px]" title={routeSummary(tr)}>
+                        {routeSummary(tr)}
+                      </TableCell>
+                      <TableCell>{tr.triggered_at ? format(new Date(tr.triggered_at), 'PPp') : '—'}</TableCell>
+                      <TableCell>{tr.completed_at ? format(new Date(tr.completed_at), 'PPp') : '—'}</TableCell>
+                      {canTrigger && (
+                        <TableCell onClick={(e) => e.stopPropagation()}>
+                          {triggerableNodes.some((n) => n.node_id === tr.source_node.node_id) ? (
+                            <Button
+                              variant="ghost"
+                              size="icon"
+                              className="h-8 w-8"
+                              onClick={() =>
+                                triggerMutation.mutate(
+                                  {
+                                    managedNodeId: tr.source_node.node_id,
+                                    targetNodeId: tr.target_node.node_id,
+                                  },
+                                  {
+                                    onError: (err) => {
+                                      toast.error('Traceroute failed', {
+                                        description: getTracerouteErrorMessage(err),
+                                      });
+                                    },
+                                  }
+                                )
+                              }
+                              disabled={triggerMutation.isPending || tr.source_node.allow_auto_traceroute === false}
+                              title="Repeat this traceroute"
+                              aria-label="Repeat traceroute"
+                            >
+                              <RotateCw className="h-4 w-4" />
+                            </Button>
+                          ) : null}
+                        </TableCell>
+                      )}
+                    </TableRow>
+                  ))}
+                </TableBody>
+              </Table>
+              <div className="mt-4 flex items-center justify-center">
+                <Button
+                  variant="outline"
+                  size="sm"
+                  onClick={() => fetchNextPage()}
+                  disabled={!hasNextPage || isFetchingNextPage}
+                >
+                  {isFetchingNextPage ? 'Loading…' : hasNextPage ? 'Load more' : 'No more results'}
+                </Button>
+              </div>
+            </>
           )}
         </CardContent>
       </Card>
@@ -232,7 +391,7 @@ export function TracerouteHistory() {
       <TriggerTracerouteModal
         open={triggerModalOpen}
         onOpenChange={setTriggerModalOpen}
-        mode={triggerMode}
+        mode={'user' as TriggerMode}
         managedNodes={triggerableNodes}
         observedNodes={observedNodes}
         onTrigger={async (managedNodeId, targetNodeId) => {

--- a/src/pages/traceroutes/TriggerTracerouteModal.tsx
+++ b/src/pages/traceroutes/TriggerTracerouteModal.tsx
@@ -10,22 +10,26 @@ import {
 import { Button } from '@/components/ui/button';
 import { Label } from '@/components/ui/label';
 import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from '@/components/ui/select';
+import { Tabs, TabsList, TabsTrigger } from '@/components/ui/tabs';
 import { NodeSearch } from '@/components/NodeSearch';
 import { NodesAndConstellationsMap, MapNode } from '@/components/nodes/NodesAndConstellationsMap';
 import { ManagedNode, ObservedNode } from '@/lib/models';
 
+export type TriggerMode = 'user' | 'auto';
+
 interface TriggerTracerouteModalProps {
   open: boolean;
   onOpenChange: (open: boolean) => void;
-  mode: 'user' | 'auto';
+  /** Initial mode when the dialog opens. The user can switch modes inside the dialog when no fixedTargetNode is set. */
+  mode: TriggerMode;
   managedNodes: ManagedNode[];
   observedNodes: ObservedNode[];
   onTrigger: (managedNodeId: number, targetNodeId?: number) => Promise<void>;
   isSubmitting: boolean;
   /**
-   * When set in `user` mode, the target is locked to this ObservedNode: the
-   * target picker/map is hidden and a read-only row is shown instead. Ignored
-   * in `auto` mode.
+   * When set, the dialog is locked to user mode with the target fixed to this
+   * ObservedNode. The picker/map is hidden, the mode toggle is hidden, and the
+   * target row is read-only.
    */
   fixedTargetNode?: ObservedNode;
 }
@@ -37,18 +41,25 @@ function formatNodeLabel(node: { short_name: string | null; node_id_str: string 
 export function TriggerTracerouteModal({
   open,
   onOpenChange,
-  mode,
+  mode: initialMode,
   managedNodes,
   observedNodes,
   onTrigger,
   isSubmitting,
   fixedTargetNode,
 }: TriggerTracerouteModalProps) {
+  const [mode, setMode] = useState<TriggerMode>(initialMode);
   const [managedNodeId, setManagedNodeId] = useState<number | null>(null);
   const [targetNodeId, setTargetNodeId] = useState<number | null>(null);
   const [targetNodeLabel, setTargetNodeLabel] = useState<string | null>(null);
 
-  const hasFixedTarget = mode === 'user' && fixedTargetNode != null;
+  const hasFixedTarget = fixedTargetNode != null;
+
+  // Reset mode when the dialog reopens or the initial mode prop changes.
+  useEffect(() => {
+    if (!open) return;
+    setMode(hasFixedTarget ? 'user' : initialMode);
+  }, [open, initialMode, hasFixedTarget]);
 
   useEffect(() => {
     if (!hasFixedTarget || !fixedTargetNode) return;
@@ -101,9 +112,18 @@ export function TriggerTracerouteModal({
     <Dialog open={open} onOpenChange={onOpenChange}>
       <DialogContent className={mode === 'user' ? 'max-w-4xl' : undefined}>
         <DialogHeader>
-          <DialogTitle>{mode === 'user' ? 'Trigger Traceroute (target)' : 'Trigger Traceroute (auto)'}</DialogTitle>
+          <DialogTitle>Trigger Traceroute</DialogTitle>
           <DialogDescription>{dialogDescription}</DialogDescription>
         </DialogHeader>
+
+        {!hasFixedTarget && (
+          <Tabs value={mode} onValueChange={(v) => setMode(v as TriggerMode)} className="w-full">
+            <TabsList className="grid w-full grid-cols-2">
+              <TabsTrigger value="user">Pick target</TabsTrigger>
+              <TabsTrigger value="auto">Auto target</TabsTrigger>
+            </TabsList>
+          </Tabs>
+        )}
 
         <div className="grid gap-4 py-4">
           <div className="grid gap-2">


### PR DESCRIPTION
# Summary

Implements [#164](https://github.com/pskillen/meshtastic-bot-ui/issues/164) — a set of independent improvements to the Traceroute History page.

- **URL-driven filters**: `source_node`, `target_node`, `status` (CSV), `trigger_type` (CSV) are now read from `useSearchParams` as the single source of truth. Existing deep links (e.g. `NodeTracerouteHistorySection` → `/traceroutes?target_node=`) finally take effect, and any future inbound link works without page changes. Unknown values pass through to the API.
- **Richer filter bar**: explicit multi-select dropdowns for status (`completed | failed | pending | sent`) and trigger type (`auto | user | external | monitor`); a "Clear filters" button appears when any filter is set.
- **Searchable Target combo box**: the observed-nodes list is long, so the Target filter is now a popover with a text input + scrollable, filtered list (matches short name, long name, node id and `!hex` id).
- **Preset toggles row** (below the filters): one-click presets that toggle the corresponding URL filter on/off.
  - **Show successful** (renamed from "Success preset") sets `status=completed,pending,sent`.
  - **Monitoring TRs** sets `trigger_type=monitor`.
  - **Manually triggered** sets `trigger_type=user`.
- **Top Routers card removed** from the stats section (no actionable signal beyond the heatmap).
- **Success Over Time** chart gains a dashed success-rate (%) line on a secondary right axis.
- **TRs Sent by Node pie chart**: new pie driven by the existing `by_source` aggregate, placed beside the "By source node" table in a 2/3 + 1/3 layout. Top 7 senders shown individually; remainder grouped as "Other (N)".
- **Promoted Trigger CTA**: a single primary "Trigger traceroute" button at the top of the page replaces the two small `outline`/`sm` buttons. Mode (pick target / auto target) is now a tab inside the dialog. Permission gating and `fixedTargetNode` behaviour (used by `NodeTracerouteHistorySection`) are preserved.
- **Load more pagination** via `useInfiniteQuery` (`useTraceroutesInfiniteWithWebSocket`); WebSocket-driven invalidation continues to work for live updates. Total row count is shown next to the table title.
- **Top / least successful target cards** consume the new `by_target` aggregate from `meshflow-api`. A min-attempts floor of 5 prevents one-off 1/1 runs from dominating. Each row links to `/traceroutes?target_node=`, exercising the new URL-driven filter wiring.

## Background

This depends on [pskillen/meshflow-api#174](https://github.com/pskillen/meshflow-api/pull/174), which adds the `by_target` aggregate to `/api/traceroutes/stats/`. The UI tolerates the field being absent (treats as empty list), so it can ship before the API rollout completes — the new ranking cards will simply read "No targets with at least 5 finished attempts." until the API is updated.

Audited inbound links to `/traceroutes`:

- `src/components/nav-main.tsx` — bare path.
- `src/components/nodes/WatchedNodesTable.tsx` — bare path.
- `src/components/nodes/NodeTracerouteHistorySection.tsx` — `?target_node=` (was previously silently ignored; now applied).

## Testing performed

- `npx vitest run` — 40 tests pass (16 in `TracerouteHistory.test.tsx`, plus all existing including `NodeTracerouteHistorySection.test.tsx` and `TriggerTracerouteModal.test.tsx`).
- `npx tsc -b` — clean.
- `npx eslint` on touched files — no new warnings.
- New test coverage: querystring hydration (single-filter, multi-filter, unknown values), trigger CTA gating, "Clear filters" affordance, Load more enable/disable + click, total count display, preset toggles (Show successful / Monitoring TRs / Manually triggered) writing the right query, searchable Target filter narrowing options by query and writing `target_node` on selection.

Closes #164