### PR TITLE
feat(sidebar): group nav items and fix mobile scroll

### DIFF
--- a/src/components/nav-main.tsx
+++ b/src/components/nav-main.tsx
@@ -1,16 +1,18 @@
+import * as React from 'react';
 import {
+  ActivityIcon,
   BarChartIcon,
   CloudRainIcon,
+  MapIcon,
+  MessageSquareIcon,
   NetworkIcon,
   RadioIcon,
-  ActivityIcon,
-  MessageSquareIcon,
-  ServerIcon,
   RouteIcon,
-  MapIcon,
+  ServerIcon,
   SignalIcon,
+  type LucideIcon,
 } from 'lucide-react';
-import { Link, useNavigate } from 'react-router-dom';
+import { Link, useLocation, useNavigate } from 'react-router-dom';
 
 import {
   SidebarGroup,
@@ -18,107 +20,120 @@ import {
   SidebarMenu,
   SidebarMenuButton,
   SidebarMenuItem,
+  SidebarMenuSub,
+  SidebarMenuSubButton,
+  SidebarMenuSubItem,
 } from '@/components/ui/sidebar';
 import { useWebSocket } from '@/providers/WebSocketProvider';
+
+type NavChild = {
+  title: string;
+  url: string;
+  icon: LucideIcon;
+};
+
+type NavItem = {
+  title: string;
+  url: string;
+  icon: LucideIcon;
+  tooltip?: string;
+  children?: NavChild[];
+};
+
+function isPathActive(pathname: string, url: string, exact: boolean) {
+  if (exact) {
+    return pathname === url;
+  }
+  return pathname === url || pathname.startsWith(`${url}/`);
+}
 
 export function NavMain() {
   const { hasUnreadMessages, unreadMessages, markAllAsRead } = useWebSocket();
   const navigate = useNavigate();
+  const { pathname } = useLocation();
 
-  const handleMessagesClick = () => {
+  const handleMessagesClick = (e: React.MouseEvent<HTMLAnchorElement>) => {
+    e.preventDefault();
     markAllAsRead();
     navigate('/messages');
   };
+
+  const items: NavItem[] = [
+    { title: 'Dashboard', url: '/', icon: BarChartIcon },
+    { title: 'Messages', url: '/messages', icon: MessageSquareIcon },
+    {
+      title: 'Nodes',
+      url: '/nodes',
+      icon: NetworkIcon,
+      children: [
+        { title: 'My nodes', url: '/nodes/my-nodes', icon: RadioIcon },
+        { title: 'Watches', url: '/nodes/monitor', icon: ActivityIcon },
+        { title: 'Mesh infra', url: '/nodes/infrastructure', icon: ServerIcon },
+      ],
+    },
+    { title: 'Weather', url: '/weather', icon: CloudRainIcon },
+    {
+      title: 'Traceroutes',
+      url: '/traceroutes',
+      icon: RouteIcon,
+      children: [
+        { title: 'Heatmap', url: '/traceroutes/map/heat', icon: MapIcon },
+        { title: 'Link quality', url: '/traceroutes/map/snr', icon: SignalIcon },
+      ],
+    },
+  ];
 
   return (
     <SidebarGroup>
       <SidebarGroupContent className="flex flex-col gap-2">
         <SidebarMenu>
-          <SidebarMenuItem key="Dashboard">
-            <SidebarMenuButton asChild tooltip="Dashboard">
-              <Link to="/">
-                <BarChartIcon />
-                <span>Dashboard</span>
-              </Link>
-            </SidebarMenuButton>
-          </SidebarMenuItem>
-          <SidebarMenuItem key="Nodes">
-            <SidebarMenuButton asChild tooltip="Nodes">
-              <Link to="/nodes">
-                <NetworkIcon />
-                <span>Nodes</span>
-              </Link>
-            </SidebarMenuButton>
-          </SidebarMenuItem>
-          <SidebarMenuItem key="My Nodes">
-            <SidebarMenuButton asChild tooltip="My Nodes">
-              <Link to="/nodes/my-nodes">
-                <RadioIcon />
-                <span>My Nodes</span>
-              </Link>
-            </SidebarMenuButton>
-          </SidebarMenuItem>
-          <SidebarMenuItem key="Mesh Infrastructure">
-            <SidebarMenuButton asChild tooltip="Mesh Infrastructure">
-              <Link to="/nodes/infrastructure">
-                <ServerIcon />
-                <span>Mesh Infrastructure</span>
-              </Link>
-            </SidebarMenuButton>
-          </SidebarMenuItem>
-          <SidebarMenuItem key="Weather">
-            <SidebarMenuButton asChild tooltip="Weather">
-              <Link to="/weather">
-                <CloudRainIcon />
-                <span>Weather</span>
-              </Link>
-            </SidebarMenuButton>
-          </SidebarMenuItem>
-          <SidebarMenuItem key="Watches">
-            <SidebarMenuButton asChild tooltip="Mesh watches">
-              <Link to="/nodes/monitor">
-                <ActivityIcon />
-                <span>Watches</span>
-              </Link>
-            </SidebarMenuButton>
-          </SidebarMenuItem>
-          <SidebarMenuItem key="Traceroutes">
-            <SidebarMenuButton asChild tooltip="Traceroutes">
-              <Link to="/traceroutes">
-                <RouteIcon />
-                <span>Traceroutes</span>
-              </Link>
-            </SidebarMenuButton>
-          </SidebarMenuItem>
-          <SidebarMenuItem key="Traceroute Heatmap">
-            <SidebarMenuButton asChild tooltip="Traceroute Heatmap">
-              <Link to="/traceroutes/map/heat">
-                <MapIcon />
-                <span>Traceroute Heatmap</span>
-              </Link>
-            </SidebarMenuButton>
-          </SidebarMenuItem>
-          <SidebarMenuItem key="Traceroute Link Quality">
-            <SidebarMenuButton asChild tooltip="Traceroute Link Quality">
-              <Link to="/traceroutes/map/snr">
-                <SignalIcon />
-                <span>Traceroute Link Quality</span>
-              </Link>
-            </SidebarMenuButton>
-          </SidebarMenuItem>
-          <SidebarMenuItem key="Messages">
-            <SidebarMenuButton asChild tooltip="Messages">
-              <Link to="/messages" className="relative" onClick={handleMessagesClick}>
-                <MessageSquareIcon />
-                <span>Messages</span>
-                {hasUnreadMessages && (
-                  <span className="absolute right-2 top-2 flex h-5 w-5 items-center justify-center rounded-full bg-red-500 p-0 text-xs text-white">
-                    {unreadMessages.length > 9 ? '9+' : unreadMessages.length}
-                  </span>
+          {items.map((item) => {
+            const Icon = item.icon;
+            // Parent should only be highlighted when its own page is active, not when a child is active.
+            const parentActive = isPathActive(pathname, item.url, true);
+            const isMessages = item.title === 'Messages';
+
+            return (
+              <SidebarMenuItem key={item.title}>
+                <SidebarMenuButton asChild tooltip={item.tooltip ?? item.title} isActive={parentActive}>
+                  {isMessages ? (
+                    <Link to={item.url} className="relative" onClick={handleMessagesClick}>
+                      <Icon />
+                      <span>{item.title}</span>
+                      {hasUnreadMessages && (
+                        <span className="absolute right-2 top-2 flex h-5 w-5 items-center justify-center rounded-full bg-red-500 p-0 text-xs text-white">
+                          {unreadMessages.length > 9 ? '9+' : unreadMessages.length}
+                        </span>
+                      )}
+                    </Link>
+                  ) : (
+                    <Link to={item.url}>
+                      <Icon />
+                      <span>{item.title}</span>
+                    </Link>
+                  )}
+                </SidebarMenuButton>
+                {item.children && item.children.length > 0 && (
+                  <SidebarMenuSub>
+                    {item.children.map((child) => {
+                      const ChildIcon = child.icon;
+                      const childIsActive = isPathActive(pathname, child.url, true);
+                      return (
+                        <SidebarMenuSubItem key={child.title}>
+                          <SidebarMenuSubButton asChild isActive={childIsActive}>
+                            <Link to={child.url}>
+                              <ChildIcon />
+                              <span>{child.title}</span>
+                            </Link>
+                          </SidebarMenuSubButton>
+                        </SidebarMenuSubItem>
+                      );
+                    })}
+                  </SidebarMenuSub>
                 )}
-              </Link>
-            </SidebarMenuButton>
-          </SidebarMenuItem>
+              </SidebarMenuItem>
+            );
+          })}
         </SidebarMenu>
       </SidebarGroupContent>
     </SidebarGroup>

--- a/src/components/ui/sidebar.tsx
+++ b/src/components/ui/sidebar.tsx
@@ -170,7 +170,7 @@ const Sidebar = React.forwardRef<
             <SheetTitle>Sidebar</SheetTitle>
             <SheetDescription>Displays the mobile sidebar.</SheetDescription>
           </SheetHeader>
-          <div className="flex h-full w-full flex-col">{children}</div>
+          <div className="flex h-full w-full flex-col overflow-y-auto overscroll-contain">{children}</div>
         </SheetContent>
       </Sheet>
     );


### PR DESCRIPTION
# Summary

Reshape the sidebar so functional areas are grouped visually, and fix a long-standing scroll bug on short / mobile viewports.

Closes #171

## Sidebar grouping

The sidebar previously listed every page as a flat set of top-level items. As more pages were added (My Nodes, Mesh Infrastructure, Watches, Traceroute Heatmap, Link Quality, ...) the list lost any sense of hierarchy.

Now the structure is:

```
Dashboard
Messages
Nodes
  My nodes
  Watches
  Mesh infra
Weather
Traceroutes
  Heatmap
  Link quality
```

Implementation notes:

- `src/components/nav-main.tsx` rewritten to drive nav from a typed `items: NavItem[]` array; children are rendered with `SidebarMenuSub` / `SidebarMenuSubButton` (the existing shadcn primitive in `ui/sidebar.tsx`).
- Parent items (Nodes, Traceroutes) remain clickable and navigate to their own landing page (`/nodes`, `/traceroutes`).
- Active highlighting uses `useLocation().pathname` and exact-match per item, so both parents and children get the active treatment when their route is current. Parents are not highlighted just because a child is active (keeps the indicator unambiguous).
- Messages still wires the existing `markAllAsRead()` + navigate behaviour and keeps the unread badge.

## Mobile scroll fix

On short viewports (mobile in landscape, narrow vertical heights) the sidebar didn't scroll, so items at the bottom were unreachable. The mobile sheet wrapper in `src/components/ui/sidebar.tsx` now uses `overflow-y-auto overscroll-contain` so the whole mobile sidebar scrolls as one column when content exceeds the viewport. Desktop behaviour is unchanged (`SidebarContent` continues to scroll between pinned header/footer via its existing `flex-1 min-h-0 overflow-auto`).

## Testing performed

- `npm run lint` — 0 errors (only pre-existing warnings)
- `npx tsc -b` — clean
- `npm test` — 40/40 passing
- `npm run format` — clean
- Pre-commit hook (lint + format check + tests) green on both commits
- Manual: navigated through `/`, `/nodes`, `/nodes/my-nodes`, `/nodes/monitor`, `/nodes/infrastructure`, `/traceroutes`, `/traceroutes/map/heat`, `/traceroutes/map/snr`, `/messages`, `/weather` — children render indented under the right parent; active state highlights the right item; parent links still navigate to landing pages.
