### PR TITLE
feat(nodes): add managed nodes operator status page

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,4 +1,4 @@
-import { Suspense } from 'react';
+import { Suspense, lazy } from 'react';
 import { TracerouteHistory } from '@/pages/traceroutes/TracerouteHistory';
 import { TracerouteHeatmapPage } from '@/pages/traceroutes/TracerouteHeatmapPage';
 import { FeederCoveragePage } from '@/pages/traceroutes/FeederCoveragePage';
@@ -28,6 +28,8 @@ import { ProtectedRoute } from '@/components/auth/ProtectedRoute';
 import { AppLayout } from '@/components/layouts/AppLayout';
 import MonitorNodes from '@/pages/nodes/monitor';
 
+const ManagedNodesStatus = lazy(() => import('@/pages/nodes/ManagedNodesStatus'));
+
 function App() {
   return (
     <Suspense fallback={<div>Loading...</div>}>
@@ -51,6 +53,14 @@ function App() {
                   <Route path="/" element={<Dashboard />} />
                   <Route path="/nodes" element={<NodesList />} />
                   <Route path="/nodes/infrastructure" element={<MeshInfrastructure />} />
+                  <Route
+                    path="/nodes/managed-nodes"
+                    element={
+                      <Suspense fallback={<div>Loading managed nodes...</div>}>
+                        <ManagedNodesStatus />
+                      </Suspense>
+                    }
+                  />
                   <Route path="/weather" element={<Weather />} />
                   <Route path="/nodes/my-nodes" element={<MyNodes />} />
                   <Route path="/nodes/monitor" element={<MonitorNodes />} />

--- a/src/components/nav-main.tsx
+++ b/src/components/nav-main.tsx
@@ -68,6 +68,7 @@ export function NavMain() {
       icon: NetworkIcon,
       children: [
         { title: 'My nodes', url: '/nodes/my-nodes', icon: RadioIcon },
+        { title: 'Managed nodes', url: '/nodes/managed-nodes', icon: ActivityIcon },
         { title: 'Watches', url: '/nodes/monitor', icon: ActivityIcon },
         { title: 'Mesh infra', url: '/nodes/infrastructure', icon: ServerIcon },
       ],

--- a/src/components/nodes/NodesAndConstellationsMap.tsx
+++ b/src/components/nodes/NodesAndConstellationsMap.tsx
@@ -65,6 +65,8 @@ export interface NodesAndConstellationsMapProps {
   getMarkerGrayscale?: (node: ObservedNode) => number;
   /** Optional CSS colour for a 3px inset border on weather-style markers (e.g. age indicator) */
   getMarkerBorderColor?: (node: ObservedNode) => string | undefined;
+  /** Optional marker colour override for managed nodes */
+  getManagedNodeMarkerColor?: (node: ManagedNode) => string;
 }
 
 export function NodesAndConstellationsMap({
@@ -86,6 +88,7 @@ export function NodesAndConstellationsMap({
   getMarkerColor,
   getMarkerGrayscale,
   getMarkerBorderColor,
+  getManagedNodeMarkerColor,
 }: NodesAndConstellationsMapProps) {
   const mapRef = useRef<HTMLDivElement>(null);
   const mapInstanceRef = useRef<L.Map | null>(null);
@@ -446,7 +449,7 @@ export function NodesAndConstellationsMap({
           const marker = L.marker(position, {
             icon: createNodeIcon(
               node.short_name || node.node_id_str?.slice(4, 8) || '?',
-              c.color,
+              getManagedNodeMarkerColor ? getManagedNodeMarkerColor(node) : c.color,
               isSelected,
               hasSelection && !isSelected
             ),
@@ -487,6 +490,7 @@ export function NodesAndConstellationsMap({
     getMarkerColor,
     getMarkerGrayscale,
     getMarkerBorderColor,
+    getManagedNodeMarkerColor,
   ]);
 
   return (

--- a/src/hooks/api/useNodes.ts
+++ b/src/hooks/api/useNodes.ts
@@ -326,6 +326,11 @@ export interface UseInfrastructureNodesOptions {
   includeClientBase?: boolean;
 }
 
+export interface UseManagedNodesSuspenseOptions {
+  pageSize?: number;
+  includeStatus?: boolean;
+}
+
 /**
  * Suspense-enabled hook to fetch infrastructure nodes (router, repeater, etc.)
  */
@@ -423,12 +428,15 @@ export function useWeatherNodesSuspense(options?: UseWeatherNodesOptions) {
 /**
  * Suspense-enabled hook to fetch managed nodes with pagination
  */
-export function useManagedNodesSuspense(pageSize = 500) {
+export function useManagedNodesSuspense(options?: UseManagedNodesSuspenseOptions) {
   const api = useMeshtasticApi();
+  const pageSize = options?.pageSize ?? 500;
+  const includeStatus = options?.includeStatus ?? false;
   const managedNodesQuery = useSuspenseInfiniteQuery<PaginatedResponse<ManagedNode>, Error>({
     refetchInterval: 1000 * 60, // 1 minute
-    queryKey: ['managed-nodes', pageSize],
-    queryFn: async ({ pageParam = 1 }) => api.getManagedNodes({ page: pageParam as number, page_size: pageSize }),
+    queryKey: ['managed-nodes', pageSize, includeStatus ? 'status' : 'base'],
+    queryFn: async ({ pageParam = 1 }) =>
+      api.getManagedNodes({ page: pageParam as number, page_size: pageSize, includeStatus }),
     initialPageParam: 1,
     getNextPageParam: (lastPage, allPages) => (lastPage.next ? allPages.length + 1 : undefined),
   });

--- a/src/lib/api/meshtastic-api.ts
+++ b/src/lib/api/meshtastic-api.ts
@@ -370,10 +370,15 @@ export class MeshtasticApi extends BaseApi {
   /**
    * Get a paginated list of managed nodes
    */
-  async getManagedNodes(params?: PaginationParams): Promise<PaginatedResponse<ManagedNode>> {
+  async getManagedNodes(
+    params?: PaginationParams & {
+      includeStatus?: boolean;
+    }
+  ): Promise<PaginatedResponse<ManagedNode>> {
     const searchParams = new URLSearchParams();
     if (params?.page) searchParams.append('page', params.page.toString());
     if (params?.page_size) searchParams.append('page_size', params.page_size.toString());
+    if (params?.includeStatus) searchParams.append('include', 'status');
     return this.get<PaginatedResponse<ManagedNode>>('/nodes/managed-nodes/', searchParams);
   }
 

--- a/src/lib/managed-node-status.test.ts
+++ b/src/lib/managed-node-status.test.ts
@@ -1,0 +1,33 @@
+import { describe, expect, it } from 'vitest';
+
+import {
+  MANAGED_NODE_ONLINE_MAX_AGE_SECONDS,
+  MANAGED_NODE_STALE_MAX_AGE_SECONDS,
+  getManagedNodeStatusTier,
+} from './managed-node-status';
+
+describe('getManagedNodeStatusTier', () => {
+  const now = new Date('2026-04-20T12:00:00Z');
+
+  it('returns never when there is no ingestion timestamp', () => {
+    expect(getManagedNodeStatusTier(null, now)).toBe('never');
+    expect(getManagedNodeStatusTier(undefined, now)).toBe('never');
+  });
+
+  it('returns online at or below online threshold', () => {
+    const onlineAtThreshold = new Date(now.getTime() - MANAGED_NODE_ONLINE_MAX_AGE_SECONDS * 1000);
+    expect(getManagedNodeStatusTier(onlineAtThreshold, now)).toBe('online');
+  });
+
+  it('returns stale just above online threshold and at stale threshold', () => {
+    const justAboveOnline = new Date(now.getTime() - (MANAGED_NODE_ONLINE_MAX_AGE_SECONDS + 1) * 1000);
+    const staleAtThreshold = new Date(now.getTime() - MANAGED_NODE_STALE_MAX_AGE_SECONDS * 1000);
+    expect(getManagedNodeStatusTier(justAboveOnline, now)).toBe('stale');
+    expect(getManagedNodeStatusTier(staleAtThreshold, now)).toBe('stale');
+  });
+
+  it('returns offline above stale threshold', () => {
+    const offline = new Date(now.getTime() - (MANAGED_NODE_STALE_MAX_AGE_SECONDS + 1) * 1000);
+    expect(getManagedNodeStatusTier(offline, now)).toBe('offline');
+  });
+});

--- a/src/lib/managed-node-status.ts
+++ b/src/lib/managed-node-status.ts
@@ -1,0 +1,29 @@
+export type ManagedNodeStatusTier = 'online' | 'stale' | 'offline' | 'never';
+
+export const MANAGED_NODE_ONLINE_MAX_AGE_SECONDS = 600;
+export const MANAGED_NODE_STALE_MAX_AGE_SECONDS = 3600;
+
+const ONE_SECOND_MS = 1000;
+
+export function getManagedNodeStatusTier(
+  lastPacketIngestedAt: Date | string | null | undefined,
+  now: Date = new Date()
+): ManagedNodeStatusTier {
+  if (!lastPacketIngestedAt) return 'never';
+
+  const lastPacketDate = lastPacketIngestedAt instanceof Date ? lastPacketIngestedAt : new Date(lastPacketIngestedAt);
+  const ageMs = Math.max(0, now.getTime() - lastPacketDate.getTime());
+  const onlineCutoffMs = MANAGED_NODE_ONLINE_MAX_AGE_SECONDS * ONE_SECOND_MS;
+  const staleCutoffMs = MANAGED_NODE_STALE_MAX_AGE_SECONDS * ONE_SECOND_MS;
+
+  if (ageMs <= onlineCutoffMs) return 'online';
+  if (ageMs <= staleCutoffMs) return 'stale';
+  return 'offline';
+}
+
+export function managedNodeStatusTierColor(tier: ManagedNodeStatusTier): string {
+  if (tier === 'online') return '#16a34a';
+  if (tier === 'stale') return '#d97706';
+  if (tier === 'offline') return '#dc2626';
+  return '#64748b';
+}

--- a/src/lib/models.ts
+++ b/src/lib/models.ts
@@ -57,6 +57,11 @@ export interface ManagedNode {
   long_name: string | null;
   short_name: string | null;
   last_heard: Date | null;
+  radio_last_heard?: Date | null;
+  last_packet_ingested_at?: Date | null;
+  packets_last_hour?: number;
+  packets_last_24h?: number;
+  is_eligible_traceroute_source?: boolean;
   node_id_str: string;
   owner: {
     id: number;

--- a/src/pages/map/NodeMap.tsx
+++ b/src/pages/map/NodeMap.tsx
@@ -51,7 +51,7 @@ function NodeMapContent() {
 
   const lastHeardAfter = useMemo(() => getLastHeardAfter(timeRange), [timeRange]);
 
-  const { managedNodes } = useManagedNodesSuspense(500);
+  const { managedNodes } = useManagedNodesSuspense({ pageSize: 500 });
   const { nodes: observedNodes } = useNodesSuspense({
     lastHeardAfter,
     pageSize: 500,

--- a/src/pages/nodes/ManagedNodesStatus.tsx
+++ b/src/pages/nodes/ManagedNodesStatus.tsx
@@ -1,0 +1,461 @@
+import { Suspense, useMemo, useState } from 'react';
+import { Link, useSearchParams } from 'react-router-dom';
+import { format, formatDistanceToNow } from 'date-fns';
+import { toast } from 'sonner';
+import { ChevronDown, Loader2 } from 'lucide-react';
+
+import { NodesAndConstellationsMap } from '@/components/nodes/NodesAndConstellationsMap';
+import { Badge } from '@/components/ui/badge';
+import { Button } from '@/components/ui/button';
+import { Card, CardContent, CardDescription, CardHeader, CardTitle } from '@/components/ui/card';
+import {
+  DropdownMenu,
+  DropdownMenuCheckboxItem,
+  DropdownMenuContent,
+  DropdownMenuLabel,
+  DropdownMenuSeparator,
+  DropdownMenuTrigger,
+} from '@/components/ui/dropdown-menu';
+import { Input } from '@/components/ui/input';
+import { Label } from '@/components/ui/label';
+import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from '@/components/ui/select';
+import { Switch } from '@/components/ui/switch';
+import { Table, TableBody, TableCell, TableHead, TableHeader, TableRow } from '@/components/ui/table';
+import { useManagedNodesSuspense } from '@/hooks/api/useNodes';
+import { useTriggerTraceroute } from '@/hooks/api/useTraceroutes';
+import { authService } from '@/lib/auth/authService';
+import {
+  ManagedNodeStatusTier,
+  getManagedNodeStatusTier,
+  managedNodeStatusTierColor,
+} from '@/lib/managed-node-status';
+import { ManagedNode } from '@/lib/models';
+
+import {
+  ManagedNodesSortKey,
+  parseManagedNodesUrlState,
+  updateManagedNodesUrlState,
+} from './managed-nodes-url-state';
+
+const STATUS_OPTIONS: Array<{ value: ManagedNodeStatusTier; label: string }> = [
+  { value: 'online', label: 'Online' },
+  { value: 'stale', label: 'Stale' },
+  { value: 'offline', label: 'Offline' },
+  { value: 'never', label: 'Never reported' },
+];
+
+const SORT_OPTIONS: Array<{ value: ManagedNodesSortKey; label: string }> = [
+  { value: 'last_packet_desc', label: 'Last packet (newest first)' },
+  { value: 'last_packet_asc', label: 'Last packet (oldest first)' },
+  { value: 'status_asc', label: 'Status (online to never)' },
+  { value: 'status_desc', label: 'Status (never to online)' },
+  { value: 'name_asc', label: 'Name (A-Z)' },
+  { value: 'name_desc', label: 'Name (Z-A)' },
+  { value: 'packets_1h_desc', label: 'Packets/hour (high to low)' },
+  { value: 'packets_1h_asc', label: 'Packets/hour (low to high)' },
+  { value: 'packets_24h_desc', label: 'Packets/24h (high to low)' },
+  { value: 'packets_24h_asc', label: 'Packets/24h (low to high)' },
+  { value: 'radio_last_heard_desc', label: 'Radio heard (newest first)' },
+  { value: 'radio_last_heard_asc', label: 'Radio heard (oldest first)' },
+  { value: 'owner_asc', label: 'Owner (A-Z)' },
+  { value: 'owner_desc', label: 'Owner (Z-A)' },
+];
+
+function compareDate(a: Date | string | null | undefined, b: Date | string | null | undefined) {
+  if (!a && !b) return 0;
+  if (!a) return -1;
+  if (!b) return 1;
+  return new Date(a).getTime() - new Date(b).getTime();
+}
+
+function statusOrder(tier: ManagedNodeStatusTier): number {
+  if (tier === 'online') return 0;
+  if (tier === 'stale') return 1;
+  if (tier === 'offline') return 2;
+  return 3;
+}
+
+function tierLabel(tier: ManagedNodeStatusTier): string {
+  if (tier === 'never') return 'Never';
+  return tier[0].toUpperCase() + tier.slice(1);
+}
+
+function formatTimestamp(value: Date | string | null | undefined): string {
+  if (!value) return 'Never';
+  const date = new Date(value);
+  return `${format(date, 'PPpp')} (${formatDistanceToNow(date, { addSuffix: true })})`;
+}
+
+function autoTracerouteBadge(node: ManagedNode) {
+  if (!node.allow_auto_traceroute) return <Badge variant="outline">disabled</Badge>;
+  return node.is_eligible_traceroute_source ? <Badge>eligible</Badge> : <Badge variant="secondary">stale-source</Badge>;
+}
+
+function ManagedNodesStatusContent() {
+  const currentUser = authService.getCurrentUser();
+  const { managedNodes } = useManagedNodesSuspense({ pageSize: 500, includeStatus: true });
+  const triggerMutation = useTriggerTraceroute();
+  const [searchParams, setSearchParams] = useSearchParams();
+  const [queryInput, setQueryInput] = useState(() => parseManagedNodesUrlState(searchParams).query);
+  const filters = useMemo(() => parseManagedNodesUrlState(searchParams), [searchParams]);
+
+  const updateFilters = (patch: Parameters<typeof updateManagedNodesUrlState>[1]) => {
+    const next = updateManagedNodesUrlState(searchParams, patch);
+    setSearchParams(next, { replace: true });
+  };
+
+  const ownerOptions = useMemo(
+    () =>
+      Array.from(new Set(managedNodes.map((node) => node.owner?.username).filter(Boolean) as string[])).sort((a, b) =>
+        a.localeCompare(b)
+      ),
+    [managedNodes]
+  );
+  const constellationOptions = useMemo(
+    () =>
+      Array.from(
+        new Map(
+          managedNodes
+            .filter((node) => node.constellation?.id != null)
+            .map((node) => [node.constellation.id, { id: node.constellation.id, name: node.constellation.name ?? '—' }])
+        ).values()
+      ),
+    [managedNodes]
+  );
+
+  const filteredManagedNodes = useMemo(() => {
+    const queryLower = filters.query.toLowerCase();
+    return managedNodes.filter((node) => {
+      const tier = getManagedNodeStatusTier(node.last_packet_ingested_at);
+      if (filters.constellationIds.length > 0 && !filters.constellationIds.includes(node.constellation.id)) return false;
+      if (filters.statusTiers.length > 0 && !filters.statusTiers.includes(tier)) return false;
+      if (filters.ownerUsernames.length > 0 && !filters.ownerUsernames.includes(node.owner.username)) return false;
+      if (filters.allowAutoTraceroute != null && !!node.allow_auto_traceroute !== filters.allowAutoTraceroute) return false;
+      if (queryLower.length > 0) {
+        const haystack = `${node.long_name ?? ''} ${node.short_name ?? ''} ${node.node_id_str}`.toLowerCase();
+        if (!haystack.includes(queryLower)) return false;
+      }
+      return true;
+    });
+  }, [managedNodes, filters]);
+
+  const sortedManagedNodes = useMemo(() => {
+    const sorted = [...filteredManagedNodes];
+    sorted.sort((a, b) => {
+      const tierA = getManagedNodeStatusTier(a.last_packet_ingested_at);
+      const tierB = getManagedNodeStatusTier(b.last_packet_ingested_at);
+      switch (filters.sort) {
+        case 'status_asc':
+          return statusOrder(tierA) - statusOrder(tierB);
+        case 'status_desc':
+          return statusOrder(tierB) - statusOrder(tierA);
+        case 'name_asc':
+          return (a.long_name ?? a.node_id_str).localeCompare(b.long_name ?? b.node_id_str);
+        case 'name_desc':
+          return (b.long_name ?? b.node_id_str).localeCompare(a.long_name ?? a.node_id_str);
+        case 'last_packet_asc':
+          return compareDate(a.last_packet_ingested_at, b.last_packet_ingested_at);
+        case 'packets_1h_desc':
+          return (b.packets_last_hour ?? 0) - (a.packets_last_hour ?? 0);
+        case 'packets_1h_asc':
+          return (a.packets_last_hour ?? 0) - (b.packets_last_hour ?? 0);
+        case 'packets_24h_desc':
+          return (b.packets_last_24h ?? 0) - (a.packets_last_24h ?? 0);
+        case 'packets_24h_asc':
+          return (a.packets_last_24h ?? 0) - (b.packets_last_24h ?? 0);
+        case 'radio_last_heard_desc':
+          return compareDate(b.radio_last_heard, a.radio_last_heard);
+        case 'radio_last_heard_asc':
+          return compareDate(a.radio_last_heard, b.radio_last_heard);
+        case 'owner_asc':
+          return a.owner.username.localeCompare(b.owner.username);
+        case 'owner_desc':
+          return b.owner.username.localeCompare(a.owner.username);
+        case 'last_packet_desc':
+        default:
+          return compareDate(b.last_packet_ingested_at, a.last_packet_ingested_at);
+      }
+    });
+    return sorted;
+  }, [filteredManagedNodes, filters.sort]);
+
+  const counts = useMemo(() => {
+    const base = { total: filteredManagedNodes.length, online: 0, stale: 0, offline: 0, never: 0 };
+    for (const node of filteredManagedNodes) {
+      const tier = getManagedNodeStatusTier(node.last_packet_ingested_at);
+      base[tier] += 1;
+    }
+    return base;
+  }, [filteredManagedNodes]);
+
+  const toggleFromList = <T extends string>(current: T[], value: T) =>
+    current.includes(value) ? current.filter((v) => v !== value) : [...current, value];
+
+  return (
+    <div className="container mx-auto p-4 space-y-6">
+      <Card>
+        <CardHeader>
+          <CardTitle>Managed Nodes</CardTitle>
+          <CardDescription>
+            Operator view of feeder fleet health. For RF-side observed infrastructure, use{' '}
+            <Link to="/nodes/infrastructure" className="underline">
+              Mesh Infrastructure
+            </Link>
+            .
+          </CardDescription>
+        </CardHeader>
+        <CardContent className="grid gap-3 sm:grid-cols-5">
+          <Badge variant="outline">Total: {counts.total}</Badge>
+          <Badge className="bg-green-700 text-white">Online: {counts.online}</Badge>
+          <Badge className="bg-amber-600 text-white">Stale: {counts.stale}</Badge>
+          <Badge className="bg-red-700 text-white">Offline: {counts.offline}</Badge>
+          <Badge variant="secondary">Never: {counts.never}</Badge>
+        </CardContent>
+      </Card>
+
+      <Card>
+        <CardHeader>
+          <CardTitle>Map</CardTitle>
+        </CardHeader>
+        <CardContent>
+          <div className="h-[450px] rounded border">
+            <NodesAndConstellationsMap
+              managedNodes={sortedManagedNodes}
+              showConstellation={true}
+              showUnmanagedNodes={false}
+              drawPositionUncertainty={true}
+              getManagedNodeMarkerColor={(node) =>
+                managedNodeStatusTierColor(getManagedNodeStatusTier(node.last_packet_ingested_at))
+              }
+            />
+          </div>
+        </CardContent>
+      </Card>
+
+      <Card>
+        <CardHeader>
+          <CardTitle>Filters</CardTitle>
+        </CardHeader>
+        <CardContent className="grid gap-4 lg:grid-cols-5">
+          <div className="space-y-2">
+            <Label>Constellation</Label>
+            <DropdownMenu>
+              <DropdownMenuTrigger asChild>
+                <Button variant="outline" className="w-full justify-between">
+                  {filters.constellationIds.length ? `Selected (${filters.constellationIds.length})` : 'All'}
+                  <ChevronDown className="h-4 w-4" />
+                </Button>
+              </DropdownMenuTrigger>
+              <DropdownMenuContent className="w-64">
+                <DropdownMenuLabel>Constellations</DropdownMenuLabel>
+                <DropdownMenuSeparator />
+                {constellationOptions.map((option) => (
+                  <DropdownMenuCheckboxItem
+                    key={option.id}
+                    checked={filters.constellationIds.includes(option.id)}
+                    onCheckedChange={() =>
+                      updateFilters({
+                        constellationIds: toggleFromList(filters.constellationIds.map(String), String(option.id)).map(
+                          Number
+                        ),
+                      })
+                    }
+                  >
+                    {option.name}
+                  </DropdownMenuCheckboxItem>
+                ))}
+              </DropdownMenuContent>
+            </DropdownMenu>
+          </div>
+
+          <div className="space-y-2">
+            <Label>Status</Label>
+            <DropdownMenu>
+              <DropdownMenuTrigger asChild>
+                <Button variant="outline" className="w-full justify-between">
+                  {filters.statusTiers.length ? `Selected (${filters.statusTiers.length})` : 'All'}
+                  <ChevronDown className="h-4 w-4" />
+                </Button>
+              </DropdownMenuTrigger>
+              <DropdownMenuContent className="w-56">
+                <DropdownMenuLabel>Status tiers</DropdownMenuLabel>
+                <DropdownMenuSeparator />
+                {STATUS_OPTIONS.map((option) => (
+                  <DropdownMenuCheckboxItem
+                    key={option.value}
+                    checked={filters.statusTiers.includes(option.value)}
+                    onCheckedChange={() =>
+                      updateFilters({ statusTiers: toggleFromList(filters.statusTiers, option.value) })
+                    }
+                  >
+                    {option.label}
+                  </DropdownMenuCheckboxItem>
+                ))}
+              </DropdownMenuContent>
+            </DropdownMenu>
+          </div>
+
+          <div className="space-y-2">
+            <Label>Owner</Label>
+            <DropdownMenu>
+              <DropdownMenuTrigger asChild>
+                <Button variant="outline" className="w-full justify-between">
+                  {filters.ownerUsernames.length ? `Selected (${filters.ownerUsernames.length})` : 'All'}
+                  <ChevronDown className="h-4 w-4" />
+                </Button>
+              </DropdownMenuTrigger>
+              <DropdownMenuContent className="w-56">
+                <DropdownMenuLabel>Owners</DropdownMenuLabel>
+                <DropdownMenuSeparator />
+                {ownerOptions.map((owner) => (
+                  <DropdownMenuCheckboxItem
+                    key={owner}
+                    checked={filters.ownerUsernames.includes(owner)}
+                    onCheckedChange={() =>
+                      updateFilters({ ownerUsernames: toggleFromList(filters.ownerUsernames, owner) })
+                    }
+                  >
+                    {owner}
+                  </DropdownMenuCheckboxItem>
+                ))}
+              </DropdownMenuContent>
+            </DropdownMenu>
+          </div>
+
+          <div className="space-y-2">
+            <Label>Search</Label>
+            <Input
+              value={queryInput}
+              onChange={(event) => setQueryInput(event.target.value)}
+              onBlur={() => updateFilters({ query: queryInput })}
+              placeholder="Name or node id"
+            />
+          </div>
+
+          <div className="space-y-2">
+            <Label>Sort</Label>
+            <Select value={filters.sort} onValueChange={(value) => updateFilters({ sort: value as ManagedNodesSortKey })}>
+              <SelectTrigger>
+                <SelectValue />
+              </SelectTrigger>
+              <SelectContent>
+                {SORT_OPTIONS.map((option) => (
+                  <SelectItem key={option.value} value={option.value}>
+                    {option.label}
+                  </SelectItem>
+                ))}
+              </SelectContent>
+            </Select>
+          </div>
+
+          <div className="flex items-center gap-2 lg:col-span-5">
+            <Switch
+              checked={filters.allowAutoTraceroute === true}
+              onCheckedChange={(checked) => updateFilters({ allowAutoTraceroute: checked ? true : null })}
+            />
+            <Label>Allow auto traceroute only</Label>
+          </div>
+        </CardContent>
+      </Card>
+
+      <Card>
+        <CardHeader>
+          <CardTitle>Managed node health</CardTitle>
+        </CardHeader>
+        <CardContent>
+          <Table>
+            <TableHeader>
+              <TableRow>
+                <TableHead>Status</TableHead>
+                <TableHead>Name</TableHead>
+                <TableHead>Node ID</TableHead>
+                <TableHead>Constellation</TableHead>
+                <TableHead>Last packet ingested</TableHead>
+                <TableHead>Packets / hour</TableHead>
+                <TableHead>Packets / 24h</TableHead>
+                <TableHead>Radio last heard</TableHead>
+                <TableHead>Owner</TableHead>
+                <TableHead>Auto-TR</TableHead>
+                <TableHead>Actions</TableHead>
+              </TableRow>
+            </TableHeader>
+            <TableBody>
+              {sortedManagedNodes.map((node) => {
+                const tier = getManagedNodeStatusTier(node.last_packet_ingested_at);
+                const canOpenSettings = currentUser?.id === node.owner.id;
+                return (
+                  <TableRow key={node.node_id}>
+                    <TableCell>
+                      <Badge style={{ backgroundColor: managedNodeStatusTierColor(tier), color: 'white' }}>
+                        {tierLabel(tier)}
+                      </Badge>
+                    </TableCell>
+                    <TableCell>
+                      <Link to={`/nodes/${node.node_id}`} className="text-primary hover:underline">
+                        {node.long_name ?? node.short_name ?? node.node_id_str}
+                      </Link>
+                    </TableCell>
+                    <TableCell>{node.node_id_str}</TableCell>
+                    <TableCell>
+                      <Badge variant="outline">{node.constellation.name ?? '—'}</Badge>
+                    </TableCell>
+                    <TableCell>{formatTimestamp(node.last_packet_ingested_at)}</TableCell>
+                    <TableCell>{node.packets_last_hour ?? 0}</TableCell>
+                    <TableCell>{node.packets_last_24h ?? 0}</TableCell>
+                    <TableCell>{formatTimestamp(node.radio_last_heard)}</TableCell>
+                    <TableCell>{node.owner.username}</TableCell>
+                    <TableCell>{autoTracerouteBadge(node)}</TableCell>
+                    <TableCell className="space-x-3">
+                      <Link to={`/nodes/${node.node_id}`} className="text-primary hover:underline">
+                        View details
+                      </Link>
+                      {canOpenSettings && (
+                        <Link to="/user/nodes" className="text-primary hover:underline">
+                          Settings
+                        </Link>
+                      )}
+                      {node.is_eligible_traceroute_source && (
+                        <Button
+                          variant="link"
+                          className="h-auto p-0"
+                          disabled={triggerMutation.isPending}
+                          onClick={async () => {
+                            try {
+                              await triggerMutation.mutateAsync({ managedNodeId: node.node_id });
+                              toast.success(`Traceroute triggered from ${node.short_name ?? node.node_id_str}`);
+                            } catch (error) {
+                              const message = error instanceof Error ? error.message : 'Failed to trigger traceroute';
+                              toast.error(message);
+                            }
+                          }}
+                        >
+                          Trigger traceroute
+                        </Button>
+                      )}
+                    </TableCell>
+                  </TableRow>
+                );
+              })}
+            </TableBody>
+          </Table>
+        </CardContent>
+      </Card>
+    </div>
+  );
+}
+
+export function ManagedNodesStatus() {
+  return (
+    <Suspense
+      fallback={
+        <div className="flex items-center justify-center min-h-screen">
+          <Loader2 className="h-8 w-8 animate-spin text-blue-500" />
+        </div>
+      }
+    >
+      <ManagedNodesStatusContent />
+    </Suspense>
+  );
+}
+
+export default ManagedNodesStatus;

--- a/src/pages/nodes/ManagedNodesStatus.tsx
+++ b/src/pages/nodes/ManagedNodesStatus.tsx
@@ -1,7 +1,6 @@
 import { Suspense, useMemo, useState } from 'react';
 import { Link, useSearchParams } from 'react-router-dom';
 import { format, formatDistanceToNow } from 'date-fns';
-import { toast } from 'sonner';
 import { ChevronDown, Loader2 } from 'lucide-react';
 
 import { NodesAndConstellationsMap } from '@/components/nodes/NodesAndConstellationsMap';
@@ -22,8 +21,6 @@ import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from '@
 import { Switch } from '@/components/ui/switch';
 import { Table, TableBody, TableCell, TableHead, TableHeader, TableRow } from '@/components/ui/table';
 import { useManagedNodesSuspense } from '@/hooks/api/useNodes';
-import { useTriggerTraceroute } from '@/hooks/api/useTraceroutes';
-import { authService } from '@/lib/auth/authService';
 import { ManagedNodeStatusTier, getManagedNodeStatusTier, managedNodeStatusTierColor } from '@/lib/managed-node-status';
 import { ManagedNode } from '@/lib/models';
 
@@ -72,10 +69,15 @@ function tierLabel(tier: ManagedNodeStatusTier): string {
   return tier[0].toUpperCase() + tier.slice(1);
 }
 
-function formatTimestamp(value: Date | string | null | undefined): string {
+function renderTimestampCell(value: Date | string | null | undefined) {
   if (!value) return 'Never';
   const date = new Date(value);
-  return `${format(date, 'PPpp')} (${formatDistanceToNow(date, { addSuffix: true })})`;
+  return (
+    <div className="flex flex-col">
+      <span>{format(date, 'PPpp')}</span>
+      <span className="text-xs text-muted-foreground">{formatDistanceToNow(date, { addSuffix: true })}</span>
+    </div>
+  );
 }
 
 function autoTracerouteBadge(node: ManagedNode) {
@@ -84,9 +86,7 @@ function autoTracerouteBadge(node: ManagedNode) {
 }
 
 function ManagedNodesStatusContent() {
-  const currentUser = authService.getCurrentUser();
   const { managedNodes } = useManagedNodesSuspense({ pageSize: 500, includeStatus: true });
-  const triggerMutation = useTriggerTraceroute();
   const [searchParams, setSearchParams] = useSearchParams();
   const [queryInput, setQueryInput] = useState(() => parseManagedNodesUrlState(searchParams).query);
   const filters = useMemo(() => parseManagedNodesUrlState(searchParams), [searchParams]);
@@ -184,6 +184,23 @@ function ManagedNodesStatusContent() {
 
   const toggleFromList = <T extends string>(current: T[], value: T) =>
     current.includes(value) ? current.filter((v) => v !== value) : [...current, value];
+  const nodesByConstellation = useMemo(() => {
+    const grouped = new Map<number, { id: number; name: string; nodes: ManagedNode[] }>();
+    for (const node of sortedManagedNodes) {
+      const constellationName = node.constellation.name ?? `Constellation ${node.constellation.id}`;
+      const existing = grouped.get(node.constellation.id);
+      if (existing) {
+        existing.nodes.push(node);
+      } else {
+        grouped.set(node.constellation.id, {
+          id: node.constellation.id,
+          name: constellationName,
+          nodes: [node],
+        });
+      }
+    }
+    return Array.from(grouped.values()).sort((a, b) => a.name.localeCompare(b.name));
+  }, [sortedManagedNodes]);
 
   return (
     <div className="container mx-auto p-4 space-y-6">
@@ -355,88 +372,63 @@ function ManagedNodesStatusContent() {
         </CardContent>
       </Card>
 
-      <Card>
-        <CardHeader>
-          <CardTitle>Managed node health</CardTitle>
-        </CardHeader>
-        <CardContent>
-          <Table>
-            <TableHeader>
-              <TableRow>
-                <TableHead>Status</TableHead>
-                <TableHead>Name</TableHead>
-                <TableHead>Node ID</TableHead>
-                <TableHead>Constellation</TableHead>
-                <TableHead>Last packet ingested</TableHead>
-                <TableHead>Packets / hour</TableHead>
-                <TableHead>Packets / 24h</TableHead>
-                <TableHead>Radio last heard</TableHead>
-                <TableHead>Owner</TableHead>
-                <TableHead>Auto-TR</TableHead>
-                <TableHead>Actions</TableHead>
-              </TableRow>
-            </TableHeader>
-            <TableBody>
-              {sortedManagedNodes.map((node) => {
-                const tier = getManagedNodeStatusTier(node.last_packet_ingested_at);
-                const canOpenSettings = currentUser?.id === node.owner.id;
-                return (
-                  <TableRow key={node.node_id}>
-                    <TableCell>
-                      <Badge style={{ backgroundColor: managedNodeStatusTierColor(tier), color: 'white' }}>
-                        {tierLabel(tier)}
-                      </Badge>
-                    </TableCell>
-                    <TableCell>
-                      <Link to={`/nodes/${node.node_id}`} className="text-primary hover:underline">
-                        {node.long_name ?? node.short_name ?? node.node_id_str}
-                      </Link>
-                    </TableCell>
-                    <TableCell>{node.node_id_str}</TableCell>
-                    <TableCell>
-                      <Badge variant="outline">{node.constellation.name ?? '—'}</Badge>
-                    </TableCell>
-                    <TableCell>{formatTimestamp(node.last_packet_ingested_at)}</TableCell>
-                    <TableCell>{node.packets_last_hour ?? 0}</TableCell>
-                    <TableCell>{node.packets_last_24h ?? 0}</TableCell>
-                    <TableCell>{formatTimestamp(node.radio_last_heard)}</TableCell>
-                    <TableCell>{node.owner.username}</TableCell>
-                    <TableCell>{autoTracerouteBadge(node)}</TableCell>
-                    <TableCell className="space-x-3">
-                      <Link to={`/nodes/${node.node_id}`} className="text-primary hover:underline">
-                        View details
-                      </Link>
-                      {canOpenSettings && (
-                        <Link to="/user/nodes" className="text-primary hover:underline">
-                          Settings
-                        </Link>
-                      )}
-                      {node.is_eligible_traceroute_source && (
-                        <Button
-                          variant="link"
-                          className="h-auto p-0"
-                          disabled={triggerMutation.isPending}
-                          onClick={async () => {
-                            try {
-                              await triggerMutation.mutateAsync({ managedNodeId: node.node_id });
-                              toast.success(`Traceroute triggered from ${node.short_name ?? node.node_id_str}`);
-                            } catch (error) {
-                              const message = error instanceof Error ? error.message : 'Failed to trigger traceroute';
-                              toast.error(message);
-                            }
-                          }}
-                        >
-                          Trigger traceroute
-                        </Button>
-                      )}
-                    </TableCell>
+      <div className="space-y-4">
+        {nodesByConstellation.map((group) => (
+          <Card key={group.id}>
+            <CardHeader>
+              <CardTitle>{group.name}</CardTitle>
+              <CardDescription>{group.nodes.length} managed nodes</CardDescription>
+            </CardHeader>
+            <CardContent>
+              <Table>
+                <TableHeader>
+                  <TableRow>
+                    <TableHead>Status</TableHead>
+                    <TableHead>Short name</TableHead>
+                    <TableHead>Long name</TableHead>
+                    <TableHead>Last packet ingested</TableHead>
+                    <TableHead>Packets / hour</TableHead>
+                    <TableHead>Packets / 24h</TableHead>
+                    <TableHead>Radio last heard</TableHead>
+                    <TableHead>Owner</TableHead>
+                    <TableHead>Auto-TR</TableHead>
                   </TableRow>
-                );
-              })}
-            </TableBody>
-          </Table>
-        </CardContent>
-      </Card>
+                </TableHeader>
+                <TableBody>
+                  {group.nodes.map((node) => {
+                    const tier = getManagedNodeStatusTier(node.last_packet_ingested_at);
+                    return (
+                      <TableRow key={node.node_id}>
+                        <TableCell>
+                          <Badge style={{ backgroundColor: managedNodeStatusTierColor(tier), color: 'white' }}>
+                            {tierLabel(tier)}
+                          </Badge>
+                        </TableCell>
+                        <TableCell>
+                          <Link to={`/nodes/${node.node_id}`} className="text-primary hover:underline">
+                            {node.short_name ?? '—'}
+                          </Link>
+                        </TableCell>
+                        <TableCell>
+                          <Link to={`/nodes/${node.node_id}`} className="text-primary hover:underline">
+                            {node.long_name ?? node.node_id_str}
+                          </Link>
+                        </TableCell>
+                        <TableCell>{renderTimestampCell(node.last_packet_ingested_at)}</TableCell>
+                        <TableCell>{node.packets_last_hour ?? 0}</TableCell>
+                        <TableCell>{node.packets_last_24h ?? 0}</TableCell>
+                        <TableCell>{renderTimestampCell(node.radio_last_heard)}</TableCell>
+                        <TableCell>{node.owner.username}</TableCell>
+                        <TableCell>{autoTracerouteBadge(node)}</TableCell>
+                      </TableRow>
+                    );
+                  })}
+                </TableBody>
+              </Table>
+            </CardContent>
+          </Card>
+        ))}
+      </div>
     </div>
   );
 }

--- a/src/pages/nodes/ManagedNodesStatus.tsx
+++ b/src/pages/nodes/ManagedNodesStatus.tsx
@@ -24,18 +24,10 @@ import { Table, TableBody, TableCell, TableHead, TableHeader, TableRow } from '@
 import { useManagedNodesSuspense } from '@/hooks/api/useNodes';
 import { useTriggerTraceroute } from '@/hooks/api/useTraceroutes';
 import { authService } from '@/lib/auth/authService';
-import {
-  ManagedNodeStatusTier,
-  getManagedNodeStatusTier,
-  managedNodeStatusTierColor,
-} from '@/lib/managed-node-status';
+import { ManagedNodeStatusTier, getManagedNodeStatusTier, managedNodeStatusTierColor } from '@/lib/managed-node-status';
 import { ManagedNode } from '@/lib/models';
 
-import {
-  ManagedNodesSortKey,
-  parseManagedNodesUrlState,
-  updateManagedNodesUrlState,
-} from './managed-nodes-url-state';
+import { ManagedNodesSortKey, parseManagedNodesUrlState, updateManagedNodesUrlState } from './managed-nodes-url-state';
 
 const STATUS_OPTIONS: Array<{ value: ManagedNodeStatusTier; label: string }> = [
   { value: 'online', label: 'Online' },
@@ -127,10 +119,12 @@ function ManagedNodesStatusContent() {
     const queryLower = filters.query.toLowerCase();
     return managedNodes.filter((node) => {
       const tier = getManagedNodeStatusTier(node.last_packet_ingested_at);
-      if (filters.constellationIds.length > 0 && !filters.constellationIds.includes(node.constellation.id)) return false;
+      if (filters.constellationIds.length > 0 && !filters.constellationIds.includes(node.constellation.id))
+        return false;
       if (filters.statusTiers.length > 0 && !filters.statusTiers.includes(tier)) return false;
       if (filters.ownerUsernames.length > 0 && !filters.ownerUsernames.includes(node.owner.username)) return false;
-      if (filters.allowAutoTraceroute != null && !!node.allow_auto_traceroute !== filters.allowAutoTraceroute) return false;
+      if (filters.allowAutoTraceroute != null && !!node.allow_auto_traceroute !== filters.allowAutoTraceroute)
+        return false;
       if (queryLower.length > 0) {
         const haystack = `${node.long_name ?? ''} ${node.short_name ?? ''} ${node.node_id_str}`.toLowerCase();
         if (!haystack.includes(queryLower)) return false;
@@ -334,7 +328,10 @@ function ManagedNodesStatusContent() {
 
           <div className="space-y-2">
             <Label>Sort</Label>
-            <Select value={filters.sort} onValueChange={(value) => updateFilters({ sort: value as ManagedNodesSortKey })}>
+            <Select
+              value={filters.sort}
+              onValueChange={(value) => updateFilters({ sort: value as ManagedNodesSortKey })}
+            >
               <SelectTrigger>
                 <SelectValue />
               </SelectTrigger>

--- a/src/pages/nodes/MeshInfrastructure.tsx
+++ b/src/pages/nodes/MeshInfrastructure.tsx
@@ -108,7 +108,7 @@ function MeshInfrastructureContent() {
     return m;
   }, [watchesQuery.data]);
 
-  const { managedNodes } = useManagedNodesSuspense(500);
+  const { managedNodes } = useManagedNodesSuspense({ pageSize: 500 });
 
   const { metricsMap } = useMultiNodeMetricsSuspense(nodes, chartDateRange);
 

--- a/src/pages/nodes/NodesList.tsx
+++ b/src/pages/nodes/NodesList.tsx
@@ -82,7 +82,7 @@ function NodesListContent() {
     pageSize: 100,
   });
 
-  const { managedNodes } = useManagedNodesSuspense(500);
+  const { managedNodes } = useManagedNodesSuspense({ pageSize: 500 });
 
   const sortNodes = (nodes: ObservedNode[]) => {
     return [...nodes].sort((a, b) => {

--- a/src/pages/nodes/managed-nodes-url-state.test.ts
+++ b/src/pages/nodes/managed-nodes-url-state.test.ts
@@ -1,0 +1,44 @@
+import { describe, expect, it } from 'vitest';
+
+import { parseManagedNodesUrlState, updateManagedNodesUrlState } from './managed-nodes-url-state';
+
+describe('managed-nodes-url-state', () => {
+  it('parses valid values and ignores invalid entries', () => {
+    const params = new URLSearchParams(
+      'constellation=1,abc,2&status=online,invalid,offline&owner=alice,bob&q=  west  &auto_tr=1&sort=name_asc'
+    );
+    const parsed = parseManagedNodesUrlState(params);
+    expect(parsed.constellationIds).toEqual([1, 2]);
+    expect(parsed.statusTiers).toEqual(['online', 'offline']);
+    expect(parsed.ownerUsernames).toEqual(['alice', 'bob']);
+    expect(parsed.query).toBe('west');
+    expect(parsed.allowAutoTraceroute).toBe(true);
+    expect(parsed.sort).toBe('name_asc');
+  });
+
+  it('keeps unknown params when applying patches', () => {
+    const initial = new URLSearchParams('foo=bar&status=online&sort=name_desc');
+    const next = updateManagedNodesUrlState(initial, {
+      statusTiers: ['stale', 'offline'],
+      query: ' feeder ',
+      allowAutoTraceroute: false,
+    });
+    expect(next.get('foo')).toBe('bar');
+    expect(next.get('status')).toBe('stale,offline');
+    expect(next.get('q')).toBe('feeder');
+    expect(next.get('auto_tr')).toBe('0');
+    expect(next.get('sort')).toBe('name_desc');
+  });
+
+  it('clears fields when patch sets empty values', () => {
+    const initial = new URLSearchParams('owner=alice&q=abc&auto_tr=1');
+    const next = updateManagedNodesUrlState(initial, {
+      ownerUsernames: [],
+      query: '',
+      allowAutoTraceroute: null,
+    });
+    expect(next.has('owner')).toBe(false);
+    expect(next.has('q')).toBe(false);
+    expect(next.has('auto_tr')).toBe(false);
+  });
+});

--- a/src/pages/nodes/managed-nodes-url-state.ts
+++ b/src/pages/nodes/managed-nodes-url-state.ts
@@ -1,0 +1,111 @@
+import { ManagedNodeStatusTier } from '@/lib/managed-node-status';
+
+export type ManagedNodesSortKey =
+  | 'status_asc'
+  | 'status_desc'
+  | 'name_asc'
+  | 'name_desc'
+  | 'last_packet_desc'
+  | 'last_packet_asc'
+  | 'packets_1h_desc'
+  | 'packets_1h_asc'
+  | 'packets_24h_desc'
+  | 'packets_24h_asc'
+  | 'radio_last_heard_desc'
+  | 'radio_last_heard_asc'
+  | 'owner_asc'
+  | 'owner_desc';
+
+export interface ManagedNodesUrlState {
+  constellationIds: number[];
+  statusTiers: ManagedNodeStatusTier[];
+  ownerUsernames: string[];
+  query: string;
+  allowAutoTraceroute: boolean | null;
+  sort: ManagedNodesSortKey;
+}
+
+export const DEFAULT_MANAGED_NODES_SORT: ManagedNodesSortKey = 'last_packet_desc';
+
+const VALID_STATUS_TIERS = new Set<ManagedNodeStatusTier>(['online', 'stale', 'offline', 'never']);
+const VALID_SORTS = new Set<ManagedNodesSortKey>([
+  'status_asc',
+  'status_desc',
+  'name_asc',
+  'name_desc',
+  'last_packet_desc',
+  'last_packet_asc',
+  'packets_1h_desc',
+  'packets_1h_asc',
+  'packets_24h_desc',
+  'packets_24h_asc',
+  'radio_last_heard_desc',
+  'radio_last_heard_asc',
+  'owner_asc',
+  'owner_desc',
+]);
+
+function parseCsv(raw: string | null): string[] {
+  if (!raw) return [];
+  return raw
+    .split(',')
+    .map((value) => value.trim())
+    .filter(Boolean);
+}
+
+export function parseManagedNodesUrlState(searchParams: URLSearchParams): ManagedNodesUrlState {
+  const constellationIds = parseCsv(searchParams.get('constellation'))
+    .map((value) => Number.parseInt(value, 10))
+    .filter((value) => Number.isFinite(value));
+  const statusTiers = parseCsv(searchParams.get('status')).filter((value): value is ManagedNodeStatusTier =>
+    VALID_STATUS_TIERS.has(value as ManagedNodeStatusTier)
+  );
+  const ownerUsernames = parseCsv(searchParams.get('owner'));
+  const query = searchParams.get('q')?.trim() ?? '';
+
+  const allowAutoRaw = searchParams.get('auto_tr');
+  const allowAutoTraceroute = allowAutoRaw === '1' ? true : allowAutoRaw === '0' ? false : null;
+
+  const sortRaw = searchParams.get('sort');
+  const sort = VALID_SORTS.has(sortRaw as ManagedNodesSortKey)
+    ? (sortRaw as ManagedNodesSortKey)
+    : DEFAULT_MANAGED_NODES_SORT;
+
+  return {
+    constellationIds,
+    statusTiers,
+    ownerUsernames,
+    query,
+    allowAutoTraceroute,
+    sort,
+  };
+}
+
+export function updateManagedNodesUrlState(
+  searchParams: URLSearchParams,
+  patch: Partial<ManagedNodesUrlState>
+): URLSearchParams {
+  const next = new URLSearchParams(searchParams);
+
+  const setCsv = (key: string, values: string[]) => {
+    if (values.length === 0) next.delete(key);
+    else next.set(key, values.join(','));
+  };
+
+  if (patch.constellationIds) setCsv('constellation', patch.constellationIds.map(String));
+  if (patch.statusTiers) setCsv('status', patch.statusTiers);
+  if (patch.ownerUsernames) setCsv('owner', patch.ownerUsernames);
+  if (patch.query !== undefined) {
+    if (patch.query.trim()) next.set('q', patch.query.trim());
+    else next.delete('q');
+  }
+  if (patch.allowAutoTraceroute !== undefined) {
+    if (patch.allowAutoTraceroute == null) next.delete('auto_tr');
+    else next.set('auto_tr', patch.allowAutoTraceroute ? '1' : '0');
+  }
+  if (patch.sort !== undefined) {
+    if (patch.sort) next.set('sort', patch.sort);
+    else next.delete('sort');
+  }
+  return next;
+}


### PR DESCRIPTION
# Summary

- Add a new `/nodes/managed-nodes` operator page to triage feeder-bot health at a glance.
- Implement URL-driven filters/sorting, status-tier counters, a status-coloured managed-node map, and a detailed health table with actions.
- Extend managed-node client typing/query plumbing for `include=status`, and add tests for status-tier logic and URL state parsing.

## Testing performed

- `npm test -- src/lib/managed-node-status.test.ts src/pages/nodes/managed-nodes-url-state.test.ts`
- `npm run lint`
- `npm run build`
- Pre-commit hook suite (`lint`, `format` check, `vitest run`) passed during commits.

Closes #174.
Related API PR: https://github.com/pskillen/meshflow-api/pull/180