### PR TITLE
fix(maps): deck.gl + Mapbox rendering hygiene (closes #150, #160)

### DIFF
--- a/.cursor/skills/meshflow-git-workflow/SKILL.md
+++ b/.cursor/skills/meshflow-git-workflow/SKILL.md
@@ -118,7 +118,7 @@ refactor(storage): extract packet parsing into service
 
 When the work is done:
 
-1. Open a PR in each affected repository
+1. Open a PR in each affected repository using the github-personal MCP. Do not use gh cli.
 2. Link the relevant issue(s) in the PR (e.g. "Closes #123")
 3. For multi-repo changes, link related PRs between repos in the description
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -82,4 +82,5 @@ When asked to create a pull request description, follow the template at
 
 ## Plan mode
 
-When creating a plan, Include that we should branch from the latest origin/main, do the work, commit, push, and open a PR. Use the github-personal MCP. the gh command is not available.
+When creating a plan, Include that we should branch from the latest origin/main, do the work, commit, push, and open a PR. Use the github-personal MCP. the gh
+command is not available, do not use it.

--- a/package-lock.json
+++ b/package-lock.json
@@ -10,7 +10,6 @@
       "dependencies": {
         "@deck.gl/geo-layers": "~9.2.0",
         "@deck.gl/layers": "^9.0.0",
-        "@deck.gl/mapbox": "^9.0.0",
         "@dnd-kit/core": "^6.3.1",
         "@dnd-kit/modifiers": "^9.0.0",
         "@dnd-kit/sortable": "^10.0.0",
@@ -1215,6 +1214,7 @@
       "resolved": "https://registry.npmjs.org/@deck.gl/mesh-layers/-/mesh-layers-9.2.11.tgz",
       "integrity": "sha512-zPB7TtnPXB3tOEoOfcOkNZo7coIq/ukIQa8HIUQLLiOE8AVSQfz3kbMmMK6rUabXlQbgSw/I/j3kFSYRHg3NGg==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@loaders.gl/gltf": "~4.3.4",
         "@loaders.gl/schema": "~4.3.4",
@@ -2711,6 +2711,7 @@
       "resolved": "https://registry.npmjs.org/@luma.gl/shadertools/-/shadertools-9.2.6.tgz",
       "integrity": "sha512-4+uUbynqPUra9d/z1nQChyHmhLgmKfSMjS7kOwLB6exSnhKnpHL3+Hu9fv55qyaX50nGH3oHawhGtJ6RRvu65w==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@math.gl/core": "^4.1.0",
         "@math.gl/types": "^4.1.0",

--- a/package.json
+++ b/package.json
@@ -23,7 +23,6 @@
   "dependencies": {
     "@deck.gl/geo-layers": "~9.2.0",
     "@deck.gl/layers": "^9.0.0",
-    "@deck.gl/mapbox": "^9.0.0",
     "@dnd-kit/core": "^6.3.1",
     "@dnd-kit/modifiers": "^9.0.0",
     "@dnd-kit/sortable": "^10.0.0",

--- a/src/components/map/DeckMapboxMap.tsx
+++ b/src/components/map/DeckMapboxMap.tsx
@@ -1,0 +1,76 @@
+import type { ReactNode } from 'react';
+
+import type { Layer, PickingInfo } from '@deck.gl/core';
+import { DeckGL } from 'deck.gl';
+import type { DeckGLProps } from 'deck.gl';
+import 'mapbox-gl/dist/mapbox-gl.css';
+import { Map } from 'react-map-gl';
+
+import { useConfig } from '@/providers/ConfigProvider';
+import { useMapboxStyle } from '@/hooks/useMapboxStyle';
+import { cn } from '@/lib/utils';
+
+/**
+ * react-map-gl allows `bounds` + `fitBoundsOptions` on initial view state; DeckGL's typings
+ * only list lon/lat/zoom. The Map child still applies bounds correctly at runtime.
+ */
+export type DeckMapboxInitialViewState =
+  | NonNullable<DeckGLProps['initialViewState']>
+  | {
+      bounds: [number, number, number, number];
+      fitBoundsOptions?: { padding?: number; maxZoom?: number; minZoom?: number };
+    };
+
+export type DeckMapboxMapProps = {
+  layers: Layer[];
+  initialViewState: DeckMapboxInitialViewState;
+  onClick?: (info: PickingInfo) => void;
+  getTooltip?: DeckGLProps['getTooltip'];
+  children?: ReactNode;
+  className?: string;
+  'data-testid'?: string;
+};
+
+/**
+ * Deck.gl owns the WebGL overlay lifecycle; Mapbox renders underneath as a child Map.
+ * Replaces fragile `useControl(() => new MapboxOverlay(props))` + render-time `setProps`,
+ * which could drop layers after unrelated React state updates (GitHub #150).
+ */
+export function DeckMapboxMap({
+  layers,
+  initialViewState,
+  onClick,
+  getTooltip,
+  children,
+  className,
+  'data-testid': testId,
+}: DeckMapboxMapProps) {
+  const config = useConfig();
+  const mapboxToken = config.mapboxToken ?? (import.meta.env.VITE_MAPBOX_TOKEN as string | undefined);
+  const mapStyle = useMapboxStyle();
+
+  if (!mapboxToken) {
+    return (
+      <div className="flex min-h-[300px] items-center justify-center rounded-md border bg-muted/30 text-muted-foreground">
+        Mapbox token required. Set VITE_MAPBOX_TOKEN (dev) or MAPBOX_TOKEN (Docker) in your environment.
+      </div>
+    );
+  }
+
+  return (
+    <div className={cn('relative h-full w-full', className)} data-testid={testId}>
+      <DeckGL
+        controller
+        layers={layers}
+        initialViewState={initialViewState as DeckGLProps['initialViewState']}
+        onClick={onClick}
+        getTooltip={getTooltip}
+        style={{ width: '100%', height: '100%' }}
+      >
+        <Map reuseMaps mapboxAccessToken={mapboxToken} mapStyle={mapStyle} style={{ width: '100%', height: '100%' }}>
+          {children}
+        </Map>
+      </DeckGL>
+    </div>
+  );
+}

--- a/src/components/nodes/NodeTracerouteLinksMap.tsx
+++ b/src/components/nodes/NodeTracerouteLinksMap.tsx
@@ -1,14 +1,12 @@
-import { useMemo, useState, useCallback, useEffect } from 'react';
-import { Map, useControl, useMap } from 'react-map-gl';
-import { MapboxOverlay, MapboxOverlayProps } from '@deck.gl/mapbox';
+import { useMemo, useState, useCallback } from 'react';
+import { Popup } from 'react-map-gl';
 import { ArcLayer, ScatterplotLayer, TextLayer } from '@deck.gl/layers';
 import type { PickingInfo } from '@deck.gl/core';
-import 'mapbox-gl/dist/mapbox-gl.css';
 import { Link } from 'react-router-dom';
-import { useConfig } from '@/providers/ConfigProvider';
-import { useMapboxStyle } from '@/hooks/useMapboxStyle';
 import { X } from 'lucide-react';
 import type { NodeTracerouteLinkEdge, NodeTracerouteLinkNode } from '@/hooks/api/useNodeTracerouteLinks';
+
+import { DeckMapboxMap } from '@/components/map/DeckMapboxMap';
 
 const DEFAULT_CENTER = { longitude: -4.2518, latitude: 55.8642, zoom: 8 };
 const FOCUS_NODE_COLOR: [number, number, number, number] = [34, 197, 94, 255]; // green - focus
@@ -26,12 +24,6 @@ function interpolateColorBySnr(snr: number, minSnr: number, maxSnr: number): [nu
   return [r, g, b, 200];
 }
 
-function DeckGLOverlay(props: MapboxOverlayProps) {
-  const overlay = useControl(() => new MapboxOverlay(props));
-  overlay.setProps(props);
-  return null;
-}
-
 export interface NodeTracerouteLinksMapProps {
   edges: NodeTracerouteLinkEdge[];
   nodes: NodeTracerouteLinkNode[];
@@ -43,97 +35,7 @@ function getNodeLabel(node: NodeTracerouteLinkNode): string {
   return node.short_name || node.long_name || node.node_id_str || `!${node.node_id.toString(16)}`;
 }
 
-function NodePopupOverlay({
-  node,
-  edge,
-  onClose,
-}: {
-  node: NodeTracerouteLinkNode;
-  edge?: NodeTracerouteLinkEdge;
-  onClose: () => void;
-}) {
-  const { current: mapRef } = useMap();
-  const [position, setPosition] = useState<{ x: number; y: number } | null>(null);
-
-  useEffect(() => {
-    const map = mapRef?.getMap?.();
-    if (!map || !mapRef || !node) return;
-
-    const updatePosition = () => {
-      try {
-        const point = mapRef.project([node.lng, node.lat]);
-        setPosition({ x: point.x, y: point.y });
-      } catch {
-        setPosition(null);
-      }
-    };
-
-    updatePosition();
-    map.on('move', updatePosition);
-    map.on('zoom', updatePosition);
-    return () => {
-      map.off('move', updatePosition);
-      map.off('zoom', updatePosition);
-    };
-  }, [mapRef, node?.lng, node?.lat]);
-
-  if (!position) return null;
-
-  return (
-    <div className="pointer-events-none absolute inset-0 z-[10000]" style={{ position: 'absolute' }}>
-      <div
-        className="pointer-events-auto min-w-[140px] rounded border border-slate-600 bg-slate-800 px-3 py-2 text-sm text-slate-100 shadow-lg"
-        style={{
-          position: 'absolute',
-          left: position.x,
-          top: position.y,
-          transform: 'translate(-50%, -100%)',
-          marginTop: -8,
-        }}
-      >
-        <button
-          type="button"
-          onClick={onClose}
-          className="absolute right-1 top-1 rounded p-0.5 text-slate-400 hover:bg-slate-700 hover:text-slate-200"
-          aria-label="Close"
-        >
-          <X className="h-3.5 w-3.5" />
-        </button>
-        <div className="pr-5">
-          <div className="font-semibold">
-            {node.long_name && node.short_name ? `${node.long_name} (${node.short_name})` : getNodeLabel(node)}
-          </div>
-          <div className="mt-0.5 text-xs text-slate-400">{node.node_id_str || `!${node.node_id.toString(16)}`}</div>
-          {edge && (
-            <div className="mt-1 space-y-0.5 text-xs">
-              {edge.avg_snr_in != null && (
-                <div>
-                  <span className="text-slate-400">SNR in:</span> {edge.avg_snr_in.toFixed(1)} dB
-                </div>
-              )}
-              {edge.avg_snr_out != null && (
-                <div>
-                  <span className="text-slate-400">SNR out:</span> {edge.avg_snr_out.toFixed(1)} dB
-                </div>
-              )}
-            </div>
-          )}
-          <Link
-            to={`/nodes/${node.node_id}`}
-            className="mt-1 inline-block text-xs text-emerald-400 hover:text-emerald-300 hover:underline"
-          >
-            Open details
-          </Link>
-        </div>
-      </div>
-    </div>
-  );
-}
-
 export function NodeTracerouteLinksMap({ edges, nodes, focusNodeId, showLabels = true }: NodeTracerouteLinksMapProps) {
-  const config = useConfig();
-  const mapboxToken = config.mapboxToken ?? (import.meta.env.VITE_MAPBOX_TOKEN as string | undefined);
-  const mapStyle = useMapboxStyle();
   const [selectedNode, setSelectedNode] = useState<NodeTracerouteLinkNode | null>(null);
   const [selectedEdge, setSelectedEdge] = useState<NodeTracerouteLinkEdge | null>(null);
 
@@ -240,34 +142,67 @@ export function NodeTracerouteLinksMap({ edges, nodes, focusNodeId, showLabels =
     return DEFAULT_CENTER;
   }, [nodes, focusNodeId]);
 
-  if (!mapboxToken) {
-    return (
-      <div className="flex min-h-[300px] items-center justify-center rounded-md border bg-muted/30 text-muted-foreground">
-        Mapbox token required. Set VITE_MAPBOX_TOKEN (dev) or MAPBOX_TOKEN (Docker) in your environment.
-      </div>
-    );
-  }
-
   return (
-    <div className="relative h-full w-full">
-      <Map
-        mapboxAccessToken={mapboxToken}
-        initialViewState={initialViewState}
-        mapStyle={mapStyle}
-        style={{ width: '100%', height: '100%' }}
-      >
-        <DeckGLOverlay interleaved={false} layers={layers} onClick={handleClick} />
-        {selectedNode && (
-          <NodePopupOverlay
-            node={selectedNode}
-            edge={selectedEdge ?? undefined}
-            onClose={() => {
-              setSelectedNode(null);
-              setSelectedEdge(null);
-            }}
-          />
-        )}
-      </Map>
-    </div>
+    <DeckMapboxMap layers={layers} initialViewState={initialViewState} onClick={handleClick}>
+      {selectedNode && (
+        <Popup
+          longitude={selectedNode.lng}
+          latitude={selectedNode.lat}
+          anchor="bottom"
+          closeButton={false}
+          closeOnClick={false}
+          onClose={() => {
+            setSelectedNode(null);
+            setSelectedEdge(null);
+          }}
+          maxWidth="320px"
+          className="meshflow-map-popup"
+        >
+          <div className="relative min-w-[140px] rounded-md border border-slate-600 bg-slate-800 px-3 py-2 text-sm text-slate-100 shadow-lg">
+            <button
+              type="button"
+              onClick={() => {
+                setSelectedNode(null);
+                setSelectedEdge(null);
+              }}
+              className="absolute right-1 top-1 rounded p-0.5 text-slate-400 hover:bg-slate-700 hover:text-slate-200"
+              aria-label="Close"
+            >
+              <X className="h-3.5 w-3.5" />
+            </button>
+            <div className="pr-5">
+              <div className="font-semibold">
+                {selectedNode.long_name && selectedNode.short_name
+                  ? `${selectedNode.long_name} (${selectedNode.short_name})`
+                  : getNodeLabel(selectedNode)}
+              </div>
+              <div className="mt-0.5 text-xs text-slate-400">
+                {selectedNode.node_id_str || `!${selectedNode.node_id.toString(16)}`}
+              </div>
+              {selectedEdge && (
+                <div className="mt-1 space-y-0.5 text-xs">
+                  {selectedEdge.avg_snr_in != null && (
+                    <div>
+                      <span className="text-slate-400">SNR in:</span> {selectedEdge.avg_snr_in.toFixed(1)} dB
+                    </div>
+                  )}
+                  {selectedEdge.avg_snr_out != null && (
+                    <div>
+                      <span className="text-slate-400">SNR out:</span> {selectedEdge.avg_snr_out.toFixed(1)} dB
+                    </div>
+                  )}
+                </div>
+              )}
+              <Link
+                to={`/nodes/${selectedNode.node_id}`}
+                className="mt-1 inline-block text-xs text-emerald-400 hover:text-emerald-300 hover:underline"
+              >
+                Open details
+              </Link>
+            </div>
+          </div>
+        </Popup>
+      )}
+    </DeckMapboxMap>
   );
 }

--- a/src/components/traceroutes/ConstellationCoverageMap.tsx
+++ b/src/components/traceroutes/ConstellationCoverageMap.tsx
@@ -1,14 +1,10 @@
-import { useCallback, useEffect, useMemo, useState } from 'react';
-import { Map, useControl, useMap } from 'react-map-gl';
-import { MapboxOverlay, type MapboxOverlayProps } from '@deck.gl/mapbox';
+import { useCallback, useMemo, useState } from 'react';
+import { Popup } from 'react-map-gl';
 import { H3HexagonLayer } from '@deck.gl/geo-layers';
 import type { Layer, PickingInfo } from '@deck.gl/core';
-import 'mapbox-gl/dist/mapbox-gl.css';
-
 import { X } from 'lucide-react';
 
-import { useConfig } from '@/providers/ConfigProvider';
-import { useMapboxStyle } from '@/hooks/useMapboxStyle';
+import { DeckMapboxMap } from '@/components/map/DeckMapboxMap';
 import type { ConstellationCoverageHex } from '@/lib/api/meshtastic-api';
 
 const DEFAULT_CENTER = { longitude: -4.2518, latitude: 55.8642, zoom: 7 };
@@ -41,95 +37,12 @@ function reliabilityColor(rate: number, alpha = 160): [number, number, number, n
   return [r, g, b, alpha];
 }
 
-function DeckGLOverlay(props: MapboxOverlayProps) {
-  const overlay = useControl(() => new MapboxOverlay(props));
-  overlay.setProps(props);
-  return null;
-}
-
-function HexPopupOverlay({ hex, onClose }: { hex: SmoothedHex | null; onClose: () => void }) {
-  const { current: mapRef } = useMap();
-  const [position, setPosition] = useState<{ x: number; y: number } | null>(null);
-
-  useEffect(() => {
-    if (!hex || !mapRef) {
-      setPosition(null);
-      return;
-    }
-    const map = mapRef.getMap?.();
-    if (!map) return;
-
-    const updatePosition = () => {
-      try {
-        const point = mapRef.project([hex.centre_lng, hex.centre_lat]);
-        setPosition({ x: point.x, y: point.y });
-      } catch {
-        setPosition(null);
-      }
-    };
-
-    updatePosition();
-    map.on('move', updatePosition);
-    map.on('zoom', updatePosition);
-    return () => {
-      map.off('move', updatePosition);
-      map.off('zoom', updatePosition);
-    };
-  }, [mapRef, hex]);
-
-  if (!hex || !position) return null;
-
-  const rawRate = hex.attempts > 0 ? hex.successes / hex.attempts : 0;
-
-  return (
-    <div
-      className="pointer-events-none absolute inset-0 z-[10000]"
-      style={{ position: 'absolute' }}
-      data-testid="coverage-hex-popup"
-    >
-      <div
-        className="pointer-events-auto min-w-[200px] rounded border border-slate-600 bg-slate-800 px-3 py-2 text-sm text-slate-100 shadow-lg"
-        style={{
-          position: 'absolute',
-          left: position.x,
-          top: position.y,
-          transform: 'translate(-50%, -100%)',
-          marginTop: -8,
-        }}
-      >
-        <button
-          type="button"
-          onClick={onClose}
-          className="absolute right-1 top-1 rounded p-0.5 text-slate-400 hover:bg-slate-700 hover:text-slate-200"
-          aria-label="Close"
-        >
-          <X className="h-3.5 w-3.5" aria-hidden />
-        </button>
-        <div className="pr-5">
-          <div className="font-mono text-xs text-slate-400">{hex.h3_index}</div>
-          <div className="mt-1 text-xs">
-            {hex.successes} / {hex.attempts} ({(rawRate * 100).toFixed(0)}% raw)
-          </div>
-          <div className="text-xs">Smoothed: {(hex.smoothed * 100).toFixed(0)}%</div>
-          <div className="mt-1 text-xs text-slate-400">
-            {hex.contributing_feeders} feeder{hex.contributing_feeders === 1 ? '' : 's'}, {hex.contributing_targets}{' '}
-            target{hex.contributing_targets === 1 ? '' : 's'}
-          </div>
-        </div>
-      </div>
-    </div>
-  );
-}
-
 export interface ConstellationCoverageMapProps {
   hexes: ConstellationCoverageHex[];
   minAttempts: number;
 }
 
 export function ConstellationCoverageMap({ hexes, minAttempts }: ConstellationCoverageMapProps) {
-  const config = useConfig();
-  const mapboxToken = config.mapboxToken ?? (import.meta.env.VITE_MAPBOX_TOKEN as string | undefined);
-  const mapStyle = useMapboxStyle();
   const [selectedHex, setSelectedHex] = useState<SmoothedHex | null>(null);
 
   const smoothedHexes: SmoothedHex[] = useMemo(
@@ -167,25 +80,48 @@ export function ConstellationCoverageMap({ hexes, minAttempts }: ConstellationCo
     }
   }, []);
 
-  if (!mapboxToken) {
-    return (
-      <div className="flex min-h-[400px] items-center justify-center rounded-md border bg-muted/30 text-muted-foreground">
-        Mapbox token required. Set VITE_MAPBOX_TOKEN (dev) or MAPBOX_TOKEN (Docker) in your environment.
-      </div>
-    );
-  }
-
   return (
-    <div className="relative h-full w-full" data-testid="constellation-coverage-map-container">
-      <Map
-        mapboxAccessToken={mapboxToken}
-        initialViewState={DEFAULT_CENTER}
-        mapStyle={mapStyle}
-        style={{ width: '100%', height: '100%' }}
-      >
-        <DeckGLOverlay interleaved={false} layers={layers} onClick={handleClick} />
-        <HexPopupOverlay hex={selectedHex} onClose={() => setSelectedHex(null)} />
-      </Map>
-    </div>
+    <DeckMapboxMap
+      layers={layers}
+      initialViewState={DEFAULT_CENTER}
+      onClick={handleClick}
+      data-testid="constellation-coverage-map-container"
+    >
+      {selectedHex && (
+        <Popup
+          longitude={selectedHex.centre_lng}
+          latitude={selectedHex.centre_lat}
+          anchor="bottom"
+          closeButton={false}
+          closeOnClick={false}
+          onClose={() => setSelectedHex(null)}
+          maxWidth="320px"
+          className="meshflow-map-popup"
+        >
+          <div className="relative min-w-[200px] rounded-md border border-slate-600 bg-slate-800 px-3 py-2 text-sm text-slate-100 shadow-lg">
+            <button
+              type="button"
+              onClick={() => setSelectedHex(null)}
+              className="absolute right-1 top-1 rounded p-0.5 text-slate-400 hover:bg-slate-700 hover:text-slate-200"
+              aria-label="Close"
+            >
+              <X className="h-3.5 w-3.5" aria-hidden />
+            </button>
+            <div className="pr-5">
+              <div className="font-mono text-xs text-slate-400">{selectedHex.h3_index}</div>
+              <div className="mt-1 text-xs">
+                {selectedHex.successes} / {selectedHex.attempts} (
+                {((selectedHex.attempts > 0 ? selectedHex.successes / selectedHex.attempts : 0) * 100).toFixed(0)}% raw)
+              </div>
+              <div className="text-xs">Smoothed: {(selectedHex.smoothed * 100).toFixed(0)}%</div>
+              <div className="mt-1 text-xs text-slate-400">
+                {selectedHex.contributing_feeders} feeder{selectedHex.contributing_feeders === 1 ? '' : 's'},{' '}
+                {selectedHex.contributing_targets} target{selectedHex.contributing_targets === 1 ? '' : 's'}
+              </div>
+            </div>
+          </div>
+        </Popup>
+      )}
+    </DeckMapboxMap>
   );
 }

--- a/src/components/traceroutes/FeederCoverageMap.tsx
+++ b/src/components/traceroutes/FeederCoverageMap.tsx
@@ -1,19 +1,16 @@
-import { useCallback, useEffect, useMemo, useState } from 'react';
-import { Map as MapboxMap, useControl, useMap } from 'react-map-gl';
-import { MapboxOverlay, type MapboxOverlayProps } from '@deck.gl/mapbox';
+import { useCallback, useMemo, useState } from 'react';
+import { Popup } from 'react-map-gl';
 import { PolygonLayer, ScatterplotLayer } from '@deck.gl/layers';
 import { H3HexagonLayer } from '@deck.gl/geo-layers';
 import type { Layer, PickingInfo } from '@deck.gl/core';
 import { latLngToCell } from 'h3-js';
 import { concave, featureCollection, point as turfPoint } from '@turf/turf';
 import type { Feature, MultiPolygon, Polygon } from 'geojson';
-import 'mapbox-gl/dist/mapbox-gl.css';
 
 import { Link } from 'react-router-dom';
 import { X } from 'lucide-react';
 
-import { useConfig } from '@/providers/ConfigProvider';
-import { useMapboxStyle } from '@/hooks/useMapboxStyle';
+import { DeckMapboxMap } from '@/components/map/DeckMapboxMap';
 import type { FeederReachFeeder, FeederReachTarget } from '@/lib/api/meshtastic-api';
 
 export type CoverageLayerKey = 'dots' | 'hex' | 'polygon';
@@ -32,7 +29,6 @@ function smoothedRate(successes: number, attempts: number): number {
 /** Map a smoothed reliability (0..1) to red→amber→green. */
 function reliabilityColor(rate: number, alpha = 220): [number, number, number, number] {
   const t = Math.max(0, Math.min(1, rate));
-  // 0.0=red(239,68,68), 0.7=amber(245,158,11), 0.9+=green(34,197,94)
   let r: number;
   let g: number;
   let b: number;
@@ -55,96 +51,8 @@ function attemptsToRadius(attempts: number): number {
   return Math.max(6, Math.min(30, 6 + Math.sqrt(attempts) * 3));
 }
 
-function DeckGLOverlay(props: MapboxOverlayProps) {
-  const overlay = useControl(() => new MapboxOverlay(props));
-  overlay.setProps(props);
-  return null;
-}
-
 function getTargetLabel(t: FeederReachTarget): string {
   return t.short_name || t.long_name || t.node_id_str || `!${t.node_id.toString(16)}`;
-}
-
-function TargetPopupOverlay({ target, onClose }: { target: FeederReachTarget | null; onClose: () => void }) {
-  const { current: mapRef } = useMap();
-  const [position, setPosition] = useState<{ x: number; y: number } | null>(null);
-
-  useEffect(() => {
-    if (!target || !mapRef) {
-      setPosition(null);
-      return;
-    }
-    const map = mapRef.getMap?.();
-    if (!map) return;
-
-    const updatePosition = () => {
-      try {
-        const point = mapRef.project([target.lng, target.lat]);
-        setPosition({ x: point.x, y: point.y });
-      } catch {
-        setPosition(null);
-      }
-    };
-
-    updatePosition();
-    map.on('move', updatePosition);
-    map.on('zoom', updatePosition);
-    return () => {
-      map.off('move', updatePosition);
-      map.off('zoom', updatePosition);
-    };
-  }, [mapRef, target]);
-
-  if (!target || !position) return null;
-
-  const rawRate = target.attempts > 0 ? target.successes / target.attempts : 0;
-  const smoothed = smoothedRate(target.successes, target.attempts);
-
-  return (
-    <div
-      className="pointer-events-none absolute inset-0 z-[10000]"
-      style={{ position: 'absolute' }}
-      data-testid="coverage-target-popup"
-    >
-      <div
-        className="pointer-events-auto min-w-[180px] rounded border border-slate-600 bg-slate-800 px-3 py-2 text-sm text-slate-100 shadow-lg"
-        style={{
-          position: 'absolute',
-          left: position.x,
-          top: position.y,
-          transform: 'translate(-50%, -100%)',
-          marginTop: -8,
-        }}
-      >
-        <button
-          type="button"
-          onClick={onClose}
-          className="absolute right-1 top-1 rounded p-0.5 text-slate-400 hover:bg-slate-700 hover:text-slate-200"
-          aria-label="Close"
-        >
-          <X className="h-3.5 w-3.5" aria-hidden />
-        </button>
-        <div className="pr-5">
-          <div className="font-semibold">
-            {target.long_name && target.short_name
-              ? `${target.long_name} (${target.short_name})`
-              : getTargetLabel(target)}
-          </div>
-          <div className="mt-0.5 text-xs text-slate-400">{target.node_id_str || `!${target.node_id.toString(16)}`}</div>
-          <div className="mt-1 text-xs">
-            {target.successes} / {target.attempts} ({(rawRate * 100).toFixed(0)}% raw)
-          </div>
-          <div className="text-xs">Smoothed: {(smoothed * 100).toFixed(0)}%</div>
-          <Link
-            to={`/nodes/${target.node_id}`}
-            className="mt-1 inline-block text-xs text-emerald-400 hover:text-emerald-300 hover:underline"
-          >
-            Open details
-          </Link>
-        </div>
-      </div>
-    </div>
-  );
 }
 
 interface HexBin {
@@ -162,9 +70,6 @@ export interface FeederCoverageMapProps {
 }
 
 export function FeederCoverageMap({ feeder, targets, enabledLayers, minAttempts }: FeederCoverageMapProps) {
-  const config = useConfig();
-  const mapboxToken = config.mapboxToken ?? (import.meta.env.VITE_MAPBOX_TOKEN as string | undefined);
-  const mapStyle = useMapboxStyle();
   const [selectedTarget, setSelectedTarget] = useState<FeederReachTarget | null>(null);
 
   const enabledSet = useMemo(() => new Set(enabledLayers), [enabledLayers]);
@@ -299,25 +204,62 @@ export function FeederCoverageMap({ feeder, targets, enabledLayers, minAttempts 
     return DEFAULT_CENTER;
   }, [feeder.lat, feeder.lng]);
 
-  if (!mapboxToken) {
-    return (
-      <div className="flex min-h-[400px] items-center justify-center rounded-md border bg-muted/30 text-muted-foreground">
-        Mapbox token required. Set VITE_MAPBOX_TOKEN (dev) or MAPBOX_TOKEN (Docker) in your environment.
-      </div>
-    );
-  }
-
   return (
-    <div className="relative h-full w-full" data-testid="feeder-coverage-map-container">
-      <MapboxMap
-        mapboxAccessToken={mapboxToken}
-        initialViewState={initialView}
-        mapStyle={mapStyle}
-        style={{ width: '100%', height: '100%' }}
-      >
-        <DeckGLOverlay interleaved={false} layers={layers} onClick={handleClick} />
-        <TargetPopupOverlay target={selectedTarget} onClose={() => setSelectedTarget(null)} />
-      </MapboxMap>
-    </div>
+    <DeckMapboxMap
+      layers={layers}
+      initialViewState={initialView}
+      onClick={handleClick}
+      data-testid="feeder-coverage-map-container"
+    >
+      {selectedTarget && (
+        <Popup
+          longitude={selectedTarget.lng}
+          latitude={selectedTarget.lat}
+          anchor="bottom"
+          closeButton={false}
+          closeOnClick={false}
+          onClose={() => setSelectedTarget(null)}
+          maxWidth="320px"
+          className="meshflow-map-popup"
+        >
+          <div className="relative min-w-[180px] rounded-md border border-slate-600 bg-slate-800 px-3 py-2 text-sm text-slate-100 shadow-lg">
+            <button
+              type="button"
+              onClick={() => setSelectedTarget(null)}
+              className="absolute right-1 top-1 rounded p-0.5 text-slate-400 hover:bg-slate-700 hover:text-slate-200"
+              aria-label="Close"
+            >
+              <X className="h-3.5 w-3.5" aria-hidden />
+            </button>
+            <div className="pr-5">
+              <div className="font-semibold">
+                {selectedTarget.long_name && selectedTarget.short_name
+                  ? `${selectedTarget.long_name} (${selectedTarget.short_name})`
+                  : getTargetLabel(selectedTarget)}
+              </div>
+              <div className="mt-0.5 text-xs text-slate-400">
+                {selectedTarget.node_id_str || `!${selectedTarget.node_id.toString(16)}`}
+              </div>
+              <div className="mt-1 text-xs">
+                {selectedTarget.successes} / {selectedTarget.attempts} (
+                {selectedTarget.attempts > 0
+                  ? ((selectedTarget.successes / selectedTarget.attempts) * 100).toFixed(0)
+                  : '0'}
+                % raw)
+              </div>
+              <div className="text-xs">
+                Smoothed: {(smoothedRate(selectedTarget.successes, selectedTarget.attempts) * 100).toFixed(0)}%
+              </div>
+              <Link
+                to={`/nodes/${selectedTarget.node_id}`}
+                className="mt-1 inline-block text-xs text-emerald-400 hover:text-emerald-300 hover:underline"
+              >
+                Open details
+              </Link>
+            </div>
+          </div>
+        </Popup>
+      )}
+    </DeckMapboxMap>
   );
 }

--- a/src/components/traceroutes/TracerouteHeatmapMap.test.tsx
+++ b/src/components/traceroutes/TracerouteHeatmapMap.test.tsx
@@ -1,0 +1,131 @@
+import { MemoryRouter } from 'react-router-dom';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { fireEvent, render, screen } from '@testing-library/react';
+
+import type { HeatmapEdge, HeatmapNode } from '@/hooks/api/useHeatmapEdges';
+import { TracerouteHeatmapMap } from './TracerouteHeatmapMap';
+
+/** Real <Popup> needs MapContext; test only needs layer stability, not mapbox popups. */
+vi.mock('react-map-gl', async (importOriginal) => {
+  const mod = await importOriginal<typeof import('react-map-gl')>();
+  return {
+    ...mod,
+    Popup: ({ children }: { children?: React.ReactNode }) => <div data-testid="popup-mock">{children}</div>,
+  };
+});
+
+vi.mock('@/providers/ConfigProvider', () => ({
+  useConfig: () => ({ mapboxToken: 'pk.test', apiUrl: '' }),
+}));
+
+type MockMapboxProps = {
+  layers: { id: string }[];
+  onClick?: (info: { object: unknown; layer: { id: string } }) => void;
+  children?: React.ReactNode;
+};
+
+const mapboxCaptures: MockMapboxProps[] = [];
+
+vi.mock('@/components/map/DeckMapboxMap', () => ({
+  DeckMapboxMap: (props: MockMapboxProps) => {
+    mapboxCaptures.push(props);
+    return (
+      <div data-testid="deck-mapbox-mock">
+        <button
+          type="button"
+          data-testid="mock-pick-node"
+          onClick={() =>
+            props.onClick?.({
+              object: nodeA,
+              layer: { id: 'heatmap-nodes' },
+            })
+          }
+        >
+          pick
+        </button>
+        {props.children}
+      </div>
+    );
+  },
+}));
+
+const nodeA: HeatmapNode = {
+  node_id: 0x11a,
+  node_id_str: '!0000011a',
+  short_name: 'A',
+  long_name: 'Node A',
+  lat: 55.9,
+  lng: -4.2,
+};
+
+const nodeB: HeatmapNode = {
+  node_id: 0x11b,
+  node_id_str: '!0000011b',
+  short_name: 'B',
+  long_name: 'Node B',
+  lat: 55.95,
+  lng: -4.15,
+};
+
+const edge: HeatmapEdge = {
+  from_node_id: nodeA.node_id,
+  to_node_id: nodeB.node_id,
+  from_lng: -4.2,
+  from_lat: 55.9,
+  to_lng: -4.15,
+  to_lat: 55.95,
+  weight: 5,
+  avg_snr: 4,
+};
+
+function layerIds(layers: { id: string }[]) {
+  return layers.map((l) => l.id);
+}
+
+function lastCapture() {
+  return mapboxCaptures[mapboxCaptures.length - 1];
+}
+
+describe('TracerouteHeatmapMap', () => {
+  beforeEach(() => {
+    mapboxCaptures.length = 0;
+  });
+
+  it('keeps arc layers after popup selection state (mock click / onClick)', () => {
+    render(
+      <MemoryRouter>
+        <TracerouteHeatmapMap edges={[edge]} nodes={[nodeA, nodeB]} edgeMetric="packets" />
+      </MemoryRouter>
+    );
+
+    expect(layerIds(lastCapture().layers)).toEqual(
+      expect.arrayContaining(['heatmap-arcs-packets', 'heatmap-nodes', 'heatmap-node-labels'])
+    );
+
+    fireEvent.click(screen.getByTestId('mock-pick-node'));
+
+    expect(layerIds(lastCapture().layers)).toEqual(
+      expect.arrayContaining(['heatmap-arcs-packets', 'heatmap-nodes', 'heatmap-node-labels'])
+    );
+  });
+
+  it('swaps arc layer id when edgeMetric changes but keeps node layers', () => {
+    const { rerender } = render(
+      <MemoryRouter>
+        <TracerouteHeatmapMap edges={[edge]} nodes={[nodeA, nodeB]} edgeMetric="packets" />
+      </MemoryRouter>
+    );
+
+    expect(lastCapture().layers.some((l) => l.id === 'heatmap-arcs-packets')).toBe(true);
+
+    rerender(
+      <MemoryRouter>
+        <TracerouteHeatmapMap edges={[edge]} nodes={[nodeA, nodeB]} edgeMetric="snr" />
+      </MemoryRouter>
+    );
+
+    expect(lastCapture().layers.some((l) => l.id === 'heatmap-arcs-snr')).toBe(true);
+    expect(lastCapture().layers.some((l) => l.id === 'heatmap-nodes')).toBe(true);
+    expect(lastCapture().layers.some((l) => l.id === 'heatmap-node-labels')).toBe(true);
+  });
+});

--- a/src/components/traceroutes/TracerouteHeatmapMap.tsx
+++ b/src/components/traceroutes/TracerouteHeatmapMap.tsx
@@ -1,14 +1,12 @@
-import { useMemo, useState, useCallback, useEffect } from 'react';
-import { Map, useControl, useMap } from 'react-map-gl';
-import { MapboxOverlay, MapboxOverlayProps } from '@deck.gl/mapbox';
+import { useMemo, useState, useCallback } from 'react';
+import { Popup } from 'react-map-gl';
 import { ArcLayer, ScatterplotLayer, TextLayer } from '@deck.gl/layers';
 import type { PickingInfo } from '@deck.gl/core';
-import 'mapbox-gl/dist/mapbox-gl.css';
 import { Link } from 'react-router-dom';
-import { useConfig } from '@/providers/ConfigProvider';
-import { useMapboxStyle } from '@/hooks/useMapboxStyle';
 import { X } from 'lucide-react';
 import type { HeatmapEdge, HeatmapNode } from '@/hooks/api/useHeatmapEdges';
+
+import { DeckMapboxMap } from '@/components/map/DeckMapboxMap';
 
 const DEFAULT_CENTER = { longitude: -4.2518, latitude: 55.8642, zoom: 8 };
 const NODE_COLOR: [number, number, number, number] = [134, 239, 172, 200]; // light green
@@ -37,12 +35,6 @@ function interpolateSnrColor(snr: number, minS: number, maxS: number): [number, 
   return [r, g, b, 200];
 }
 
-function DeckGLOverlay(props: MapboxOverlayProps) {
-  const overlay = useControl(() => new MapboxOverlay(props));
-  overlay.setProps(props);
-  return null;
-}
-
 export interface TracerouteHeatmapMapProps {
   edges: HeatmapEdge[];
   nodes: HeatmapNode[];
@@ -54,89 +46,12 @@ function getNodeLabel(node: HeatmapNode): string {
   return node.short_name || node.long_name || node.node_id_str || `!${node.node_id.toString(16)}`;
 }
 
-/** Custom popup overlay - avoids Mapbox Popup which can interfere with deck.gl layers */
-function NodePopupOverlay({ node, onClose }: { node: HeatmapNode | null; onClose: () => void }) {
-  const { current: mapRef } = useMap();
-  const [position, setPosition] = useState<{ x: number; y: number } | null>(null);
-
-  useEffect(() => {
-    if (!node || !mapRef) {
-      setPosition(null);
-      return;
-    }
-    const map = mapRef.getMap?.();
-    if (!map) return;
-
-    const updatePosition = () => {
-      try {
-        const point = mapRef.project([node.lng, node.lat]);
-        setPosition({ x: point.x, y: point.y });
-      } catch {
-        setPosition(null);
-      }
-    };
-
-    updatePosition();
-    map.on('move', updatePosition);
-    map.on('zoom', updatePosition);
-    return () => {
-      map.off('move', updatePosition);
-      map.off('zoom', updatePosition);
-    };
-  }, [mapRef, node?.lng, node?.lat, node]);
-
-  if (!node || !position) return null;
-
-  return (
-    <div
-      className="pointer-events-none absolute inset-0 z-[10000]"
-      style={{ position: 'absolute' }}
-      data-testid="node-popup"
-    >
-      <div
-        className="pointer-events-auto min-w-[120px] rounded border border-slate-600 bg-slate-800 px-3 py-2 text-sm text-slate-100 shadow-lg"
-        style={{
-          position: 'absolute',
-          left: position.x,
-          top: position.y,
-          transform: 'translate(-50%, -100%)',
-          marginTop: -8,
-        }}
-      >
-        <button
-          type="button"
-          onClick={onClose}
-          className="absolute right-1 top-1 rounded p-0.5 text-slate-400 hover:bg-slate-700 hover:text-slate-200"
-          aria-label="Close"
-        >
-          <X className="h-3.5 w-3.5" aria-hidden />
-        </button>
-        <div className="pr-5">
-          <div className="font-semibold">
-            {node.long_name && node.short_name ? `${node.long_name} (${node.short_name})` : getNodeLabel(node)}
-          </div>
-          <div className="mt-0.5 text-xs text-slate-400">{node.node_id_str || `!${node.node_id.toString(16)}`}</div>
-          <Link
-            to={`/nodes/${node.node_id}`}
-            className="mt-1 inline-block text-xs text-emerald-400 hover:text-emerald-300 hover:underline"
-          >
-            Open details
-          </Link>
-        </div>
-      </div>
-    </div>
-  );
-}
-
 export function TracerouteHeatmapMap({
   edges,
   nodes,
   intensity = 0.7,
   edgeMetric = 'packets',
 }: TracerouteHeatmapMapProps) {
-  const config = useConfig();
-  const mapboxToken = config.mapboxToken ?? (import.meta.env.VITE_MAPBOX_TOKEN as string | undefined);
-  const mapStyle = useMapboxStyle();
   const [selectedNode, setSelectedNode] = useState<HeatmapNode | null>(null);
 
   const handleClick = useCallback((info: PickingInfo) => {
@@ -222,25 +137,52 @@ export function TracerouteHeatmapMap({
     [arcLayer, scatterLayer, textLayer]
   );
 
-  if (!mapboxToken) {
-    return (
-      <div className="flex min-h-[400px] items-center justify-center rounded-md border bg-muted/30 text-muted-foreground">
-        Mapbox token required. Set VITE_MAPBOX_TOKEN (dev) or MAPBOX_TOKEN (Docker) in your environment.
-      </div>
-    );
-  }
-
   return (
-    <div className="relative h-full w-full" data-testid="heatmap-map-container">
-      <Map
-        mapboxAccessToken={mapboxToken}
-        initialViewState={DEFAULT_CENTER}
-        mapStyle={mapStyle}
-        style={{ width: '100%', height: '100%' }}
-      >
-        <DeckGLOverlay interleaved={false} layers={layers} onClick={handleClick} />
-        <NodePopupOverlay node={selectedNode} onClose={() => setSelectedNode(null)} />
-      </Map>
-    </div>
+    <DeckMapboxMap
+      layers={layers}
+      initialViewState={DEFAULT_CENTER}
+      onClick={handleClick}
+      data-testid="heatmap-map-container"
+    >
+      {selectedNode && (
+        <Popup
+          longitude={selectedNode.lng}
+          latitude={selectedNode.lat}
+          anchor="bottom"
+          closeButton={false}
+          closeOnClick={false}
+          onClose={() => setSelectedNode(null)}
+          maxWidth="320px"
+          className="meshflow-map-popup"
+        >
+          <div className="relative min-w-[120px] rounded-md border border-slate-600 bg-slate-800 px-3 py-2 text-sm text-slate-100 shadow-lg">
+            <button
+              type="button"
+              onClick={() => setSelectedNode(null)}
+              className="absolute right-1 top-1 rounded p-0.5 text-slate-400 hover:bg-slate-700 hover:text-slate-200"
+              aria-label="Close"
+            >
+              <X className="h-3.5 w-3.5" aria-hidden />
+            </button>
+            <div className="pr-5">
+              <div className="font-semibold">
+                {selectedNode.long_name && selectedNode.short_name
+                  ? `${selectedNode.long_name} (${selectedNode.short_name})`
+                  : getNodeLabel(selectedNode)}
+              </div>
+              <div className="mt-0.5 text-xs text-slate-400">
+                {selectedNode.node_id_str || `!${selectedNode.node_id.toString(16)}`}
+              </div>
+              <Link
+                to={`/nodes/${selectedNode.node_id}`}
+                className="mt-1 inline-block text-xs text-emerald-400 hover:text-emerald-300 hover:underline"
+              >
+                Open details
+              </Link>
+            </div>
+          </div>
+        </Popup>
+      )}
+    </DeckMapboxMap>
   );
 }

--- a/src/index.css
+++ b/src/index.css
@@ -98,3 +98,14 @@
 .traceroute-heatmap-popup .mapboxgl-popup-tip {
   border-top-color: rgb(30 41 59);
 }
+
+/* Mapbox GL Popup + deck.gl maps (TracerouteHeatmapMap, coverage maps, links map) */
+.meshflow-map-popup .mapboxgl-popup-content {
+  background: transparent;
+  padding: 0;
+  border: none;
+  box-shadow: none;
+}
+.meshflow-map-popup .mapboxgl-popup-tip {
+  border-top-color: rgb(30 41 59); /* slate-800 */
+}


### PR DESCRIPTION
## Summary

Replaces the fragile `MapboxOverlay` + `useControl` + render-time `setProps` pattern with a shared `DeckMapboxMap` built from `DeckGL` (from `deck.gl`) wrapping `react-map-gl` `Map` as a child, so React/deck own the WebGL overlay lifecycle.

Switches custom DOM popups (`project` + move listeners) to `react-map-gl` `Popup` for:

- Traceroute heatmap
- Node traceroute links
- Feeder coverage
- Constellation coverage

Removed direct `@deck.gl/mapbox` dependency from `package.json` (it may still appear transitively in the lockfile via `deck.gl`).

## Testing performed

- `npm run build`
- `npm test` (includes new `TracerouteHeatmapMap` regression tests for layer stability on mock-pick and for `edgeMetric` mode switch)
- `npm run format` / `npm run lint` (existing repo warnings only)

Manual: verify `/traceroutes/map/heat`, `/traceroutes/map/snr`, feeder coverage map, constellation coverage map, node traceroute links map — pan/zoom, click labels/markers for popup, arcs stay visible.

Closes #150
Closes #160