### PR TITLE
feat(weather, stats): temperature-coloured weather map and tidy New Nodes chart

### DIFF
--- a/src/components/MeshStatsSection.tsx
+++ b/src/components/MeshStatsSection.tsx
@@ -72,8 +72,8 @@ export function MeshStatsSection() {
       <CardHeader className="relative">
         <CardTitle>Mesh stats</CardTitle>
         <CardDescription>
-          Online nodes, new node discovery, and packet volume over time. Longer ranges are aggregated into 6-hour or
-          daily windows.
+          Online nodes and packet volume over time, aggregated into hourly, 6-hour, or daily windows depending on the
+          selected range. New nodes are always shown as daily totals.
         </CardDescription>
         <div className="absolute right-4 top-4">
           <TimeRangeSelect options={MESH_STATS_TIME_OPTIONS} value={timeRangeKey} onChange={handleTimeRangeChange} />
@@ -91,7 +91,7 @@ export function MeshStatsSection() {
         />
         <OnlineNodesChart
           title="New Nodes"
-          description="Newly discovered nodes per window (sum)"
+          description="Newly discovered nodes per day"
           metric="new_nodes"
           config={newNodesOnlyChartConfig}
           embedded

--- a/src/components/OnlineNodesChart.tsx
+++ b/src/components/OnlineNodesChart.tsx
@@ -74,8 +74,8 @@ export function OnlineNodesChart({
   };
 
   const aggregationWindow = React.useMemo(
-    () => getAggregationWindow(dateRange.startDate, dateRange.endDate),
-    [dateRange.startDate, dateRange.endDate]
+    () => (metric === 'new_nodes' ? 'daily' : getAggregationWindow(dateRange.startDate, dateRange.endDate)),
+    [dateRange.startDate, dateRange.endDate, metric]
   );
 
   const chartData = React.useMemo(() => {
@@ -89,12 +89,12 @@ export function OnlineNodesChart({
 
     const mergeMethod = metric === 'online_nodes' ? 'average' : 'sum';
     const aggregated = aggregateStats(raw, aggregationWindow, mergeMethod);
+    const rounded = metric === 'new_nodes' ? aggregated.map((p) => ({ ...p, value: Math.round(p.value) })) : aggregated;
 
-    const windowSize =
-      aggregationWindow === 'hourly' ? Math.min(24, aggregated.length) : Math.min(4, aggregated.length);
-    return aggregated.map((stat, index) => {
+    const windowSize = aggregationWindow === 'hourly' ? Math.min(24, rounded.length) : Math.min(4, rounded.length);
+    return rounded.map((stat, index) => {
       const startIdx = Math.max(0, index - windowSize + 1);
-      const window = aggregated.slice(startIdx, index + 1);
+      const window = rounded.slice(startIdx, index + 1);
       const avg = window.length > 0 ? window.reduce((acc, i) => acc + i.value, 0) / window.length : 0;
       return { ...stat, movingAverage: avg };
     });
@@ -162,7 +162,8 @@ export function OnlineNodesChart({
           tickLine={false}
           axisLine={false}
           tickMargin={8}
-          allowDecimals={metric === 'new_nodes'}
+          allowDecimals={false}
+          tickFormatter={metric === 'new_nodes' ? (v: number) => Math.round(v).toString() : undefined}
         />
         <ChartTooltip
           cursor={false}

--- a/src/components/nodes/NodesAndConstellationsMap.tsx
+++ b/src/components/nodes/NodesAndConstellationsMap.tsx
@@ -63,6 +63,8 @@ export interface NodesAndConstellationsMapProps {
   getMarkerColor?: (node: ObservedNode) => string;
   /** Optional grayscale 0-1 for observed node markers (e.g. 24h = 100% gray) */
   getMarkerGrayscale?: (node: ObservedNode) => number;
+  /** Optional CSS colour for a 3px inset border on weather-style markers (e.g. age indicator) */
+  getMarkerBorderColor?: (node: ObservedNode) => string | undefined;
 }
 
 export function NodesAndConstellationsMap({
@@ -83,6 +85,7 @@ export function NodesAndConstellationsMap({
   getMarkerOpacity,
   getMarkerColor,
   getMarkerGrayscale,
+  getMarkerBorderColor,
 }: NodesAndConstellationsMapProps) {
   const mapRef = useRef<HTMLDivElement>(null);
   const mapInstanceRef = useRef<L.Map | null>(null);
@@ -410,10 +413,19 @@ export function NodesAndConstellationsMap({
       const color = getMarkerColor
         ? getMarkerColor(node as ObservedNode)
         : getRoleColor('role' in node ? node.role : undefined);
-      const iconFn = getMarkerLabel ? createWeatherNodeIcon : createNodeIcon;
-      const marker = L.marker(position, {
-        icon: iconFn(label, color, isSelected, hasSelection && !isSelected, opacity, grayscale),
-      });
+      const dimmed = hasSelection && !isSelected;
+      const icon = getMarkerLabel
+        ? createWeatherNodeIcon(
+            label,
+            color,
+            isSelected,
+            dimmed,
+            opacity,
+            grayscale,
+            getMarkerBorderColor?.(node as ObservedNode)
+          )
+        : createNodeIcon(label, color, isSelected, dimmed, opacity, grayscale);
+      const marker = L.marker(position, { icon });
       marker.on('click', () => handleMarkerClick(node));
       if (enableBubbles) {
         const constellationName = managedNodeConstellationMap.get(node.node_id) ?? null;
@@ -474,6 +486,7 @@ export function NodesAndConstellationsMap({
     getMarkerOpacity,
     getMarkerColor,
     getMarkerGrayscale,
+    getMarkerBorderColor,
   ]);
 
   return (

--- a/src/components/nodes/WeatherMapAgeLegend.tsx
+++ b/src/components/nodes/WeatherMapAgeLegend.tsx
@@ -1,27 +1,78 @@
-import { WEATHER_MARKER_FRESH_HEX, WEATHER_MARKER_STALE_HEX } from './map-utils';
+import {
+  WEATHER_MARKER_STALE_HEX,
+  WEATHER_TEMP_COLD_HEX,
+  WEATHER_TEMP_HOT_HEX,
+  WeatherTemperatureAnchors,
+} from './map-utils';
 
-export interface WeatherMapAgeLegendProps {
-  /** Must match `WeatherNodesMap` cutoff (hours until markers are hidden / fully gray). */
+export interface WeatherMapLegendProps {
+  /** Must match `WeatherNodesMap` cutoff (hours until markers are hidden / fully bordered). */
   fadeHours?: number;
+  /** Live temperature anchors from the visible weather-map nodes (5th / 95th percentile). */
+  temperatureAnchors?: WeatherTemperatureAnchors;
 }
 
-export function WeatherMapAgeLegend({ fadeHours = 24 }: WeatherMapAgeLegendProps) {
-  const label = `Marker colour: fresh env reading on the left, fading to gray by ${fadeHours} hours on the right`;
+function formatTemp(value: number | null | undefined): string {
+  if (value == null || !Number.isFinite(value)) return 'n/a';
+  return `${value.toFixed(1)}°C`;
+}
+
+function formatMidTemp(min: number | null | undefined, max: number | null | undefined): string {
+  if (min == null || max == null || !Number.isFinite(min) || !Number.isFinite(max)) return 'n/a';
+  return `${((min + max) / 2).toFixed(1)}°C`;
+}
+
+/**
+ * Two-row legend for the Weather map:
+ *   Row 1 — temperature gradient (cold blue → hot red) anchored on visible p5 / p95.
+ *   Row 2 — border colour gradient (transparent → slate) representing reading age.
+ *
+ * Component name kept as `WeatherMapAgeLegend` for backward compatibility; it now
+ * conveys both temperature and age.
+ */
+export function WeatherMapAgeLegend({ fadeHours = 24, temperatureAnchors }: WeatherMapLegendProps) {
+  const { minC = null, maxC = null } = temperatureAnchors ?? {};
+  const degenerate = minC == null || maxC == null || Math.abs(maxC - minC) < 0.001;
+  const tempLabel = degenerate
+    ? 'Marker fill colour: not enough temperature variance to colour by temperature'
+    : `Marker fill colour: cold (${formatTemp(minC)}) on the left, hot (${formatTemp(maxC)}) on the right`;
+  const ageLabel = `Marker border colour: fresh on the left, fully stale by ${fadeHours} hours on the right`;
 
   return (
-    <div className="mb-3">
-      <div
-        className="h-2.5 w-full rounded-full border border-border/70 shadow-sm ring-1 ring-black/5 dark:ring-white/10"
-        style={{
-          background: `linear-gradient(to right, ${WEATHER_MARKER_FRESH_HEX}, ${WEATHER_MARKER_STALE_HEX})`,
-        }}
-        role="img"
-        aria-label={label}
-      />
-      <div className="mt-1.5 flex justify-between gap-2 text-xs text-muted-foreground">
-        <span>Fresh</span>
-        <span className="tabular-nums">{fadeHours}h</span>
-        <span>Stale</span>
+    <div className="mb-3 space-y-3">
+      <div>
+        <div
+          className="h-2.5 w-full rounded-full border border-border/70 shadow-sm ring-1 ring-black/5 dark:ring-white/10"
+          style={{
+            background: degenerate
+              ? undefined
+              : `linear-gradient(to right, ${WEATHER_TEMP_COLD_HEX}, ${WEATHER_TEMP_HOT_HEX})`,
+          }}
+          role="img"
+          aria-label={tempLabel}
+        />
+        <div className="mt-1.5 flex justify-between gap-2 text-xs text-muted-foreground tabular-nums">
+          <span>{formatTemp(minC)}</span>
+          <span>{formatMidTemp(minC, maxC)}</span>
+          <span>{formatTemp(maxC)}</span>
+        </div>
+        <div className="mt-0.5 text-[11px] text-muted-foreground">Fill colour: cold → hot temperature</div>
+      </div>
+      <div>
+        <div
+          className="h-2.5 w-full rounded-full border border-border/70 shadow-sm ring-1 ring-black/5 dark:ring-white/10"
+          style={{
+            background: `linear-gradient(to right, transparent, ${WEATHER_MARKER_STALE_HEX})`,
+          }}
+          role="img"
+          aria-label={ageLabel}
+        />
+        <div className="mt-1.5 flex justify-between gap-2 text-xs text-muted-foreground">
+          <span>Fresh</span>
+          <span className="tabular-nums">{fadeHours}h</span>
+          <span>Stale</span>
+        </div>
+        <div className="mt-0.5 text-[11px] text-muted-foreground">Border colour: reading age</div>
       </div>
     </div>
   );

--- a/src/components/nodes/WeatherNodesMap.tsx
+++ b/src/components/nodes/WeatherNodesMap.tsx
@@ -1,30 +1,16 @@
 import { useMemo } from 'react';
-import { subHours } from 'date-fns';
-import { ObservedNode } from '@/lib/models';
+import { ObservedNode, LatestEnvironmentMetrics } from '@/lib/models';
 import { NodesAndConstellationsMap } from './NodesAndConstellationsMap';
-import { weatherMarkerBackgroundColor, WEATHER_MARKER_STALE_COLOR } from './map-utils';
-import { LatestEnvironmentMetrics } from '@/lib/models';
+import {
+  WeatherTemperatureAnchors,
+  computeWeatherTemperatureAnchors,
+  temperatureColor,
+  weatherBorderColor,
+  WEATHER_TEMP_NEUTRAL_COLOR,
+} from './map-utils';
+import { filterNodesForWeatherMap, getEnvironmentReportedTime } from './weather-map-helpers';
 
 const MAP_CUTOFF_HOURS = 24;
-
-function hasRecentLocation(node: ObservedNode): boolean {
-  const pos = node.latest_position as {
-    latitude?: number;
-    longitude?: number;
-    reported_time?: Date | string;
-  } | null;
-  if (!pos) return false;
-  const lat = pos.latitude;
-  const lon = pos.longitude;
-  if (lat == null || lon == null || lat === 0 || lon === 0) return false;
-  return true;
-}
-
-function getEnvironmentReportedTime(node: ObservedNode): Date | null {
-  const env = node.latest_environment_metrics as LatestEnvironmentMetrics | null;
-  if (!env?.reported_time) return null;
-  return new Date(env.reported_time);
-}
 
 function formatWeatherLabel(env: LatestEnvironmentMetrics | null | undefined): string {
   if (!env) return '—';
@@ -39,32 +25,39 @@ export interface WeatherNodesMapProps {
   nodes: ObservedNode[];
   /** Nodes with env reported after this are shown on map. Older are hidden. Default 24h. */
   cutoffHours?: number;
+  /**
+   * Optional pre-computed temperature anchors (e.g. lifted to a parent so the legend
+   * shows matching min/max). When omitted, anchors are derived from the visible nodes.
+   */
+  temperatureAnchors?: WeatherTemperatureAnchors;
 }
 
 /**
- * Map of weather nodes with temp labels and a fixed sky-blue pill that fades to slate gray
- * as the env reading ages (linear over cutoffHours). Nodes older than cutoff are hidden.
+ * Map of weather nodes. Marker fill is the node's latest temperature mapped onto a
+ * cold-blue → hot-red gradient anchored on the visible 5th/95th percentile. The 3px
+ * inset border fades from transparent (fresh) to slate (stale) over `cutoffHours`.
  */
-export function WeatherNodesMap({ nodes, cutoffHours = MAP_CUTOFF_HOURS }: WeatherNodesMapProps) {
-  const cutoff = useMemo(() => subHours(new Date(), cutoffHours), [cutoffHours]);
+export function WeatherNodesMap({ nodes, cutoffHours = MAP_CUTOFF_HOURS, temperatureAnchors }: WeatherNodesMapProps) {
+  const nodesForMap = useMemo(() => filterNodesForWeatherMap(nodes, cutoffHours), [nodes, cutoffHours]);
 
-  const nodesForMap = useMemo(() => {
-    return nodes.filter((node) => {
-      if (!hasRecentLocation(node)) return false;
-      const reported = getEnvironmentReportedTime(node);
-      if (!reported) return false;
-      return reported >= cutoff;
-    });
-  }, [nodes, cutoff]);
+  const anchors = useMemo<WeatherTemperatureAnchors>(() => {
+    if (temperatureAnchors) return temperatureAnchors;
+    return computeWeatherTemperatureAnchors(nodesForMap.map((n) => n.latest_environment_metrics?.temperature));
+  }, [temperatureAnchors, nodesForMap]);
 
   const getMarkerLabel = useMemo(() => (node: ObservedNode) => formatWeatherLabel(node.latest_environment_metrics), []);
 
   const getMarkerColor = useMemo(
     () => (node: ObservedNode) => {
-      const reported = getEnvironmentReportedTime(node);
-      if (!reported) return WEATHER_MARKER_STALE_COLOR;
-      return weatherMarkerBackgroundColor(reported, cutoffHours);
+      const temp = node.latest_environment_metrics?.temperature;
+      if (temp == null) return WEATHER_TEMP_NEUTRAL_COLOR;
+      return temperatureColor(temp, anchors.minC, anchors.maxC);
     },
+    [anchors]
+  );
+
+  const getMarkerBorderColor = useMemo(
+    () => (node: ObservedNode) => weatherBorderColor(getEnvironmentReportedTime(node), cutoffHours),
     [cutoffHours]
   );
 
@@ -79,6 +72,7 @@ export function WeatherNodesMap({ nodes, cutoffHours = MAP_CUTOFF_HOURS }: Weath
       enableBubbles={true}
       getMarkerLabel={getMarkerLabel}
       getMarkerColor={getMarkerColor}
+      getMarkerBorderColor={getMarkerBorderColor}
     />
   );
 }

--- a/src/components/nodes/map-utils.ts
+++ b/src/components/nodes/map-utils.ts
@@ -26,6 +26,16 @@ const WEATHER_MARKER_STALE_RGB = { r: 148, g: 163, b: 184 }; // sync with WEATHE
 /** Pill colour when env time is missing (should not appear on map for long). */
 export const WEATHER_MARKER_STALE_COLOR = `rgb(${WEATHER_MARKER_STALE_RGB.r},${WEATHER_MARKER_STALE_RGB.g},${WEATHER_MARKER_STALE_RGB.b})`;
 
+/** Cold and hot endpoints for the temperature gradient on the weather map. */
+export const WEATHER_TEMP_COLD_HEX = '#2563eb'; // cold blue
+export const WEATHER_TEMP_HOT_HEX = '#dc2626'; // hot red
+
+const WEATHER_TEMP_COLD_RGB = { r: 37, g: 99, b: 235 }; // sync with WEATHER_TEMP_COLD_HEX
+const WEATHER_TEMP_HOT_RGB = { r: 220, g: 38, b: 38 }; // sync with WEATHER_TEMP_HOT_HEX
+
+/** Neutral fill used when temperature is missing or the visible range is degenerate. */
+export const WEATHER_TEMP_NEUTRAL_COLOR = WEATHER_MARKER_STALE_COLOR;
+
 /**
  * Background color for a weather map pill by env reading age: full sky blue when fresh, slate gray at `fadeHours`.
  */
@@ -42,6 +52,80 @@ export function weatherMarkerBackgroundColor(
   const g = Math.round(a.g + (b.g - a.g) * t);
   const bl = Math.round(a.b + (b.b - a.b) * t);
   return `rgb(${r},${g},${bl})`;
+}
+
+/**
+ * Map a temperature in Celsius to a colour on the cold-blue → hot-red gradient.
+ * Returns a neutral fill when temperature is missing or the [min, max] range is degenerate.
+ */
+export function temperatureColor(
+  tempC: number | null | undefined,
+  minC: number | null | undefined,
+  maxC: number | null | undefined
+): string {
+  if (tempC == null || !Number.isFinite(tempC)) return WEATHER_TEMP_NEUTRAL_COLOR;
+  if (minC == null || maxC == null || !Number.isFinite(minC) || !Number.isFinite(maxC)) {
+    return WEATHER_TEMP_NEUTRAL_COLOR;
+  }
+  if (maxC - minC < 0.001) return WEATHER_TEMP_NEUTRAL_COLOR;
+  const t = Math.max(0, Math.min(1, (tempC - minC) / (maxC - minC)));
+  const a = WEATHER_TEMP_COLD_RGB;
+  const b = WEATHER_TEMP_HOT_RGB;
+  const r = Math.round(a.r + (b.r - a.r) * t);
+  const g = Math.round(a.g + (b.g - a.g) * t);
+  const bl = Math.round(a.b + (b.b - a.b) * t);
+  return `rgb(${r},${g},${bl})`;
+}
+
+/**
+ * Border colour for a weather marker indicating env reading age:
+ * fully transparent at fresh, fading to opaque slate over `fadeHours`.
+ */
+export function weatherBorderColor(
+  reportedTime: Date | null | undefined,
+  fadeHours: number,
+  nowMs: number = Date.now()
+): string {
+  if (!reportedTime) {
+    const s = WEATHER_MARKER_STALE_RGB;
+    return `rgba(${s.r},${s.g},${s.b},1)`;
+  }
+  const ageMs = Math.max(0, nowMs - reportedTime.getTime());
+  const t = Math.min(1, ageMs / (fadeHours * 60 * 60 * 1000));
+  const s = WEATHER_MARKER_STALE_RGB;
+  return `rgba(${s.r},${s.g},${s.b},${t.toFixed(3)})`;
+}
+
+export interface WeatherTemperatureAnchors {
+  /** 5th-percentile temperature across the input set (°C); null if undefined. */
+  minC: number | null;
+  /** 95th-percentile temperature across the input set (°C); null if undefined. */
+  maxC: number | null;
+}
+
+/**
+ * Compute robust temperature anchors (5th / 95th percentile) from a list of Celsius readings.
+ * Filters non-finite values. Returns nulls when fewer than 2 valid readings.
+ *
+ * >>> computeWeatherTemperatureAnchors([])
+ * { minC: null, maxC: null }
+ */
+export function computeWeatherTemperatureAnchors(
+  temperaturesC: Array<number | null | undefined>
+): WeatherTemperatureAnchors {
+  const values = temperaturesC.filter((t): t is number => t != null && Number.isFinite(t));
+  if (values.length === 0) return { minC: null, maxC: null };
+  if (values.length === 1) return { minC: values[0], maxC: values[0] };
+  const sorted = [...values].sort((a, b) => a - b);
+  return { minC: percentileSorted(sorted, 5), maxC: percentileSorted(sorted, 95) };
+}
+
+function percentileSorted(sorted: number[], p: number): number {
+  const idx = (p / 100) * (sorted.length - 1);
+  const lo = Math.floor(idx);
+  const hi = Math.ceil(idx);
+  if (lo === hi) return sorted[lo];
+  return sorted[lo] + (sorted[hi] - sorted[lo]) * (idx - lo);
 }
 
 /** Minimal node fields for popup content */
@@ -136,6 +220,7 @@ const WEATHER_MARKER_HEIGHT = 56;
  * @param dimmed - When true, applies opacity 0.5
  * @param opacity - Optional 0-1 opacity override
  * @param grayscale - Optional 0-1 grayscale (0=full color, 1=100% gray)
+ * @param borderColor - Optional CSS colour for a 3px inset border (e.g. age indicator)
  */
 export function createWeatherNodeIcon(
   text: string,
@@ -143,19 +228,23 @@ export function createWeatherNodeIcon(
   highlighted = false,
   dimmed = false,
   opacity?: number,
-  grayscale?: number
+  grayscale?: number,
+  borderColor?: string
 ): L.DivIcon {
   const styles: string[] = [];
   if (opacity != null) styles.push(`opacity: ${opacity}`);
   else if (dimmed) styles.push('opacity: 0.5');
   if (grayscale != null && grayscale > 0) styles.push(`filter: grayscale(${grayscale * 100}%)`);
   const containerStyle = styles.length > 0 ? styles.join('; ') + ';' : '';
-  const highlightStyle = highlighted ? 'box-shadow: 0 0 0 3px rgba(226, 153, 6, 0.9);' : '';
+  const shadowParts: string[] = [];
+  if (borderColor) shadowParts.push(`inset 0 0 0 3px ${borderColor}`);
+  if (highlighted) shadowParts.push('0 0 0 3px rgba(226, 153, 6, 0.9)');
+  const shadowStyle = shadowParts.length > 0 ? `box-shadow: ${shadowParts.join(', ')};` : '';
   return L.divIcon({
     className: 'custom-node-marker weather-node-marker',
     html: `
       <div class="weather-marker-container" style="${containerStyle}">
-        <div class="weather-marker-pill" style="background: ${color}; ${highlightStyle}">
+        <div class="weather-marker-pill" style="background: ${color}; ${shadowStyle}">
           <span class="weather-marker-text">${escapeHtmlForMarker(text)}</span>
         </div>
       </div>

--- a/src/components/nodes/map-utils.ts
+++ b/src/components/nodes/map-utils.ts
@@ -237,7 +237,7 @@ export function createWeatherNodeIcon(
   if (grayscale != null && grayscale > 0) styles.push(`filter: grayscale(${grayscale * 100}%)`);
   const containerStyle = styles.length > 0 ? styles.join('; ') + ';' : '';
   const shadowParts: string[] = [];
-  if (borderColor) shadowParts.push(`inset 0 0 0 3px ${borderColor}`);
+  if (borderColor) shadowParts.push(`inset 0 0 0 5px ${borderColor}`);
   if (highlighted) shadowParts.push('0 0 0 3px rgba(226, 153, 6, 0.9)');
   const shadowStyle = shadowParts.length > 0 ? `box-shadow: ${shadowParts.join(', ')};` : '';
   return L.divIcon({

--- a/src/components/nodes/weather-map-helpers.ts
+++ b/src/components/nodes/weather-map-helpers.ts
@@ -1,0 +1,50 @@
+import { subHours } from 'date-fns';
+import { ObservedNode, LatestEnvironmentMetrics } from '@/lib/models';
+import { computeWeatherTemperatureAnchors, WeatherTemperatureAnchors } from './map-utils';
+
+function hasRecentLocation(node: ObservedNode): boolean {
+  const pos = node.latest_position as {
+    latitude?: number;
+    longitude?: number;
+    reported_time?: Date | string;
+  } | null;
+  if (!pos) return false;
+  const lat = pos.latitude;
+  const lon = pos.longitude;
+  if (lat == null || lon == null || lat === 0 || lon === 0) return false;
+  return true;
+}
+
+export function getEnvironmentReportedTime(node: ObservedNode): Date | null {
+  const env = node.latest_environment_metrics as LatestEnvironmentMetrics | null;
+  if (!env?.reported_time) return null;
+  return new Date(env.reported_time);
+}
+
+/**
+ * Filter a node set to those visible on the weather map: a usable position and
+ * an env reading reported within `cutoffHours`.
+ */
+export function filterNodesForWeatherMap(
+  nodes: ObservedNode[],
+  cutoffHours: number,
+  now: Date = new Date()
+): ObservedNode[] {
+  const cutoff = subHours(now, cutoffHours);
+  return nodes.filter((node) => {
+    if (!hasRecentLocation(node)) return false;
+    const reported = getEnvironmentReportedTime(node);
+    if (!reported) return false;
+    return reported >= cutoff;
+  });
+}
+
+/** Compute temperature anchors (5th/95th percentile) for the visible weather-map node set. */
+export function computeVisibleWeatherTemperatureAnchors(
+  nodes: ObservedNode[],
+  cutoffHours: number,
+  now: Date = new Date()
+): WeatherTemperatureAnchors {
+  const visible = filterNodesForWeatherMap(nodes, cutoffHours, now);
+  return computeWeatherTemperatureAnchors(visible.map((n) => n.latest_environment_metrics?.temperature));
+}

--- a/src/pages/Weather.tsx
+++ b/src/pages/Weather.tsx
@@ -5,6 +5,7 @@ import { useMultiNodeEnvironmentMetricsSuspense } from '@/hooks/api/useMultiNode
 import { WeatherNodeCard } from '@/components/nodes/WeatherNodeCard';
 import { WeatherMapAgeLegend } from '@/components/nodes/WeatherMapAgeLegend';
 import { WeatherNodesMap } from '@/components/nodes/WeatherNodesMap';
+import { computeVisibleWeatherTemperatureAnchors } from '@/components/nodes/weather-map-helpers';
 import { TimeRangeSelect } from '@/components/TimeRangeSelect';
 import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from '@/components/ui/select';
 import { Card, CardHeader, CardTitle, CardContent } from '@/components/ui/card';
@@ -70,6 +71,11 @@ function WeatherContent() {
 
   const { metricsMap } = useMultiNodeEnvironmentMetricsSuspense(nodes, chartDateRange);
 
+  const temperatureAnchors = useMemo(
+    () => computeVisibleWeatherTemperatureAnchors(nodes, WEATHER_MAP_ENV_AGE_HOURS),
+    [nodes]
+  );
+
   const sortedNodes = useMemo(
     () =>
       [...nodes].sort((a, b) => {
@@ -131,14 +137,19 @@ function WeatherContent() {
           <CardHeader>
             <CardTitle>Weather Node Locations</CardTitle>
             <p className="text-sm text-muted-foreground">
-              Markers use a sky-blue tone when fresh and fade to gray as the reading ages (linear over 24h). Older
-              readings are hidden.
+              Marker fill colour reflects the latest reported temperature (cold blue → hot red, anchored on the visible
+              5th / 95th percentile). The 3px border fades from transparent (fresh) to slate as the reading ages over
+              24h. Older readings are hidden.
             </p>
           </CardHeader>
           <CardContent>
-            <WeatherMapAgeLegend fadeHours={WEATHER_MAP_ENV_AGE_HOURS} />
+            <WeatherMapAgeLegend fadeHours={WEATHER_MAP_ENV_AGE_HOURS} temperatureAnchors={temperatureAnchors} />
             <div className="h-[600px] w-full">
-              <WeatherNodesMap nodes={nodes} cutoffHours={WEATHER_MAP_ENV_AGE_HOURS} />
+              <WeatherNodesMap
+                nodes={nodes}
+                cutoffHours={WEATHER_MAP_ENV_AGE_HOURS}
+                temperatureAnchors={temperatureAnchors}
+              />
             </div>
           </CardContent>
         </Card>


### PR DESCRIPTION
# Summary

Bundles two small UI tickets:

**#137 — Weather map: colour markers by temperature**

- Marker fill is now driven by the node's latest temperature on a cold-blue → hot-red gradient anchored on the **5th / 95th percentile** of the currently visible nodes (robust to outliers, handles single-node and degenerate min == max sets gracefully).
- A 5 px inset border on the marker indicates **reading age**: transparent when fresh, fading to slate by the 24 h cutoff. This replaces the previous sky-blue → slate fill.
- Legend now has two rows: a temperature gradient (with live min / mid / max in °C) and a border-age gradient. Falls back to "n/a" when there is not enough variance to colour by temperature.
- Node fallback: missing temperature → neutral slate fill; border still tracks age.

**#127 — "New Nodes" chart: integers, daily buckets only**

- `new_nodes` series is always aggregated into **daily** buckets (calendar-day boundaries via existing `getBucketStart`), regardless of selected range. The Online Nodes / Packet volume charts keep their range-based hourly / 6-hour / daily aggregation.
- Y-axis enforces `allowDecimals={false}` and a rounding tick formatter; data values for `new_nodes` are also rounded at source so tooltips show whole integers.
- Card description and the New Nodes chart sub-title were updated to match.

## Background

Closes #137  
Closes #127

Both tickets describe small polish fixes on the dashboard / Weather page. They were small enough to bundle into one PR.

## Testing performed

- `npm run lint` — no new warnings (28 → 26 after splitting weather helpers into a separate module to satisfy `react-refresh/only-export-components`).
- `npm run format` — clean.
- `npm run build` — succeeds.
- `npm test` (vitest) — all 40 tests pass.
- Manual checks to perform when reviewing:
  - Weather map: markers should span blue → red across the visible set; legend min/mid/max should match what's on the map; stale nodes show a slate border; missing-temperature nodes show neutral fill.
  - Mesh stats / "New Nodes": switch range between 48h / 7d / 30d — chart should always be on calendar-day buckets and Y-axis should be integers; Online Nodes / Mesh Activity behaviour should be unchanged.
