### PR TITLE
feat(traceroute): strategy UI and heatmap source/strategy filters

### DIFF
--- a/src/components/nodes/InfrastructureNodeCard.tsx
+++ b/src/components/nodes/InfrastructureNodeCard.tsx
@@ -1,7 +1,9 @@
 import { Link } from 'react-router-dom';
 import { formatDistanceToNow } from 'date-fns';
-import { DeviceMetrics, ObservedNode, NodeWatch, PaginatedResponse } from '@/lib/models';
+import { DeviceMetrics, ManagedNode, ObservedNode, NodeWatch, PaginatedResponse } from '@/lib/models';
 import { MeshWatchControls } from '@/components/nodes/MeshWatchControls';
+import { Tooltip, TooltipContent, TooltipProvider, TooltipTrigger } from '@/components/ui/tooltip';
+import { STRATEGY_META, type TracerouteStrategyValue } from '@/lib/traceroute-strategy';
 import type { UseQueryResult } from '@tanstack/react-query';
 import { getRoleLabel } from '@/lib/meshtastic';
 import { Badge } from '@/components/ui/badge';
@@ -22,6 +24,8 @@ interface InfrastructureNodeCardProps {
   watch?: NodeWatch;
   /** From useNodeWatches — loading/error for watch list */
   watchesQuery?: Pick<UseQueryResult<PaginatedResponse<NodeWatch>>, 'isLoading' | 'isError'>;
+  /** When this infrastructure node is a managed feeder, geo classification from the API */
+  managedNode?: ManagedNode | null;
 }
 
 function InfrastructureNodeCardInner({
@@ -31,6 +35,7 @@ function InfrastructureNodeCardInner({
   onCompareToggle,
   watch,
   watchesQuery,
+  managedNode,
 }: InfrastructureNodeCardProps) {
   const roleLabel = getRoleLabel(node.role);
   const [compareSelected, setCompareSelected] = useState(false);
@@ -80,6 +85,33 @@ function InfrastructureNodeCardInner({
       </div>
       <div className="flex-1 space-y-2">
         <p className="text-slate-600 dark:text-slate-400">ID: {node.node_id_str}</p>
+        {managedNode?.geo_classification && (
+          <div className="flex flex-wrap gap-1.5 py-1" data-testid="infra-feeder-geo">
+            <Badge variant="outline" className="text-xs font-normal">
+              {managedNode.geo_classification.tier === 'perimeter'
+                ? `Perimeter${
+                    managedNode.geo_classification.bearing_octant
+                      ? ` (${managedNode.geo_classification.bearing_octant})`
+                      : ''
+                  }`
+                : 'Internal feeder'}
+            </Badge>
+            <TooltipProvider delayDuration={200}>
+              {managedNode.geo_classification.applicable_strategies.map((s) => (
+                <Tooltip key={s}>
+                  <TooltipTrigger asChild>
+                    <Badge variant="secondary" className="text-xs cursor-help font-normal">
+                      {STRATEGY_META[s as TracerouteStrategyValue]?.label ?? s}
+                    </Badge>
+                  </TooltipTrigger>
+                  <TooltipContent side="top" className="max-w-xs text-xs">
+                    {STRATEGY_META[s as TracerouteStrategyValue]?.shortDescription ?? s}
+                  </TooltipContent>
+                </Tooltip>
+              ))}
+            </TooltipProvider>
+          </div>
+        )}
         {node.owner && <p className="text-slate-600 dark:text-slate-400">Owner: {node.owner.username}</p>}
         {node.latest_device_metrics && (
           <div className="flex flex-wrap gap-3 text-sm">

--- a/src/components/nodes/NodeDetailContent.tsx
+++ b/src/components/nodes/NodeDetailContent.tsx
@@ -24,6 +24,8 @@ import type { EnvironmentExposureSlug, LatestEnvironmentMetrics, WeatherUseSlug 
 import { NodeEnvironmentSettingsDialog } from '@/components/nodes/NodeEnvironmentSettingsDialog';
 import { NodeMeshMonitoringSection } from '@/components/nodes/NodeMeshMonitoringSection';
 import { NodeTracerouteHistorySection } from '@/components/nodes/NodeTracerouteHistorySection';
+import { Tooltip, TooltipContent, TooltipProvider, TooltipTrigger } from '@/components/ui/tooltip';
+import { STRATEGY_META, type TracerouteStrategyValue } from '@/lib/traceroute-strategy';
 
 interface NodeDetailContentProps {
   nodeId: number;
@@ -154,11 +156,13 @@ export function NodeDetailContent({ nodeId, compact = false }: NodeDetailContent
     navigator.clipboard.writeText(text);
   };
 
-  const { managedNodes } = useManagedNodesSuspense();
+  const { managedNodes } = useManagedNodesSuspense({ includeGeoClassification: true });
 
   const isManagedNode = useMemo(() => {
     return managedNodes.some((managedNode) => managedNode.node_id === nodeId);
   }, [managedNodes, nodeId]);
+
+  const managedForThisNode = useMemo(() => managedNodes.find((m) => m.node_id === nodeId), [managedNodes, nodeId]);
 
   useEffect(() => {
     if (node) {
@@ -245,6 +249,44 @@ export function NodeDetailContent({ nodeId, compact = false }: NodeDetailContent
               ))}
           </div>
         </div>
+      )}
+
+      {managedForThisNode?.geo_classification && (
+        <Card className="mb-6" data-testid="node-detail-feeder-geo">
+          <CardHeader>
+            <CardTitle>Traceroute feeder classification</CardTitle>
+            <CardDescription>
+              Geometry vs constellation envelope — drives which automated target strategies apply.
+            </CardDescription>
+          </CardHeader>
+          <CardContent>
+            <div className="flex flex-wrap gap-2 items-center">
+              <Badge variant="outline">
+                {managedForThisNode.geo_classification.tier === 'perimeter'
+                  ? `Perimeter${
+                      managedForThisNode.geo_classification.bearing_octant
+                        ? ` (${managedForThisNode.geo_classification.bearing_octant})`
+                        : ''
+                    }`
+                  : 'Internal'}
+              </Badge>
+              <TooltipProvider delayDuration={200}>
+                {managedForThisNode.geo_classification.applicable_strategies.map((s) => (
+                  <Tooltip key={s}>
+                    <TooltipTrigger asChild>
+                      <Badge variant="secondary" className="cursor-help">
+                        {STRATEGY_META[s as TracerouteStrategyValue]?.label ?? s}
+                      </Badge>
+                    </TooltipTrigger>
+                    <TooltipContent side="top" className="max-w-xs text-sm">
+                      {STRATEGY_META[s as TracerouteStrategyValue]?.shortDescription ?? s}
+                    </TooltipContent>
+                  </Tooltip>
+                ))}
+              </TooltipProvider>
+            </div>
+          </CardContent>
+        </Card>
       )}
 
       <div className={`grid grid-cols-1 ${compact ? 'gap-4' : 'md:grid-cols-2 gap-6'} mb-6`}>

--- a/src/components/nodes/NodeTracerouteHistorySection.test.tsx
+++ b/src/components/nodes/NodeTracerouteHistorySection.test.tsx
@@ -11,6 +11,10 @@ vi.mock('@/hooks/api/useTraceroutes', () => ({
   useTriggerTraceroute: vi.fn(),
 }));
 
+vi.mock('@/hooks/api/useNodes', () => ({
+  useManagedNodesSuspense: vi.fn(),
+}));
+
 vi.mock('@/pages/traceroutes/TracerouteDetailModal', () => ({
   TracerouteDetailModal: ({
     tracerouteId,
@@ -38,7 +42,11 @@ vi.mock('@/pages/traceroutes/TriggerTracerouteModal', () => ({
     mode: 'user' | 'auto';
     managedNodes: ManagedNode[];
     observedNodes: ObservedNode[];
-    onTrigger: (managedNodeId: number, targetNodeId?: number) => Promise<void>;
+    onTrigger: (
+      managedNodeId: number,
+      targetNodeId?: number,
+      targetStrategy?: 'intra_zone' | 'dx_across' | 'dx_same_side',
+    ) => Promise<void>;
     isSubmitting: boolean;
   }) =>
     open ? (
@@ -50,11 +58,13 @@ vi.mock('@/pages/traceroutes/TriggerTracerouteModal', () => ({
 
 import { useTraceroutesWithWebSocket } from '@/hooks/useTraceroutesWithWebSocket';
 import { useTracerouteTriggerableNodesSuspense, useTriggerTraceroute } from '@/hooks/api/useTraceroutes';
+import { useManagedNodesSuspense } from '@/hooks/api/useNodes';
 import { NodeTracerouteHistorySection } from './NodeTracerouteHistorySection';
 
 const mockedUseTraceroutesWithWebSocket = vi.mocked(useTraceroutesWithWebSocket);
 const mockedUseTriggerableNodes = vi.mocked(useTracerouteTriggerableNodesSuspense);
 const mockedUseTriggerTraceroute = vi.mocked(useTriggerTraceroute);
+const mockedUseManagedNodes = vi.mocked(useManagedNodesSuspense);
 
 function makeObservedNode(overrides: Partial<ObservedNode> = {}): ObservedNode {
   return {
@@ -114,6 +124,7 @@ interface UseTraceroutesReturn {
 function setupHooks(options: {
   traceroutes?: AutoTraceRoute[];
   triggerableNodes?: ManagedNode[];
+  managedNodes?: ManagedNode[];
   isLoading?: boolean;
   error?: Error | null;
   mutate?: ReturnType<typeof vi.fn>;
@@ -133,6 +144,13 @@ function setupHooks(options: {
     mutateAsync: vi.fn(),
     isPending: options.isPending ?? false,
   } as unknown as ReturnType<typeof useTriggerTraceroute>);
+  const managedList = options.managedNodes ?? options.triggerableNodes ?? [];
+  mockedUseManagedNodes.mockReturnValue({
+    managedNodes: managedList,
+    totalManagedNodes: managedList.length,
+    fetchNextPage: vi.fn(),
+    hasNextPage: false,
+  } as unknown as ReturnType<typeof useManagedNodesSuspense>);
 }
 
 function renderSection(observedNode: ObservedNode = makeObservedNode()) {
@@ -215,7 +233,7 @@ describe('NodeTracerouteHistorySection', () => {
     renderSection(observed);
     fireEvent.click(screen.getByRole('button', { name: /repeat traceroute/i }));
     expect(mutate).toHaveBeenCalledWith(
-      { managedNodeId: 777, targetNodeId: 888 },
+      expect.objectContaining({ managedNodeId: 777, targetNodeId: 888 }),
       expect.objectContaining({ onError: expect.any(Function) })
     );
   });

--- a/src/components/nodes/NodeTracerouteHistorySection.tsx
+++ b/src/components/nodes/NodeTracerouteHistorySection.tsx
@@ -1,4 +1,4 @@
-import { useState } from 'react';
+import { useState, useMemo } from 'react';
 import { format } from 'date-fns';
 import { Link } from 'react-router-dom';
 import { toast } from 'sonner';
@@ -13,6 +13,7 @@ import { TracerouteDetailModal } from '@/pages/traceroutes/TracerouteDetailModal
 import { TriggerTracerouteModal } from '@/pages/traceroutes/TriggerTracerouteModal';
 import { getTracerouteErrorMessage } from '@/pages/traceroutes/tracerouteErrors';
 import type { AutoTraceRoute, ObservedNode } from '@/lib/models';
+import { useManagedNodesSuspense } from '@/hooks/api/useNodes';
 
 const PAGE_SIZE = 10;
 
@@ -53,6 +54,20 @@ export function NodeTracerouteHistorySection({ nodeId, observedNode }: NodeTrace
     page_size: PAGE_SIZE,
   });
   const { triggerableNodes } = useTracerouteTriggerableNodesSuspense();
+  const { managedNodes } = useManagedNodesSuspense({
+    pageSize: 500,
+    includeStatus: true,
+    includeGeoClassification: true,
+  });
+  const managedByMeshId = useMemo(() => new Map(managedNodes.map((m) => [m.node_id, m])), [managedNodes]);
+  const modalManagedNodes = useMemo(
+    () =>
+      triggerableNodes.map((t) => {
+        const full = managedByMeshId.get(t.node_id);
+        return full ? { ...t, ...full } : t;
+      }),
+    [triggerableNodes, managedByMeshId]
+  );
   const canTrigger = triggerableNodes.length > 0;
   const triggerMutation = useTriggerTraceroute();
 
@@ -60,7 +75,16 @@ export function NodeTracerouteHistorySection({ nodeId, observedNode }: NodeTrace
 
   const handleRepeat = (tr: AutoTraceRoute) => {
     triggerMutation.mutate(
-      { managedNodeId: tr.source_node.node_id, targetNodeId: tr.target_node.node_id },
+      {
+        managedNodeId: tr.source_node.node_id,
+        targetNodeId: tr.target_node.node_id,
+        targetStrategy:
+          tr.target_strategy === 'intra_zone' ||
+          tr.target_strategy === 'dx_across' ||
+          tr.target_strategy === 'dx_same_side'
+            ? tr.target_strategy
+            : undefined,
+      },
       {
         onError: (err) => {
           toast.error('Traceroute failed', {
@@ -183,12 +207,12 @@ export function NodeTracerouteHistorySection({ nodeId, observedNode }: NodeTrace
         open={triggerModalOpen}
         onOpenChange={setTriggerModalOpen}
         mode="user"
-        managedNodes={triggerableNodes}
+        managedNodes={modalManagedNodes}
         observedNodes={[observedNode]}
         fixedTargetNode={observedNode}
-        onTrigger={async (managedNodeId, targetNodeId) => {
+        onTrigger={async (managedNodeId, targetNodeId, targetStrategy) => {
           try {
-            await triggerMutation.mutateAsync({ managedNodeId, targetNodeId });
+            await triggerMutation.mutateAsync({ managedNodeId, targetNodeId, targetStrategy });
             setTriggerModalOpen(false);
           } catch (err) {
             toast.error('Traceroute failed', {

--- a/src/components/traceroutes/StrategyBadge.test.tsx
+++ b/src/components/traceroutes/StrategyBadge.test.tsx
@@ -1,0 +1,15 @@
+import { describe, it, expect } from 'vitest';
+import { render, screen } from '@testing-library/react';
+import { StrategyBadge } from './StrategyBadge';
+
+describe('StrategyBadge', () => {
+  it('renders Legacy for null', () => {
+    render(<StrategyBadge value={null} />);
+    expect(screen.getByText('Legacy')).toBeInTheDocument();
+  });
+
+  it('renders intra-zone label', () => {
+    render(<StrategyBadge value="intra_zone" />);
+    expect(screen.getByText('Intra-zone')).toBeInTheDocument();
+  });
+});

--- a/src/components/traceroutes/StrategyBadge.tsx
+++ b/src/components/traceroutes/StrategyBadge.tsx
@@ -1,0 +1,32 @@
+import { Badge } from '@/components/ui/badge';
+import { Tooltip, TooltipContent, TooltipProvider, TooltipTrigger } from '@/components/ui/tooltip';
+import { STRATEGY_META, type TracerouteStrategyValue } from '@/lib/traceroute-strategy';
+
+export function StrategyBadge({
+  value,
+  className,
+}: {
+  /** API field; null / undefined renders Legacy */
+  value: TracerouteStrategyValue | string | null | undefined;
+  className?: string;
+}) {
+  const key: TracerouteStrategyValue = value == null || value === '' ? 'legacy' : (value as TracerouteStrategyValue);
+  const meta = STRATEGY_META[key] ?? STRATEGY_META.legacy;
+
+  return (
+    <TooltipProvider delayDuration={200}>
+      <Tooltip>
+        <TooltipTrigger asChild>
+          <span className="inline-flex">
+            <Badge variant={meta.badgeVariant} className={className}>
+              {meta.label}
+            </Badge>
+          </span>
+        </TooltipTrigger>
+        <TooltipContent side="top" className="max-w-xs">
+          <p className="text-xs">{meta.shortDescription}</p>
+        </TooltipContent>
+      </Tooltip>
+    </TooltipProvider>
+  );
+}

--- a/src/components/traceroutes/TracerouteStatsSection.tsx
+++ b/src/components/traceroutes/TracerouteStatsSection.tsx
@@ -9,6 +9,7 @@ import { Table, TableBody, TableCell, TableHead, TableHeader, TableRow } from '@
 import { Tooltip, TooltipContent, TooltipProvider, TooltipTrigger } from '@/components/ui/tooltip';
 import { HelpCircle } from 'lucide-react';
 import { useTracerouteStats } from '@/hooks/api/useTraceroutes';
+import { strategyLabel } from '@/lib/traceroute-strategy';
 
 const TR_STATS_TIMEFRAME_OPTIONS = [
   { key: '24h', label: '24 hours' },
@@ -59,6 +60,21 @@ export function TracerouteStatsSection() {
       fill: CHART_COLORS[idx % CHART_COLORS.length],
     }));
   }, [data?.sources]);
+
+  const strategyMixChartData = useMemo(() => {
+    const raw = data?.by_strategy;
+    if (!raw || typeof raw !== 'object') return [];
+    return Object.entries(raw)
+      .map(([key, counts], idx) => {
+        const total = counts.completed + counts.failed + counts.pending + counts.sent;
+        return {
+          name: strategyLabel(key),
+          value: total,
+          fill: CHART_COLORS[idx % CHART_COLORS.length],
+        };
+      })
+      .filter((d) => d.value > 0);
+  }, [data?.by_strategy]);
 
   const sentByNodeChartData = useMemo(() => {
     const rows = data?.by_source ?? [];
@@ -149,7 +165,7 @@ export function TracerouteStatsSection() {
         </Select>
       </div>
 
-      <div className="grid gap-4 md:grid-cols-2 lg:grid-cols-3">
+      <div className="grid gap-4 md:grid-cols-2 lg:grid-cols-4">
         {/* TR sources pie */}
         <Card>
           <CardHeader className="pb-2">
@@ -173,6 +189,44 @@ export function TracerouteStatsSection() {
                     label={({ name, percent }) => `${name} ${(percent * 100).toFixed(0)}%`}
                   >
                     {sourcesChartData.map((entry, idx) => (
+                      <Cell key={idx} fill={entry.fill} />
+                    ))}
+                  </Pie>
+                  <RechartsTooltip content={<ChartTooltipContent formatter={(v) => [v, '']} />} />
+                </PieChart>
+              </ChartContainer>
+            ) : (
+              <div className="h-[180px] flex items-center justify-center text-muted-foreground text-sm">No data</div>
+            )}
+          </CardContent>
+        </Card>
+
+        {/* Strategy mix */}
+        <Card data-testid="traceroute-strategy-mix-card">
+          <CardHeader className="pb-2">
+            <CardTitle className="text-sm">Strategy mix</CardTitle>
+            <CardDescription className="text-xs text-muted-foreground">
+              Share of runs by target selection hypothesis (scheduled + manual when recorded).
+            </CardDescription>
+          </CardHeader>
+          <CardContent>
+            {isLoading ? (
+              <div className="h-[180px] flex items-center justify-center text-muted-foreground text-sm">Loading…</div>
+            ) : strategyMixChartData.length > 0 ? (
+              <ChartContainer config={{}} className="aspect-auto h-[180px] w-full">
+                <PieChart>
+                  <Pie
+                    data={strategyMixChartData}
+                    dataKey="value"
+                    nameKey="name"
+                    cx="50%"
+                    cy="50%"
+                    innerRadius={40}
+                    outerRadius={65}
+                    paddingAngle={2}
+                    label={({ name, percent }) => `${name} ${(percent * 100).toFixed(0)}%`}
+                  >
+                    {strategyMixChartData.map((entry, idx) => (
                       <Cell key={idx} fill={entry.fill} />
                     ))}
                   </Pie>

--- a/src/hooks/api/useHeatmapEdges.ts
+++ b/src/hooks/api/useHeatmapEdges.ts
@@ -35,6 +35,10 @@ export interface UseHeatmapEdgesParams {
   constellationId?: number;
   bbox?: [number, number, number, number];
   edgeMetric?: 'packets' | 'snr';
+  /** Meshtastic node id of the feeder (matches API `source_node_id`) */
+  sourceNodeId?: number;
+  /** CSV of strategy tokens sent to API `target_strategy` */
+  targetStrategy?: string;
 }
 
 export function useHeatmapEdges(params?: UseHeatmapEdgesParams) {
@@ -49,6 +53,8 @@ export function useHeatmapEdges(params?: UseHeatmapEdgesParams) {
         constellationId: params?.constellationId,
         bbox: params?.bbox,
         edgeMetric: params?.edgeMetric,
+        sourceNodeId: params?.sourceNodeId,
+        targetStrategy: params?.targetStrategy,
       },
     ],
     placeholderData: keepPreviousData,
@@ -58,6 +64,8 @@ export function useHeatmapEdges(params?: UseHeatmapEdgesParams) {
         constellation_id: params?.constellationId,
         bbox: params?.bbox,
         edge_metric: params?.edgeMetric,
+        source_node_id: params?.sourceNodeId,
+        target_strategy: params?.targetStrategy,
       }),
   });
 }

--- a/src/hooks/api/useNodes.ts
+++ b/src/hooks/api/useNodes.ts
@@ -329,6 +329,7 @@ export interface UseInfrastructureNodesOptions {
 export interface UseManagedNodesSuspenseOptions {
   pageSize?: number;
   includeStatus?: boolean;
+  includeGeoClassification?: boolean;
 }
 
 /**
@@ -432,11 +433,19 @@ export function useManagedNodesSuspense(options?: UseManagedNodesSuspenseOptions
   const api = useMeshtasticApi();
   const pageSize = options?.pageSize ?? 500;
   const includeStatus = options?.includeStatus ?? false;
+  const includeGeoClassification = options?.includeGeoClassification ?? false;
+  const includeKey =
+    [includeStatus ? 'status' : '', includeGeoClassification ? 'geo' : ''].filter(Boolean).join('+') || 'base';
   const managedNodesQuery = useSuspenseInfiniteQuery<PaginatedResponse<ManagedNode>, Error>({
     refetchInterval: 1000 * 60, // 1 minute
-    queryKey: ['managed-nodes', pageSize, includeStatus ? 'status' : 'base'],
+    queryKey: ['managed-nodes', pageSize, includeKey],
     queryFn: async ({ pageParam = 1 }) =>
-      api.getManagedNodes({ page: pageParam as number, page_size: pageSize, includeStatus }),
+      api.getManagedNodes({
+        page: pageParam as number,
+        page_size: pageSize,
+        includeStatus,
+        includeGeoClassification,
+      }),
     initialPageParam: 1,
     getNextPageParam: (lastPage, allPages) => (lastPage.next ? allPages.length + 1 : undefined),
   });

--- a/src/hooks/api/useTraceroutes.ts
+++ b/src/hooks/api/useTraceroutes.ts
@@ -7,6 +7,8 @@ export interface UseTraceroutesParams {
   target_node?: number;
   status?: string;
   trigger_type?: string;
+  /** CSV of strategy tokens (intra_zone, dx_across, dx_same_side, legacy) */
+  target_strategy?: string;
   triggered_after?: string;
   triggered_before?: string;
   page?: number;
@@ -87,8 +89,15 @@ export function useTriggerTraceroute() {
   const api = useMeshtasticApi();
   const queryClient = useQueryClient();
   return useMutation({
-    mutationFn: ({ managedNodeId, targetNodeId }: { managedNodeId: number; targetNodeId?: number }) =>
-      api.triggerTraceroute(managedNodeId, targetNodeId),
+    mutationFn: ({
+      managedNodeId,
+      targetNodeId,
+      targetStrategy,
+    }: {
+      managedNodeId: number;
+      targetNodeId?: number;
+      targetStrategy?: 'intra_zone' | 'dx_across' | 'dx_same_side';
+    }) => api.triggerTraceroute(managedNodeId, targetNodeId, targetStrategy),
     onSuccess: () => {
       queryClient.invalidateQueries({ queryKey: ['traceroutes'] });
       queryClient.invalidateQueries({ queryKey: ['traceroutes', 'triggerable-nodes'] });

--- a/src/lib/api/meshtastic-api.ts
+++ b/src/lib/api/meshtastic-api.ts
@@ -373,12 +373,16 @@ export class MeshtasticApi extends BaseApi {
   async getManagedNodes(
     params?: PaginationParams & {
       includeStatus?: boolean;
+      includeGeoClassification?: boolean;
     }
   ): Promise<PaginatedResponse<ManagedNode>> {
     const searchParams = new URLSearchParams();
     if (params?.page) searchParams.append('page', params.page.toString());
     if (params?.page_size) searchParams.append('page_size', params.page_size.toString());
-    if (params?.includeStatus) searchParams.append('include', 'status');
+    const includes: string[] = [];
+    if (params?.includeStatus) includes.push('status');
+    if (params?.includeGeoClassification) includes.push('geo_classification');
+    if (includes.length) searchParams.set('include', includes.join(','));
     return this.get<PaginatedResponse<ManagedNode>>('/nodes/managed-nodes/', searchParams);
   }
 
@@ -673,6 +677,7 @@ export class MeshtasticApi extends BaseApi {
     target_node?: number;
     status?: string;
     trigger_type?: string;
+    target_strategy?: string;
     triggered_after?: string;
     triggered_before?: string;
     page?: number;
@@ -684,6 +689,7 @@ export class MeshtasticApi extends BaseApi {
     if (params?.target_node) searchParams.append('target_node', params.target_node.toString());
     if (params?.status) searchParams.append('status', params.status);
     if (params?.trigger_type) searchParams.append('trigger_type', params.trigger_type);
+    if (params?.target_strategy) searchParams.append('target_strategy', params.target_strategy);
     if (params?.triggered_after) searchParams.append('triggered_after', params.triggered_after);
     if (params?.triggered_before) searchParams.append('triggered_before', params.triggered_before);
     if (params?.page) searchParams.append('page', params.page.toString());
@@ -701,9 +707,18 @@ export class MeshtasticApi extends BaseApi {
   /**
    * Trigger a traceroute manually
    */
-  async triggerTraceroute(managedNodeId: number, targetNodeId?: number): Promise<AutoTraceRoute> {
-    const data: { managed_node_id: number; target_node_id?: number } = { managed_node_id: managedNodeId };
+  async triggerTraceroute(
+    managedNodeId: number,
+    targetNodeId?: number,
+    targetStrategy?: 'intra_zone' | 'dx_across' | 'dx_same_side'
+  ): Promise<AutoTraceRoute> {
+    const data: {
+      managed_node_id: number;
+      target_node_id?: number;
+      target_strategy?: 'intra_zone' | 'dx_across' | 'dx_same_side';
+    } = { managed_node_id: managedNodeId };
     if (targetNodeId != null) data.target_node_id = targetNodeId;
+    if (targetStrategy != null) data.target_strategy = targetStrategy;
     return this.post<AutoTraceRoute>('/traceroutes/trigger/', data);
   }
 
@@ -750,6 +765,7 @@ export class MeshtasticApi extends BaseApi {
       success_rate: number | null;
     }>;
     success_over_time: Array<{ date: string; completed: number; failed: number }>;
+    by_strategy: Record<string, { completed: number; failed: number; pending: number; sent: number }>;
   }> {
     const searchParams = new URLSearchParams();
     if (params?.triggered_at_after) {
@@ -766,6 +782,8 @@ export class MeshtasticApi extends BaseApi {
     constellation_id?: number;
     bbox?: [number, number, number, number];
     edge_metric?: 'packets' | 'snr';
+    source_node_id?: number;
+    target_strategy?: string;
   }): Promise<{
     edges: Array<{
       from_node_id: number;
@@ -802,6 +820,12 @@ export class MeshtasticApi extends BaseApi {
     }
     if (params?.edge_metric) {
       searchParams.append('edge_metric', params.edge_metric);
+    }
+    if (params?.source_node_id != null) {
+      searchParams.append('source_node_id', params.source_node_id.toString());
+    }
+    if (params?.target_strategy) {
+      searchParams.append('target_strategy', params.target_strategy);
     }
     return this.get('/traceroutes/heatmap-edges/', searchParams);
   }

--- a/src/lib/models.ts
+++ b/src/lib/models.ts
@@ -51,6 +51,13 @@ export interface ObservedNode {
   claim?: ObservedNodeClaimEmbedded | null;
 }
 
+/** Present when API is called with include=geo_classification */
+export interface GeoClassification {
+  tier: 'perimeter' | 'internal';
+  bearing_octant: 'N' | 'NE' | 'E' | 'SE' | 'S' | 'SW' | 'W' | 'NW' | null;
+  applicable_strategies: ('intra_zone' | 'dx_across' | 'dx_same_side')[];
+}
+
 // ManagedNode from Meshflow API v2
 export interface ManagedNode {
   node_id: number;
@@ -62,6 +69,7 @@ export interface ManagedNode {
   packets_last_hour?: number;
   packets_last_24h?: number;
   is_eligible_traceroute_source?: boolean;
+  geo_classification?: GeoClassification | null;
   node_id_str: string;
   owner: {
     id: number;
@@ -127,7 +135,9 @@ export interface AutoTraceRoute {
   id: number;
   source_node: ManagedNode;
   target_node: ObservedNode;
-  trigger_type: 'auto' | 'user';
+  trigger_type: 'auto' | 'user' | 'external' | 'monitor';
+  /** Hypothesis-driven selector; null means legacy / unspecified */
+  target_strategy?: 'intra_zone' | 'dx_across' | 'dx_same_side' | 'legacy' | null;
   triggered_by: number | null;
   triggered_by_username: string | null;
   trigger_source: string | null;

--- a/src/lib/traceroute-strategy.test.ts
+++ b/src/lib/traceroute-strategy.test.ts
@@ -1,0 +1,19 @@
+import { describe, it, expect } from 'vitest';
+import { applicableStrategiesFromGeo, strategyLabel } from '@/lib/traceroute-strategy';
+
+describe('traceroute-strategy', () => {
+  it('strategyLabel maps known keys and falls back', () => {
+    expect(strategyLabel(null)).toBe('Legacy');
+    expect(strategyLabel('dx_across')).toBe('DX across');
+    expect(strategyLabel('unknown_xyz')).toBe('unknown_xyz');
+  });
+
+  it('applicableStrategiesFromGeo filters invalid tokens', () => {
+    expect(
+      applicableStrategiesFromGeo({
+        applicable_strategies: ['intra_zone', 'bogus', 'dx_same_side'],
+      })
+    ).toEqual(['intra_zone', 'dx_same_side']);
+    expect(applicableStrategiesFromGeo(null)).toEqual([]);
+  });
+});

--- a/src/lib/traceroute-strategy.ts
+++ b/src/lib/traceroute-strategy.ts
@@ -1,0 +1,54 @@
+/** Target selection strategy (`AutoTraceRoute.target_strategy`). */
+
+export type TracerouteStrategyValue = 'intra_zone' | 'dx_across' | 'dx_same_side' | 'legacy';
+
+export const TRACEROUTE_STRATEGIES = [
+  'intra_zone',
+  'dx_across',
+  'dx_same_side',
+  'legacy',
+] as const satisfies readonly TracerouteStrategyValue[];
+
+export const STRATEGY_META: Record<
+  TracerouteStrategyValue,
+  { label: string; shortDescription: string; badgeVariant: 'default' | 'secondary' | 'outline' }
+> = {
+  intra_zone: {
+    label: 'Intra-zone',
+    shortDescription: 'Target inside the constellation envelope — tests intra-mesh continuity.',
+    badgeVariant: 'default',
+  },
+  dx_across: {
+    label: 'DX across',
+    shortDescription: 'Distant target on the opposite side of centroid — tests long paths across the zone.',
+    badgeVariant: 'secondary',
+  },
+  dx_same_side: {
+    label: 'DX same side',
+    shortDescription: 'Distant target outside the envelope on your side — tests outreach past the perimeter.',
+    badgeVariant: 'outline',
+  },
+  legacy: {
+    label: 'Legacy',
+    shortDescription: 'Recorded before strategy tracking or unspecified.',
+    badgeVariant: 'outline',
+  },
+};
+
+export function strategyLabel(value: TracerouteStrategyValue | string | null | undefined): string {
+  if (value == null || value === '') return STRATEGY_META.legacy.label;
+  const k = value as TracerouteStrategyValue;
+  return STRATEGY_META[k]?.label ?? String(value);
+}
+
+export function applicableStrategiesFromGeo(
+  geo:
+    | {
+        applicable_strategies?: string[];
+      }
+    | null
+    | undefined
+): TracerouteStrategyValue[] {
+  const raw = geo?.applicable_strategies ?? [];
+  return raw.filter((s): s is TracerouteStrategyValue => TRACEROUTE_STRATEGIES.includes(s as TracerouteStrategyValue));
+}

--- a/src/lib/utils.ts
+++ b/src/lib/utils.ts
@@ -49,3 +49,13 @@ export function formatUptimeSeconds(seconds: number): string {
 
   return parts.length > 0 ? parts.join(' ') : '0 seconds';
 }
+
+/**
+ * Wall-clock duration between two instants, using the same unit rules as {@link formatUptimeSeconds}
+ * (e.g. "1 minute 30 seconds").
+ */
+export function formatElapsedBetween(start: Date, end: Date): string {
+  const ms = end.getTime() - start.getTime();
+  if (!Number.isFinite(ms) || ms < 0) return '—';
+  return formatUptimeSeconds(Math.floor(ms / 1000));
+}

--- a/src/pages/nodes/MeshInfrastructure.tsx
+++ b/src/pages/nodes/MeshInfrastructure.tsx
@@ -108,7 +108,8 @@ function MeshInfrastructureContent() {
     return m;
   }, [watchesQuery.data]);
 
-  const { managedNodes } = useManagedNodesSuspense({ pageSize: 500 });
+  const { managedNodes } = useManagedNodesSuspense({ pageSize: 500, includeGeoClassification: true });
+  const managedByMeshId = useMemo(() => new Map(managedNodes.map((m) => [m.node_id, m])), [managedNodes]);
 
   const { metricsMap } = useMultiNodeMetricsSuspense(nodes, chartDateRange);
 
@@ -343,6 +344,7 @@ function MeshInfrastructureContent() {
             <InfrastructureNodeCard
               key={node.internal_id}
               node={node}
+              managedNode={managedByMeshId.get(node.node_id)}
               metrics={metricsMap[node.node_id] ?? []}
               dateRange={chartDateRange}
               onCompareToggle={handleCompareToggle}

--- a/src/pages/traceroutes/TracerouteHeatmapPage.test.tsx
+++ b/src/pages/traceroutes/TracerouteHeatmapPage.test.tsx
@@ -1,0 +1,77 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { render, screen } from '@testing-library/react';
+import { MemoryRouter } from 'react-router-dom';
+import { TracerouteHeatmapPage } from './TracerouteHeatmapPage';
+
+vi.mock('@/hooks/api/useHeatmapEdges', () => ({
+  useHeatmapEdges: vi.fn(),
+}));
+
+vi.mock('@/hooks/api/useNodes', () => ({
+  useManagedNodesSuspense: vi.fn(),
+}));
+
+vi.mock('@/components/traceroutes/TracerouteHeatmapMap', () => ({
+  TracerouteHeatmapMap: () => <div data-testid="heatmap-map-stub" />,
+}));
+
+import { useHeatmapEdges } from '@/hooks/api/useHeatmapEdges';
+import { useManagedNodesSuspense } from '@/hooks/api/useNodes';
+
+const mockUseHeatmap = vi.mocked(useHeatmapEdges);
+const mockUseManaged = vi.mocked(useManagedNodesSuspense);
+
+describe('TracerouteHeatmapPage URL → API', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockUseManaged.mockReturnValue({
+      managedNodes: [
+        {
+          node_id: 99,
+          short_name: 'Feed',
+          node_id_str: '!00000063',
+          long_name: null,
+          last_heard: null,
+          owner: { id: 1, username: 'x' },
+          constellation: { id: 1 },
+          position: { latitude: null, longitude: null },
+        },
+      ],
+      totalManagedNodes: 1,
+      fetchNextPage: vi.fn(),
+      hasNextPage: false,
+    } as unknown as ReturnType<typeof useManagedNodesSuspense>);
+    mockUseHeatmap.mockReturnValue({
+      data: {
+        edges: [],
+        nodes: [],
+        meta: { active_nodes_count: 0, total_trace_routes_count: 0 },
+      },
+      isLoading: false,
+      error: null,
+    } as unknown as ReturnType<typeof useHeatmapEdges>);
+  });
+
+  function renderPage(path: string) {
+    render(
+      <MemoryRouter initialEntries={[path]}>
+        <TracerouteHeatmapPage edgeMetric="packets" />
+      </MemoryRouter>
+    );
+  }
+
+  it('passes strategy CSV and source mesh id from search params to useHeatmapEdges', () => {
+    renderPage('/traceroutes/map/heat?strategy=dx_across,intra_zone&source=99');
+    expect(mockUseHeatmap).toHaveBeenCalledWith(
+      expect.objectContaining({
+        targetStrategy: 'dx_across,intra_zone',
+        sourceNodeId: 99,
+      })
+    );
+  });
+
+  it('renders source selector for URL round-trip', () => {
+    renderPage('/traceroutes/map/heat?source=99');
+    expect(screen.getByTestId('heatmap-source-select')).toBeInTheDocument();
+  });
+});

--- a/src/pages/traceroutes/TracerouteHeatmapPage.tsx
+++ b/src/pages/traceroutes/TracerouteHeatmapPage.tsx
@@ -1,15 +1,70 @@
-import { useState, useMemo } from 'react';
-import { Link } from 'react-router-dom';
+import { useState, useMemo, useCallback } from 'react';
+import { Link, useSearchParams } from 'react-router-dom';
 import { subHours, subDays } from 'date-fns';
 import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card';
 import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from '@/components/ui/select';
+import { Button } from '@/components/ui/button';
+import {
+  DropdownMenu,
+  DropdownMenuCheckboxItem,
+  DropdownMenuContent,
+  DropdownMenuLabel,
+  DropdownMenuSeparator,
+  DropdownMenuTrigger,
+} from '@/components/ui/dropdown-menu';
 import { useHeatmapEdges } from '@/hooks/api/useHeatmapEdges';
+import { useManagedNodesSuspense } from '@/hooks/api/useNodes';
 import { TracerouteHeatmapMap } from '@/components/traceroutes/TracerouteHeatmapMap';
-import { RouteIcon } from 'lucide-react';
+import { RouteIcon, ChevronDown, X } from 'lucide-react';
 import { cn } from '@/lib/utils';
+import { TRACEROUTE_STRATEGIES, type TracerouteStrategyValue } from '@/lib/traceroute-strategy';
 
 type TimeRange = '24h' | '7d' | '30d' | 'custom';
 export type EdgeMetric = 'packets' | 'snr';
+
+function parseCsvParam<T extends string>(raw: string | null): T[] {
+  if (!raw) return [];
+  return raw
+    .split(',')
+    .map((s) => s.trim())
+    .filter(Boolean) as T[];
+}
+
+function parseSourceParam(raw: string | null): number | null {
+  if (!raw) return null;
+  const n = parseInt(raw, 10);
+  return Number.isFinite(n) ? n : null;
+}
+
+const HEATMAP_STRATEGY_OPTIONS: Array<{ value: TracerouteStrategyValue; label: string }> = TRACEROUTE_STRATEGIES.filter(
+  (v) => v !== 'legacy'
+).map((value) => ({
+  value,
+  label:
+    value === 'intra_zone'
+      ? 'Intra-zone'
+      : value === 'dx_across'
+        ? 'DX across'
+        : value === 'dx_same_side'
+          ? 'DX same side'
+          : value,
+}));
+
+function multiSelectLabel<T extends string>(
+  values: T[],
+  options: Array<{ value: T; label: string }>,
+  fallback: string
+): string {
+  if (values.length === 0) return fallback;
+  if (values.length === 1) {
+    return options.find((o) => o.value === values[0])?.label ?? values[0];
+  }
+  return `${fallback} (${values.length})`;
+}
+
+function toggleValue<T extends string>(current: T[], value: T): T[] {
+  return current.includes(value) ? current.filter((v) => v !== value) : [...current, value];
+}
 
 function NetworkStatsCard({
   meta,
@@ -56,7 +111,23 @@ function NetworkStatsCard({
 }
 
 export function TracerouteHeatmapPage({ edgeMetric }: { edgeMetric: EdgeMetric }) {
+  const [searchParams, setSearchParams] = useSearchParams();
   const [timeRange, setTimeRange] = useState<TimeRange>('7d');
+
+  const strategyTokens = parseCsvParam<TracerouteStrategyValue>(searchParams.get('strategy'));
+  const sourceMeshId = parseSourceParam(searchParams.get('source'));
+
+  const updateParams = useCallback(
+    (patch: Record<string, string | null>) => {
+      const next = new URLSearchParams(searchParams);
+      for (const [key, value] of Object.entries(patch)) {
+        if (value == null || value === '') next.delete(key);
+        else next.set(key, value);
+      }
+      setSearchParams(next, { replace: true });
+    },
+    [searchParams, setSearchParams]
+  );
 
   const triggeredAtAfter = useMemo(() => {
     if (timeRange === '24h') return subHours(new Date(), 24);
@@ -65,14 +136,20 @@ export function TracerouteHeatmapPage({ edgeMetric }: { edgeMetric: EdgeMetric }
     return undefined; // Custom would open a date picker
   }, [timeRange]);
 
+  const { managedNodes } = useManagedNodesSuspense({ pageSize: 500 });
+
   const { data, isLoading, error } = useHeatmapEdges({
     triggeredAtAfter,
     edgeMetric,
+    sourceNodeId: sourceMeshId ?? undefined,
+    targetStrategy: strategyTokens.length ? strategyTokens.join(',') : undefined,
   });
 
   const edges = data?.edges ?? [];
   const nodes = data?.nodes ?? [];
   const meta = data?.meta ?? { active_nodes_count: 0, total_trace_routes_count: 0 };
+
+  const hasGeoFilters = strategyTokens.length > 0 || sourceMeshId != null;
 
   return (
     <div className="flex min-h-[50vh] flex-col gap-4 px-4 py-4 md:px-6 md:py-6">
@@ -120,6 +197,63 @@ export function TracerouteHeatmapPage({ edgeMetric }: { edgeMetric: EdgeMetric }
               </SelectContent>
             </Select>
           </div>
+
+          <Select
+            value={sourceMeshId != null ? String(sourceMeshId) : 'all'}
+            onValueChange={(v) => updateParams({ source: v === 'all' ? null : v })}
+          >
+            <SelectTrigger className="w-full sm:w-[200px]" data-testid="heatmap-source-select">
+              <SelectValue placeholder="Source feeder" />
+            </SelectTrigger>
+            <SelectContent>
+              <SelectItem value="all">All sources</SelectItem>
+              {managedNodes.map((n) => (
+                <SelectItem key={n.node_id} value={String(n.node_id)}>
+                  {n.short_name ?? n.node_id_str ?? String(n.node_id)}
+                </SelectItem>
+              ))}
+            </SelectContent>
+          </Select>
+
+          <DropdownMenu>
+            <DropdownMenuTrigger asChild>
+              <Button variant="outline" size="sm" className="w-full sm:w-[180px] justify-between" type="button">
+                {multiSelectLabel(strategyTokens, HEATMAP_STRATEGY_OPTIONS, 'Strategy')}
+                <ChevronDown className="h-4 w-4 opacity-50" />
+              </Button>
+            </DropdownMenuTrigger>
+            <DropdownMenuContent align="start">
+              <DropdownMenuLabel>Strategy</DropdownMenuLabel>
+              <DropdownMenuSeparator />
+              {HEATMAP_STRATEGY_OPTIONS.map((opt) => (
+                <DropdownMenuCheckboxItem
+                  key={opt.value}
+                  checked={strategyTokens.includes(opt.value)}
+                  onCheckedChange={() =>
+                    updateParams({
+                      strategy: toggleValue(strategyTokens, opt.value).join(',') || null,
+                    })
+                  }
+                  onSelect={(e) => e.preventDefault()}
+                >
+                  {opt.label}
+                </DropdownMenuCheckboxItem>
+              ))}
+            </DropdownMenuContent>
+          </DropdownMenu>
+
+          {hasGeoFilters && (
+            <Button
+              variant="ghost"
+              size="sm"
+              type="button"
+              onClick={() => updateParams({ strategy: null, source: null })}
+              data-testid="heatmap-clear-geo-filters"
+            >
+              <X className="mr-1 h-4 w-4" />
+              Clear geo filters
+            </Button>
+          )}
         </div>
       </div>
 

--- a/src/pages/traceroutes/TracerouteHistory.test.tsx
+++ b/src/pages/traceroutes/TracerouteHistory.test.tsx
@@ -12,6 +12,7 @@ vi.mock('@/hooks/api/useTraceroutes', () => ({
 }));
 vi.mock('@/hooks/api/useNodes', () => ({
   useNodesSuspense: vi.fn(),
+  useManagedNodesSuspense: vi.fn(),
 }));
 
 vi.mock('@/components/traceroutes/TracerouteStatsSection', () => ({
@@ -30,13 +31,14 @@ vi.mock('@/pages/traceroutes/TriggerTracerouteModal', () => ({
 
 import { useTraceroutesInfiniteWithWebSocket } from '@/hooks/useTraceroutesWithWebSocket';
 import { useTracerouteTriggerableNodesSuspense, useTriggerTraceroute } from '@/hooks/api/useTraceroutes';
-import { useNodesSuspense } from '@/hooks/api/useNodes';
+import { useNodesSuspense, useManagedNodesSuspense } from '@/hooks/api/useNodes';
 import { TracerouteHistory } from './TracerouteHistory';
 
 const mockedUseInfinite = vi.mocked(useTraceroutesInfiniteWithWebSocket);
 const mockedUseTriggerable = vi.mocked(useTracerouteTriggerableNodesSuspense);
 const mockedUseTrigger = vi.mocked(useTriggerTraceroute);
 const mockedUseNodes = vi.mocked(useNodesSuspense);
+const mockedUseManagedNodes = vi.mocked(useManagedNodesSuspense);
 
 function makeManagedNode(overrides: Partial<ManagedNode> = {}): ManagedNode {
   return {
@@ -130,6 +132,9 @@ function setupHooks(
     nodes: observed,
     totalCount: observed.length,
   } as unknown as ReturnType<typeof useNodesSuspense>);
+  mockedUseManagedNodes.mockReturnValue({
+    managedNodes: triggerable,
+  } as unknown as ReturnType<typeof useManagedNodesSuspense>);
   return { fetchNextPage };
 }
 
@@ -167,6 +172,14 @@ describe('TracerouteHistory', () => {
     renderAt('/traceroutes?trigger_type=user,monitor');
     expect(mockedUseInfinite).toHaveBeenCalledWith(
       expect.objectContaining({ trigger_type: 'user,monitor' })
+    );
+  });
+
+  it('hydrates strategy CSV from the URL into target_strategy', () => {
+    setupHooks();
+    renderAt('/traceroutes?strategy=intra_zone,dx_across');
+    expect(mockedUseInfinite).toHaveBeenCalledWith(
+      expect.objectContaining({ target_strategy: 'intra_zone,dx_across' })
     );
   });
 

--- a/src/pages/traceroutes/TracerouteHistory.tsx
+++ b/src/pages/traceroutes/TracerouteHistory.tsx
@@ -25,6 +25,7 @@ import { getTracerouteErrorMessage } from './tracerouteErrors';
 import { TracerouteStatsSection } from '@/components/traceroutes/TracerouteStatsSection';
 import { StrategyBadge } from '@/components/traceroutes/StrategyBadge';
 import { AutoTraceRoute, ObservedNode } from '@/lib/models';
+import { formatElapsedBetween } from '@/lib/utils';
 import { TRACEROUTE_STRATEGIES, type TracerouteStrategyValue } from '@/lib/traceroute-strategy';
 import { ChevronDown, RotateCw, RouteIcon, X } from 'lucide-react';
 
@@ -96,6 +97,12 @@ function parseNumberParam(raw: string | null): number | null {
   if (!raw) return null;
   const n = parseInt(raw, 10);
   return Number.isFinite(n) ? n : null;
+}
+
+function completedElapsedDisplay(tr: AutoTraceRoute): string {
+  if (tr.status === 'failed') return '—';
+  if (!tr.triggered_at || !tr.completed_at) return '—';
+  return formatElapsedBetween(new Date(tr.triggered_at), new Date(tr.completed_at));
 }
 
 function multiSelectLabel<T extends string>(
@@ -385,7 +392,7 @@ export function TracerouteHistory() {
                     <TableHead>Status</TableHead>
                     <TableHead>Route</TableHead>
                     <TableHead>Triggered</TableHead>
-                    <TableHead>Completed</TableHead>
+                    <TableHead title="Time from triggered to completion (successful runs only)">Elapsed</TableHead>
                     {canTrigger && <TableHead className="w-12"></TableHead>}
                   </TableRow>
                 </TableHeader>
@@ -410,7 +417,15 @@ export function TracerouteHistory() {
                         {routeSummary(tr)}
                       </TableCell>
                       <TableCell>{tr.triggered_at ? format(new Date(tr.triggered_at), 'PPp') : '—'}</TableCell>
-                      <TableCell>{tr.completed_at ? format(new Date(tr.completed_at), 'PPp') : '—'}</TableCell>
+                      <TableCell
+                        title={
+                          tr.status !== 'failed' && tr.completed_at
+                            ? format(new Date(tr.completed_at), 'PPp')
+                            : undefined
+                        }
+                      >
+                        {completedElapsedDisplay(tr)}
+                      </TableCell>
                       {canTrigger && (
                         <TableCell onClick={(e) => e.stopPropagation()}>
                           {triggerableNodes.some((n) => n.node_id === tr.source_node.node_id) ? (

--- a/src/pages/traceroutes/TracerouteHistory.tsx
+++ b/src/pages/traceroutes/TracerouteHistory.tsx
@@ -18,12 +18,14 @@ import {
 import { toast } from 'sonner';
 import { useTraceroutesInfiniteWithWebSocket } from '@/hooks/useTraceroutesWithWebSocket';
 import { useTracerouteTriggerableNodesSuspense, useTriggerTraceroute } from '@/hooks/api/useTraceroutes';
-import { useNodesSuspense } from '@/hooks/api/useNodes';
+import { useManagedNodesSuspense, useNodesSuspense } from '@/hooks/api/useNodes';
 import { TriggerTracerouteModal, TriggerMode } from './TriggerTracerouteModal';
 import { TracerouteDetailModal } from './TracerouteDetailModal';
 import { getTracerouteErrorMessage } from './tracerouteErrors';
 import { TracerouteStatsSection } from '@/components/traceroutes/TracerouteStatsSection';
+import { StrategyBadge } from '@/components/traceroutes/StrategyBadge';
 import { AutoTraceRoute, ObservedNode } from '@/lib/models';
+import { TRACEROUTE_STRATEGIES, type TracerouteStrategyValue } from '@/lib/traceroute-strategy';
 import { ChevronDown, RotateCw, RouteIcon, X } from 'lucide-react';
 
 type StatusValue = 'completed' | 'failed' | 'pending' | 'sent';
@@ -42,6 +44,20 @@ const TRIGGER_TYPE_OPTIONS: Array<{ value: TriggerTypeValue; label: string }> = 
   { value: 'external', label: 'External' },
   { value: 'monitor', label: 'Monitor' },
 ];
+
+const STRATEGY_FILTER_OPTIONS: Array<{ value: TracerouteStrategyValue; label: string }> = TRACEROUTE_STRATEGIES.map(
+  (value) => ({
+    value,
+    label:
+      value === 'intra_zone'
+        ? 'Intra-zone'
+        : value === 'dx_across'
+          ? 'DX across'
+          : value === 'dx_same_side'
+            ? 'DX same side'
+            : 'Legacy',
+  })
+);
 
 function routeSummary(tr: AutoTraceRoute): string {
   const route = tr.route;
@@ -102,6 +118,7 @@ export function TracerouteHistory() {
   const targetNodeId = parseNumberParam(searchParams.get('target_node'));
   const statusValues = parseCsvParam<StatusValue>(searchParams.get('status'));
   const triggerTypeValues = parseCsvParam<TriggerTypeValue>(searchParams.get('trigger_type'));
+  const strategyValues = parseCsvParam<TracerouteStrategyValue>(searchParams.get('strategy'));
 
   const updateParams = (patch: Record<string, string | null>) => {
     const next = new URLSearchParams(searchParams);
@@ -120,12 +137,18 @@ export function TracerouteHistory() {
   const setStatusValues = (values: StatusValue[]) => updateParams({ status: values.length ? values.join(',') : null });
   const setTriggerTypeValues = (values: TriggerTypeValue[]) =>
     updateParams({ trigger_type: values.length ? values.join(',') : null });
+  const setStrategyValues = (values: TracerouteStrategyValue[]) =>
+    updateParams({ strategy: values.length ? values.join(',') : null });
 
   const toggleValue = <T extends string>(current: T[], value: T): T[] =>
     current.includes(value) ? current.filter((v) => v !== value) : [...current, value];
 
   const hasAnyFilter =
-    sourceNodeId != null || targetNodeId != null || statusValues.length > 0 || triggerTypeValues.length > 0;
+    sourceNodeId != null ||
+    targetNodeId != null ||
+    statusValues.length > 0 ||
+    triggerTypeValues.length > 0 ||
+    strategyValues.length > 0;
 
   const clearFilters = () => {
     const next = new URLSearchParams(searchParams);
@@ -133,6 +156,7 @@ export function TracerouteHistory() {
     next.delete('target_node');
     next.delete('status');
     next.delete('trigger_type');
+    next.delete('strategy');
     setSearchParams(next, { replace: true });
   };
 
@@ -153,6 +177,7 @@ export function TracerouteHistory() {
     target_node: targetNodeId ?? undefined,
     status: statusValues.length ? statusValues.join(',') : undefined,
     trigger_type: triggerTypeValues.length ? triggerTypeValues.join(',') : undefined,
+    target_strategy: strategyValues.length ? strategyValues.join(',') : undefined,
     page_size: 50,
   };
 
@@ -160,6 +185,20 @@ export function TracerouteHistory() {
     useTraceroutesInfiniteWithWebSocket(queryParams);
 
   const { triggerableNodes } = useTracerouteTriggerableNodesSuspense();
+  const { managedNodes } = useManagedNodesSuspense({
+    pageSize: 500,
+    includeStatus: true,
+    includeGeoClassification: true,
+  });
+  const managedByMeshId = useMemo(() => new Map(managedNodes.map((m) => [m.node_id, m])), [managedNodes]);
+  const modalManagedNodes = useMemo(
+    () =>
+      triggerableNodes.map((t) => {
+        const full = managedByMeshId.get(t.node_id);
+        return full ? { ...t, ...full } : t;
+      }),
+    [triggerableNodes, managedByMeshId]
+  );
   const canTrigger = triggerableNodes.length > 0;
   const { nodes: observedNodes } = useNodesSuspense({
     lastHeardAfter: subDays(new Date(), 7),
@@ -265,6 +304,29 @@ export function TracerouteHistory() {
               </DropdownMenuContent>
             </DropdownMenu>
 
+            <DropdownMenu>
+              <DropdownMenuTrigger asChild>
+                <Button variant="outline" size="sm" className="w-[180px] justify-between">
+                  {multiSelectLabel(strategyValues, STRATEGY_FILTER_OPTIONS, 'Strategy')}
+                  <ChevronDown className="h-4 w-4 opacity-50" />
+                </Button>
+              </DropdownMenuTrigger>
+              <DropdownMenuContent align="start">
+                <DropdownMenuLabel>Strategy</DropdownMenuLabel>
+                <DropdownMenuSeparator />
+                {STRATEGY_FILTER_OPTIONS.map((opt) => (
+                  <DropdownMenuCheckboxItem
+                    key={opt.value}
+                    checked={strategyValues.includes(opt.value)}
+                    onCheckedChange={() => setStrategyValues(toggleValue(strategyValues, opt.value))}
+                    onSelect={(e) => e.preventDefault()}
+                  >
+                    {opt.label}
+                  </DropdownMenuCheckboxItem>
+                ))}
+              </DropdownMenuContent>
+            </DropdownMenu>
+
             {hasAnyFilter && (
               <Button variant="ghost" size="sm" onClick={clearFilters} title="Clear all filters">
                 <X className="mr-1 h-4 w-4" />
@@ -318,6 +380,7 @@ export function TracerouteHistory() {
                     <TableHead>Source</TableHead>
                     <TableHead>Target</TableHead>
                     <TableHead>Type</TableHead>
+                    <TableHead>Strategy</TableHead>
                     <TableHead>Triggered by</TableHead>
                     <TableHead>Status</TableHead>
                     <TableHead>Route</TableHead>
@@ -336,6 +399,9 @@ export function TracerouteHistory() {
                       <TableCell>{tr.source_node?.short_name ?? tr.source_node?.node_id_str ?? '—'}</TableCell>
                       <TableCell>{tr.target_node?.short_name ?? tr.target_node?.node_id_str ?? '—'}</TableCell>
                       <TableCell>{tr.trigger_type}</TableCell>
+                      <TableCell>
+                        <StrategyBadge value={tr.target_strategy} />
+                      </TableCell>
                       <TableCell>{tr.triggered_by_username ?? '—'}</TableCell>
                       <TableCell>
                         <StatusBadge status={tr.status} />
@@ -357,6 +423,12 @@ export function TracerouteHistory() {
                                   {
                                     managedNodeId: tr.source_node.node_id,
                                     targetNodeId: tr.target_node.node_id,
+                                    targetStrategy:
+                                      tr.target_strategy === 'intra_zone' ||
+                                      tr.target_strategy === 'dx_across' ||
+                                      tr.target_strategy === 'dx_same_side'
+                                        ? tr.target_strategy
+                                        : undefined,
                                   },
                                   {
                                     onError: (err) => {
@@ -405,11 +477,11 @@ export function TracerouteHistory() {
         open={triggerModalOpen}
         onOpenChange={setTriggerModalOpen}
         mode={'user' as TriggerMode}
-        managedNodes={triggerableNodes}
+        managedNodes={modalManagedNodes}
         observedNodes={observedNodes}
-        onTrigger={async (managedNodeId, targetNodeId) => {
+        onTrigger={async (managedNodeId, targetNodeId, targetStrategy) => {
           try {
-            await triggerMutation.mutateAsync({ managedNodeId, targetNodeId });
+            await triggerMutation.mutateAsync({ managedNodeId, targetNodeId, targetStrategy });
             setTriggerModalOpen(false);
           } catch (err) {
             toast.error('Traceroute failed', {

--- a/src/pages/traceroutes/TracerouteHistory.tsx
+++ b/src/pages/traceroutes/TracerouteHistory.tsx
@@ -99,8 +99,19 @@ function parseNumberParam(raw: string | null): number | null {
   return Number.isFinite(n) ? n : null;
 }
 
-function completedElapsedDisplay(tr: AutoTraceRoute): string {
+function TracerouteElapsedCell({ tr }: { tr: AutoTraceRoute }) {
   if (tr.status === 'failed') return '—';
+  /** Only completion time is reliable for externally ingested traceroutes */
+  if (tr.trigger_type === 'external') {
+    return (
+      <span
+        className="text-muted-foreground"
+        title="External traceroutes do not record when the probe started; elapsed time cannot be computed."
+      >
+        Unknown
+      </span>
+    );
+  }
   if (!tr.triggered_at || !tr.completed_at) return '—';
   return formatElapsedBetween(new Date(tr.triggered_at), new Date(tr.completed_at));
 }
@@ -420,11 +431,13 @@ export function TracerouteHistory() {
                       <TableCell
                         title={
                           tr.status !== 'failed' && tr.completed_at
-                            ? format(new Date(tr.completed_at), 'PPp')
+                            ? tr.trigger_type === 'external'
+                              ? `Completed ${format(new Date(tr.completed_at), 'PPp')} (start time not recorded)`
+                              : format(new Date(tr.completed_at), 'PPp')
                             : undefined
                         }
                       >
-                        {completedElapsedDisplay(tr)}
+                        <TracerouteElapsedCell tr={tr} />
                       </TableCell>
                       {canTrigger && (
                         <TableCell onClick={(e) => e.stopPropagation()}>

--- a/src/pages/traceroutes/TriggerTracerouteModal.test.tsx
+++ b/src/pages/traceroutes/TriggerTracerouteModal.test.tsx
@@ -78,6 +78,21 @@ describe('TriggerTracerouteModal with fixedTargetNode', () => {
     expect(trigger).toBeDisabled();
   });
 
+  it('shows target strategy selector in auto mode', () => {
+    render(
+      <TriggerTracerouteModal
+        open={true}
+        onOpenChange={vi.fn()}
+        mode="auto"
+        managedNodes={[makeManagedNode()]}
+        observedNodes={[]}
+        onTrigger={vi.fn()}
+        isSubmitting={false}
+      />
+    );
+    expect(screen.getByTestId('trigger-traceroute-strategy')).toBeInTheDocument();
+  });
+
   it('does not render the fixed-target row when fixedTargetNode is omitted', () => {
     // NodeSearch pulls in the nodes API; render the auto mode to avoid that
     // while still verifying the fixed-target UI is absent.

--- a/src/pages/traceroutes/TriggerTracerouteModal.tsx
+++ b/src/pages/traceroutes/TriggerTracerouteModal.tsx
@@ -14,6 +14,10 @@ import { Tabs, TabsList, TabsTrigger } from '@/components/ui/tabs';
 import { NodeSearch } from '@/components/NodeSearch';
 import { NodesAndConstellationsMap, MapNode } from '@/components/nodes/NodesAndConstellationsMap';
 import { ManagedNode, ObservedNode } from '@/lib/models';
+import { Tooltip, TooltipContent, TooltipProvider, TooltipTrigger } from '@/components/ui/tooltip';
+import { Badge } from '@/components/ui/badge';
+import { Info } from 'lucide-react';
+export type ManualTargetStrategyChoice = 'auto' | 'intra_zone' | 'dx_across' | 'dx_same_side';
 
 export type TriggerMode = 'user' | 'auto';
 
@@ -24,7 +28,11 @@ interface TriggerTracerouteModalProps {
   mode: TriggerMode;
   managedNodes: ManagedNode[];
   observedNodes: ObservedNode[];
-  onTrigger: (managedNodeId: number, targetNodeId?: number) => Promise<void>;
+  onTrigger: (
+    managedNodeId: number,
+    targetNodeId?: number,
+    targetStrategy?: 'intra_zone' | 'dx_across' | 'dx_same_side'
+  ) => Promise<void>;
   isSubmitting: boolean;
   /**
    * When set, the dialog is locked to user mode with the target fixed to this
@@ -52,6 +60,7 @@ export function TriggerTracerouteModal({
   const [managedNodeId, setManagedNodeId] = useState<number | null>(null);
   const [targetNodeId, setTargetNodeId] = useState<number | null>(null);
   const [targetNodeLabel, setTargetNodeLabel] = useState<string | null>(null);
+  const [strategyChoice, setStrategyChoice] = useState<ManualTargetStrategyChoice>('auto');
 
   const hasFixedTarget = fixedTargetNode != null;
 
@@ -59,6 +68,7 @@ export function TriggerTracerouteModal({
   useEffect(() => {
     if (!open) return;
     setMode(hasFixedTarget ? 'user' : initialMode);
+    setStrategyChoice('auto');
   }, [open, initialMode, hasFixedTarget]);
 
   useEffect(() => {
@@ -67,10 +77,21 @@ export function TriggerTracerouteModal({
     setTargetNodeLabel(formatNodeLabel(fixedTargetNode));
   }, [hasFixedTarget, fixedTargetNode]);
 
+  const selectedManaged = managedNodes.find((m) => m.node_id === managedNodeId);
+  const geo = selectedManaged?.geo_classification;
+  const canIntraZone = geo?.applicable_strategies?.includes('intra_zone') ?? false;
+
+  const strategyForApi: 'intra_zone' | 'dx_across' | 'dx_same_side' | undefined =
+    strategyChoice === 'auto'
+      ? undefined
+      : strategyChoice === 'intra_zone' && !canIntraZone
+        ? undefined
+        : strategyChoice;
+
   const handleSubmit = async () => {
     if (!managedNodeId) return;
     if (mode === 'user' && !targetNodeId) return;
-    await onTrigger(managedNodeId, mode === 'user' ? (targetNodeId ?? undefined) : undefined);
+    await onTrigger(managedNodeId, mode === 'user' ? (targetNodeId ?? undefined) : undefined, strategyForApi);
     setManagedNodeId(null);
     if (!hasFixedTarget) {
       setTargetNodeId(null);
@@ -78,7 +99,10 @@ export function TriggerTracerouteModal({
     }
   };
 
-  const canSubmit = managedNodeId != null && (mode === 'auto' || targetNodeId != null);
+  const canSubmit =
+    managedNodeId != null &&
+    (mode === 'auto' || targetNodeId != null) &&
+    !(strategyChoice === 'intra_zone' && !canIntraZone);
 
   const handleMapNodeSelect = (node: MapNode | null) => {
     if (!node) {
@@ -141,6 +165,56 @@ export function TriggerTracerouteModal({
                     {node.short_name ?? node.node_id_str} ({node.node_id_str})
                   </SelectItem>
                 ))}
+              </SelectContent>
+            </Select>
+            {selectedManaged?.geo_classification && (
+              <div className="flex flex-wrap items-center gap-2 text-sm text-muted-foreground">
+                <Badge variant="outline" className="font-normal">
+                  {selectedManaged.geo_classification.tier === 'perimeter'
+                    ? `Perimeter${
+                        selectedManaged.geo_classification.bearing_octant
+                          ? ` (${selectedManaged.geo_classification.bearing_octant})`
+                          : ''
+                      }`
+                    : 'Internal'}
+                </Badge>
+                <span className="text-xs">Traceroute feeder geometry vs constellation</span>
+              </div>
+            )}
+          </div>
+
+          <div className="grid gap-2">
+            <div className="flex items-center gap-2">
+              <Label htmlFor="tr-strategy">Target strategy</Label>
+              <TooltipProvider delayDuration={200}>
+                <Tooltip>
+                  <TooltipTrigger asChild>
+                    <button
+                      type="button"
+                      className="text-muted-foreground hover:text-foreground"
+                      aria-label="Strategy help"
+                    >
+                      <Info className="h-4 w-4" />
+                    </button>
+                  </TooltipTrigger>
+                  <TooltipContent side="right" className="max-w-xs text-xs">
+                    In auto mode, chooses how the API picks a target. In pick-target mode, records the hypothesis with
+                    an explicit target. Intra-zone only applies to perimeter feeders.
+                  </TooltipContent>
+                </Tooltip>
+              </TooltipProvider>
+            </div>
+            <Select value={strategyChoice} onValueChange={(v) => setStrategyChoice(v as ManualTargetStrategyChoice)}>
+              <SelectTrigger id="tr-strategy" data-testid="trigger-traceroute-strategy">
+                <SelectValue />
+              </SelectTrigger>
+              <SelectContent>
+                <SelectItem value="auto">Pick automatically</SelectItem>
+                <SelectItem value="intra_zone" disabled={!canIntraZone}>
+                  Intra-zone
+                </SelectItem>
+                <SelectItem value="dx_across">DX across</SelectItem>
+                <SelectItem value="dx_same_side">DX same side</SelectItem>
               </SelectContent>
             </Select>
           </div>


### PR DESCRIPTION
# Summary

Surfaces **traceroute target strategy** in the UI: history filter + **Strategy** column, **Strategy mix** chart from stats `by_strategy`, **Trigger traceroute** modal (strategy select + feeder **geo classification** badge), **feeder classification** on infrastructure cards and managed node details, and **heatmap** controls for **strategy** (multi-select, `?strategy=`) and **source feeder** (combobox, `?source=` mesh node id) wired to the API.

Traceroute **history** table: the former **Completed** datetime column is now **Elapsed**, showing human-readable **trigger → completion duration** (`formatElapsedBetween`, same unit styling as `formatUptimeSeconds`). Rows with status **failed** show **—** in that column even when a completion timestamp exists. **External** traceroutes (ingested without a real start time) show **Unknown** in muted text so it is not confused with **—** (failure) or a literal **0 seconds** duration. Tooltips still note completion time where available.

Closes #175, Closes #128.

**Depends on:** meshflow-api PR implementing #176 / #178 / heatmap backend for #128 (merged or deployed before this UI is useful against production).

## Testing performed

- `npm test` (Vitest)
- `npm run format` (Prettier)