### PR TITLE
refactor(traceroutes): clarify managed node coverage copy

### DIFF
--- a/src/components/nav-main.tsx
+++ b/src/components/nav-main.tsx
@@ -80,7 +80,7 @@ export function NavMain() {
       children: [
         { title: 'Heatmap', url: '/traceroutes/map/heat', icon: MapIcon },
         { title: 'Link quality', url: '/traceroutes/map/snr', icon: SignalIcon },
-        { title: 'Coverage', url: '/traceroutes/map/coverage', icon: CircleDashedIcon },
+        { title: 'Coverage by node', url: '/traceroutes/map/coverage', icon: CircleDashedIcon },
         {
           title: 'Constellation coverage',
           url: '/traceroutes/map/coverage/constellation',

--- a/src/pages/traceroutes/ConstellationCoveragePage.tsx
+++ b/src/pages/traceroutes/ConstellationCoveragePage.tsx
@@ -1,5 +1,5 @@
 import { useEffect, useMemo, useState } from 'react';
-import { Link, useNavigate, useParams } from 'react-router-dom';
+import { useNavigate, useParams } from 'react-router-dom';
 import { subDays, subHours } from 'date-fns';
 import { CircleDashedIcon } from 'lucide-react';
 
@@ -109,18 +109,19 @@ export function ConstellationCoveragePage() {
 
   return (
     <div className="flex min-h-[50vh] flex-col gap-4 px-4 py-4 md:px-6 md:py-6">
-      <div className="flex flex-col gap-4 sm:flex-row sm:items-center sm:justify-between">
-        <div className="flex items-center gap-2">
-          <CircleDashedIcon className="h-6 w-6" />
-          <h1 className="text-xl font-semibold sm:text-2xl">Constellation coverage</h1>
+      <div className="flex flex-col gap-4 lg:flex-row lg:items-start lg:justify-between">
+        <div className="min-w-0 flex-1 space-y-1">
+          <div className="flex items-center gap-2">
+            <CircleDashedIcon className="h-6 w-6 shrink-0" />
+            <h1 className="text-xl font-semibold sm:text-2xl">Constellation coverage</h1>
+          </div>
+          <p className="max-w-2xl text-sm text-muted-foreground">
+            Combines traceroute attempts from every managed node in the selected constellation, grouped into map hex
+            cells. Each cell shows aggregate successes and failures toward targets in that area (smoothing and
+            minimum-attempt filters apply below).
+          </p>
         </div>
         <div className="flex flex-wrap items-center gap-3" data-testid="constellation-coverage-filters">
-          <Link
-            to="/traceroutes/map/coverage"
-            className="text-sm text-muted-foreground underline-offset-4 hover:text-foreground hover:underline"
-          >
-            Per-feeder view
-          </Link>
           <div className="flex items-center gap-2">
             <Label className="text-xs text-muted-foreground" htmlFor="constellation-coverage-constellation">
               Constellation

--- a/src/pages/traceroutes/FeederCoveragePage.tsx
+++ b/src/pages/traceroutes/FeederCoveragePage.tsx
@@ -153,18 +153,19 @@ export function FeederCoveragePage() {
 
   return (
     <div className="flex min-h-[50vh] flex-col gap-4 px-4 py-4 md:px-6 md:py-6">
-      <div className="flex flex-col gap-4 sm:flex-row sm:items-center sm:justify-between">
-        <div className="flex items-center gap-2">
-          <CircleDashedIcon className="h-6 w-6" />
-          <h1 className="text-xl font-semibold sm:text-2xl">Feeder coverage</h1>
+      <div className="flex flex-col gap-4 lg:flex-row lg:items-start lg:justify-between">
+        <div className="min-w-0 flex-1 space-y-1">
+          <div className="flex items-center gap-2">
+            <CircleDashedIcon className="h-6 w-6 shrink-0" />
+            <h1 className="text-xl font-semibold sm:text-2xl">Managed node coverage</h1>
+          </div>
+          <p className="max-w-2xl text-sm text-muted-foreground">
+            Maps completed and failed auto-traceroutes from one managed node to each probed target over the time window.
+            Dots show per-target reliability; hex bins summarise nearby targets; the polygon outlines where at least one
+            successful route was observed (not a guarantee of RF coverage).
+          </p>
         </div>
         <div className="flex flex-wrap items-center gap-3" data-testid="coverage-filters">
-          <Link
-            to="/traceroutes/map/coverage/constellation"
-            className="text-sm text-muted-foreground underline-offset-4 hover:text-foreground hover:underline"
-          >
-            Constellation view
-          </Link>
           <div className="flex w-full items-center gap-2 sm:w-auto">
             <Label className="text-xs text-muted-foreground" htmlFor="feeder-coverage-feeder">
               Feeder


### PR DESCRIPTION
# Summary

- rename traceroute sidebar link from "Coverage" to "Coverage by node"
- rename the feeder coverage page title to "Managed node coverage"
- add short explanatory descriptions under the titles on both coverage pages
- remove the redundant "switch" links in page headers (navigation already exists in the sidebar)

## Testing performed

- pre-commit checks ran successfully on commit (`eslint`, `prettier --check`, `vitest run`)
- manually verified route labels and page headings in the UI

Refs #178.