### PR TITLE
feat(nodes): RF propagation map and profile UI

### DIFF
--- a/src/components/nodes/InfrastructureNodeCard.test.tsx
+++ b/src/components/nodes/InfrastructureNodeCard.test.tsx
@@ -1,9 +1,28 @@
-import { describe, it, expect } from 'vitest';
+import { describe, it, expect, vi } from 'vitest';
 import { render, screen } from '@testing-library/react';
 import { MemoryRouter } from 'react-router-dom';
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
 import type { ObservedNode } from '@/lib/models';
 
 import { InfrastructureNodeCard } from './InfrastructureNodeCard';
+
+vi.mock('@/hooks/api/useRfPropagation', () => ({
+  useRfProfile: () => ({ data: null, isLoading: false }),
+  useRfPropagation: () => ({ data: { status: 'none' }, isLoading: false }),
+  useUpdateRfProfile: () => ({ mutateAsync: vi.fn(), isPending: false }),
+  useRecomputeRfPropagation: () => ({ mutateAsync: vi.fn(), isPending: false }),
+}));
+
+function renderCard(node: ObservedNode) {
+  const client = new QueryClient();
+  return render(
+    <QueryClientProvider client={client}>
+      <MemoryRouter>
+        <InfrastructureNodeCard node={node} />
+      </MemoryRouter>
+    </QueryClientProvider>
+  );
+}
 
 function makeNode(overrides: Partial<ObservedNode> = {}): ObservedNode {
   return {
@@ -24,23 +43,35 @@ function makeNode(overrides: Partial<ObservedNode> = {}): ObservedNode {
 
 describe('InfrastructureNodeCard', () => {
   it('renders a deep-linked Coverage map link to /traceroutes/map/coverage?feeder=<node_id>', () => {
-    render(
-      <MemoryRouter>
-        <InfrastructureNodeCard node={makeNode({ node_id: 4242 })} />
-      </MemoryRouter>
-    );
+    renderCard(makeNode({ node_id: 4242 }));
     const link = screen.getByTestId('infra-coverage-link-4242');
     expect(link).toBeInTheDocument();
     expect(link.getAttribute('href')).toBe('/traceroutes/map/coverage?feeder=4242');
   });
 
   it('also renders the Open node details link to /nodes/<node_id>', () => {
-    render(
-      <MemoryRouter>
-        <InfrastructureNodeCard node={makeNode({ node_id: 7 })} />
-      </MemoryRouter>
-    );
+    renderCard(makeNode({ node_id: 7 }));
     const detailsLink = screen.getByRole('link', { name: /open node details/i });
     expect(detailsLink.getAttribute('href')).toBe('/nodes/7');
+  });
+
+  it('shows Propagation map only when has_ready_rf_render is true', () => {
+    const client = new QueryClient();
+    const { rerender } = render(
+      <QueryClientProvider client={client}>
+        <MemoryRouter>
+          <InfrastructureNodeCard node={makeNode({ node_id: 9, has_ready_rf_render: false })} />
+        </MemoryRouter>
+      </QueryClientProvider>
+    );
+    expect(screen.queryByTestId('infra-propagation-map-9')).not.toBeInTheDocument();
+    rerender(
+      <QueryClientProvider client={client}>
+        <MemoryRouter>
+          <InfrastructureNodeCard node={makeNode({ node_id: 9, has_ready_rf_render: true })} />
+        </MemoryRouter>
+      </QueryClientProvider>
+    );
+    expect(screen.getByTestId('infra-propagation-map-9')).toBeInTheDocument();
   });
 });

--- a/src/components/nodes/InfrastructureNodeCard.tsx
+++ b/src/components/nodes/InfrastructureNodeCard.tsx
@@ -10,6 +10,7 @@ import { Badge } from '@/components/ui/badge';
 import { NodeMiniChart } from '@/components/nodes/NodeMiniChart';
 import { Check, ChevronRight } from 'lucide-react';
 import { useState, memo } from 'react';
+import { RfPropagationMapModal } from '@/components/nodes/RfPropagationMapModal';
 
 interface InfrastructureNodeCardProps {
   node: ObservedNode;
@@ -39,6 +40,7 @@ function InfrastructureNodeCardInner({
 }: InfrastructureNodeCardProps) {
   const roleLabel = getRoleLabel(node.role);
   const [compareSelected, setCompareSelected] = useState(false);
+  const [propagationMapOpen, setPropagationMapOpen] = useState(false);
 
   return (
     <div className="flex flex-col h-full p-6 bg-white dark:bg-slate-800 rounded-lg shadow-md hover:shadow-lg transition-shadow duration-200 border border-slate-200 dark:border-slate-700">
@@ -159,6 +161,24 @@ function InfrastructureNodeCardInner({
         >
           Coverage map
         </Link>
+        {node.has_ready_rf_render === true && (
+          <>
+            <button
+              type="button"
+              className="text-sm text-muted-foreground underline-offset-4 hover:text-primary hover:underline"
+              data-testid={`infra-propagation-map-${node.node_id}`}
+              onClick={() => setPropagationMapOpen(true)}
+            >
+              Propagation map
+            </button>
+            <RfPropagationMapModal
+              open={propagationMapOpen}
+              onOpenChange={setPropagationMapOpen}
+              nodeId={node.node_id}
+              shortLabel={node.short_name}
+            />
+          </>
+        )}
         <Link
           to={`/nodes/${node.node_id}`}
           className="inline-flex items-center gap-1.5 text-sm text-primary hover:underline"

--- a/src/components/nodes/NodeDetailContent.tsx
+++ b/src/components/nodes/NodeDetailContent.tsx
@@ -19,11 +19,12 @@ import { CheckCircle, Clock, Copy, Settings } from 'lucide-react';
 import { Badge } from '@/components/ui/badge';
 import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from '@/components/ui/select';
 import { authService } from '@/lib/auth/authService';
-import { getRoleLabel } from '@/lib/meshtastic';
+import { getRoleLabel, INFRASTRUCTURE_ROLE_IDS } from '@/lib/meshtastic';
 import type { EnvironmentExposureSlug, LatestEnvironmentMetrics, WeatherUseSlug } from '@/lib/models';
 import { NodeEnvironmentSettingsDialog } from '@/components/nodes/NodeEnvironmentSettingsDialog';
 import { NodeMeshMonitoringSection } from '@/components/nodes/NodeMeshMonitoringSection';
 import { NodeTracerouteHistorySection } from '@/components/nodes/NodeTracerouteHistorySection';
+import { RfPropagationSection } from '@/components/nodes/RfPropagationSection';
 import { Tooltip, TooltipContent, TooltipProvider, TooltipTrigger } from '@/components/ui/tooltip';
 import { STRATEGY_META, type TracerouteStrategyValue } from '@/lib/traceroute-strategy';
 
@@ -535,6 +536,7 @@ export function NodeDetailContent({ nodeId, compact = false }: NodeDetailContent
         <>
           <NodeMeshMonitoringSection node={node} />
           <TracerouteLinksSection nodeId={nodeId} isManagedNode={isManagedNode} />
+          {node.role != null && INFRASTRUCTURE_ROLE_IDS.has(node.role) && <RfPropagationSection node={node} />}
           <Suspense
             fallback={
               <div className="mb-6 flex min-h-[120px] items-center justify-center text-muted-foreground">

--- a/src/components/nodes/RfProfileModal.test.tsx
+++ b/src/components/nodes/RfProfileModal.test.tsx
@@ -87,17 +87,20 @@ describe('RfProfileModal', () => {
     expect(altInput.value).toContain('90');
   });
 
-  it('shows azimuth and beamwidth when pattern is directional', async () => {
+  it('shows frequency band selector and map container (omni-only UI)', async () => {
     useRfProfile.mockReturnValue({
       data: {
         antenna_pattern: 'directional',
         antenna_azimuth_deg: 10,
         antenna_beamwidth_deg: 30,
+        rf_frequency_mhz: 868,
       },
       isLoading: false,
     });
     renderModal(makeNode());
-    expect(screen.getByLabelText(/azimuth/i)).toBeInTheDocument();
-    expect(screen.getByLabelText(/beamwidth/i)).toBeInTheDocument();
+    expect(screen.getByTestId('rf-profile-map')).toBeInTheDocument();
+    expect(screen.queryByLabelText(/azimuth/i)).not.toBeInTheDocument();
+    expect(screen.queryByLabelText(/beamwidth/i)).not.toBeInTheDocument();
+    expect(screen.getByRole('combobox', { name: /frequency/i })).toBeInTheDocument();
   });
 });

--- a/src/components/nodes/RfProfileModal.test.tsx
+++ b/src/components/nodes/RfProfileModal.test.tsx
@@ -1,0 +1,103 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import type { ReactElement } from 'react';
+import type { ObservedNode } from '@/lib/models';
+import { RfProfileModal } from './RfProfileModal';
+
+vi.mock('sonner', () => ({
+  toast: { success: vi.fn(), error: vi.fn(), message: vi.fn() },
+}));
+
+vi.mock('@/hooks/useMapTileUrl', () => ({
+  useMapTileUrl: () => ({
+    url: 'https://tile.openstreetmap.org/{z}/{x}/{y}.png',
+    attribution: 'OSM',
+  }),
+}));
+
+const useRfProfile = vi.fn();
+const useUpdateRfProfile = vi.fn();
+const useRecomputeRfPropagation = vi.fn();
+
+vi.mock('@/hooks/api/useRfPropagation', () => ({
+  useRfProfile: (...a: unknown[]) => useRfProfile(...a),
+  useUpdateRfProfile: (...a: unknown[]) => useUpdateRfProfile(...a),
+  useRecomputeRfPropagation: (...a: unknown[]) => useRecomputeRfPropagation(...a),
+}));
+
+function makeNode(overrides: Partial<ObservedNode> = {}): ObservedNode {
+  return {
+    internal_id: 1,
+    node_id: 55,
+    node_id_str: '!00000037',
+    mac_addr: null,
+    long_name: 'N',
+    short_name: 'N',
+    hw_model: null,
+    public_key: null,
+    role: 2,
+    last_heard: null,
+    latest_position: {
+      latitude: 12.34,
+      longitude: 56.78,
+      altitude: 90,
+      logged_time: null,
+      reported_time: null,
+    },
+    ...overrides,
+  } as ObservedNode;
+}
+
+function renderModal(node: ObservedNode) {
+  const client = new QueryClient({ defaultOptions: { queries: { retry: false } } });
+  const ui: ReactElement = (
+    <QueryClientProvider client={client}>
+      <RfProfileModal open node={node} onOpenChange={() => {}} />
+    </QueryClientProvider>
+  );
+  return render(ui);
+}
+
+describe('RfProfileModal', () => {
+  beforeEach(() => {
+    useUpdateRfProfile.mockReturnValue({
+      mutateAsync: vi.fn().mockResolvedValue({}),
+      isPending: false,
+    });
+    useRecomputeRfPropagation.mockReturnValue({
+      mutateAsync: vi.fn().mockResolvedValue({}),
+      isPending: false,
+    });
+  });
+
+  it('Copy from GPS fills lat/lng/alt from latest_position', async () => {
+    useRfProfile.mockReturnValue({
+      data: { antenna_pattern: 'omni', rf_latitude: 0, rf_longitude: 0, rf_altitude_m: 0 },
+      isLoading: false,
+    });
+    renderModal(makeNode());
+    await userEvent.click(screen.getByRole('button', { name: /copy from gps/i }));
+    const latInput = screen.getByLabelText(/latitude/i) as HTMLInputElement;
+    const lngInput = screen.getByLabelText(/longitude/i) as HTMLInputElement;
+    const altInput = screen.getByLabelText(/altitude/i) as HTMLInputElement;
+    expect(latInput.value).toContain('12.34');
+    expect(lngInput.value).toContain('56.78');
+    expect(altInput.value).toContain('90');
+  });
+
+  it('shows azimuth and beamwidth when pattern is directional', async () => {
+    useRfProfile.mockReturnValue({
+      data: {
+        antenna_pattern: 'directional',
+        antenna_azimuth_deg: 10,
+        antenna_beamwidth_deg: 30,
+      },
+      isLoading: false,
+    });
+    renderModal(makeNode());
+    expect(screen.getByLabelText(/azimuth/i)).toBeInTheDocument();
+    expect(screen.getByLabelText(/beamwidth/i)).toBeInTheDocument();
+  });
+});

--- a/src/components/nodes/RfProfileModal.tsx
+++ b/src/components/nodes/RfProfileModal.tsx
@@ -13,7 +13,7 @@ import { Label } from '@/components/ui/label';
 import { Input } from '@/components/ui/input';
 import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from '@/components/ui/select';
 import { Card, CardDescription, CardHeader, CardTitle } from '@/components/ui/card';
-import type { AntennaPattern, ObservedNode, RfProfileUpdateBody } from '@/lib/models';
+import type { ObservedNode, RfProfileUpdateBody } from '@/lib/models';
 import { useMapTileUrl } from '@/hooks/useMapTileUrl';
 import { useRecomputeRfPropagation, useRfProfile, useUpdateRfProfile } from '@/hooks/api/useRfPropagation';
 import L from 'leaflet';
@@ -39,6 +39,22 @@ function numOrNull(v: string): number | null {
   return Number.isFinite(n) ? n : null;
 }
 
+/** Supported ISM bands for propagation (MHz). */
+const RF_FREQUENCY_BANDS = [433, 868, 915] as const;
+
+function mhzToBandKey(mhz: number | null | undefined): string {
+  if (mhz == null) return '';
+  for (const b of RF_FREQUENCY_BANDS) {
+    if (Math.abs(mhz - b) < 0.5) return String(b);
+  }
+  return '';
+}
+
+const inputSurfaceClass = 'border border-slate-300 bg-background shadow-sm dark:border-slate-500 dark:bg-background';
+
+/** Radix Select value when no band chosen (keeps Select controlled; not sent to API). */
+const FREQ_BAND_UNSET = '__freq_unset__';
+
 export function RfProfileModal({ open, onOpenChange, node }: RfProfileModalProps) {
   const nodeId = node.node_id;
   const { data: profile, isLoading } = useRfProfile(nodeId, { enabled: open });
@@ -49,10 +65,8 @@ export function RfProfileModal({ open, onOpenChange, node }: RfProfileModalProps
   const [antennaHeight, setAntennaHeight] = useState('');
   const [antennaGain, setAntennaGain] = useState('');
   const [txPower, setTxPower] = useState('');
-  const [freq, setFreq] = useState('');
-  const [pattern, setPattern] = useState<AntennaPattern>('omni');
-  const [azimuth, setAzimuth] = useState('');
-  const [beamwidth, setBeamwidth] = useState('');
+  /** One of 433 | 868 | 915 or '' when unset / legacy value */
+  const [freqBand, setFreqBand] = useState('');
   const [rfLat, setRfLat] = useState('');
   const [rfLng, setRfLng] = useState('');
   const [rfAlt, setRfAlt] = useState('');
@@ -70,10 +84,7 @@ export function RfProfileModal({ open, onOpenChange, node }: RfProfileModalProps
       setAntennaHeight('');
       setAntennaGain('');
       setTxPower('');
-      setFreq('');
-      setPattern('omni');
-      setAzimuth('');
-      setBeamwidth('');
+      setFreqBand('');
       setRfLat('');
       setRfLng('');
       setRfAlt('');
@@ -83,10 +94,7 @@ export function RfProfileModal({ open, onOpenChange, node }: RfProfileModalProps
     setAntennaHeight(profile.antenna_height_m != null ? String(profile.antenna_height_m) : '');
     setAntennaGain(profile.antenna_gain_dbi != null ? String(profile.antenna_gain_dbi) : '');
     setTxPower(profile.tx_power_dbm != null ? String(profile.tx_power_dbm) : '');
-    setFreq(profile.rf_frequency_mhz != null ? String(profile.rf_frequency_mhz) : '');
-    setPattern((profile.antenna_pattern as AntennaPattern) ?? 'omni');
-    setAzimuth(profile.antenna_azimuth_deg != null ? String(profile.antenna_azimuth_deg) : '');
-    setBeamwidth(profile.antenna_beamwidth_deg != null ? String(profile.antenna_beamwidth_deg) : '');
+    setFreqBand(mhzToBandKey(profile.rf_frequency_mhz));
     const latS = profile.rf_latitude != null ? String(profile.rf_latitude) : '';
     const lngS = profile.rf_longitude != null ? String(profile.rf_longitude) : '';
     const altS = profile.rf_altitude_m != null ? String(profile.rf_altitude_m) : '';
@@ -104,12 +112,27 @@ export function RfProfileModal({ open, onOpenChange, node }: RfProfileModalProps
     return { lat: 55.8642, lng: -4.2518 };
   }, [node.latest_position?.latitude, node.latest_position?.longitude]);
 
-  // Intentionally omit rfLat/rfLng from deps: map is created once per open; marker syncs via a separate effect.
+  // Map mounts only after `!isLoading` so `mapRef` exists; tear down fully when dialog closes.
   useEffect(() => {
-    if (!open || !mapRef.current || mapInstanceRef.current) return;
-    const startLat = numOrUndef(rfLat) ?? initialCenter.lat;
-    const startLng = numOrUndef(rfLng) ?? initialCenter.lng;
-    const map = L.map(mapRef.current).setView([startLat, startLng], 13);
+    if (!open) {
+      markerRef.current?.remove();
+      markerRef.current = null;
+      if (mapInstanceRef.current) {
+        mapInstanceRef.current.remove();
+        mapInstanceRef.current = null;
+      }
+      tileLayerRef.current = null;
+      if (mapRef.current) mapRef.current.innerHTML = '';
+      return;
+    }
+    if (isLoading || profile === undefined) return;
+    const el = mapRef.current;
+    if (!el || mapInstanceRef.current) return;
+
+    const startLat = profile !== null && profile.rf_latitude != null ? profile.rf_latitude : initialCenter.lat;
+    const startLng = profile !== null && profile.rf_longitude != null ? profile.rf_longitude : initialCenter.lng;
+
+    const map = L.map(el).setView([startLat, startLng], 13);
     const tileLayer = L.tileLayer(tileUrl, { attribution }).addTo(map);
     tileLayerRef.current = tileLayer;
     const marker = L.marker([startLat, startLng], { draggable: true }).addTo(map);
@@ -125,18 +148,21 @@ export function RfProfileModal({ open, onOpenChange, node }: RfProfileModalProps
       setRfLng(String(e.latlng.lng));
     });
     mapInstanceRef.current = map;
-    const t = setTimeout(() => map.invalidateSize(), 100);
+
+    const t1 = window.setTimeout(() => map.invalidateSize(), 100);
+    const t2 = window.setTimeout(() => map.invalidateSize(), 400);
+
     return () => {
-      clearTimeout(t);
+      window.clearTimeout(t1);
+      window.clearTimeout(t2);
       markerRef.current?.remove();
       markerRef.current = null;
-      mapInstanceRef.current?.remove();
+      map.remove();
       mapInstanceRef.current = null;
       tileLayerRef.current = null;
-      if (mapRef.current) mapRef.current.innerHTML = '';
+      el.innerHTML = '';
     };
-    // eslint-disable-next-line react-hooks/exhaustive-deps -- marker position synced in a follow-up effect
-  }, [open, initialCenter.lat, initialCenter.lng, tileUrl, attribution]);
+  }, [open, isLoading, profile, initialCenter.lat, initialCenter.lng, tileUrl, attribution]);
 
   useEffect(() => {
     if (!open) return;
@@ -175,10 +201,10 @@ export function RfProfileModal({ open, onOpenChange, node }: RfProfileModalProps
     antenna_height_m: numOrNull(antennaHeight),
     antenna_gain_dbi: numOrNull(antennaGain),
     tx_power_dbm: numOrNull(txPower),
-    rf_frequency_mhz: numOrNull(freq),
-    antenna_pattern: pattern,
-    antenna_azimuth_deg: pattern === 'directional' ? numOrNull(azimuth) : null,
-    antenna_beamwidth_deg: pattern === 'directional' ? numOrNull(beamwidth) : null,
+    rf_frequency_mhz: freqBand === '' ? null : Number(freqBand),
+    antenna_pattern: 'omni',
+    antenna_azimuth_deg: null,
+    antenna_beamwidth_deg: null,
     rf_latitude: numOrNull(rfLat),
     rf_longitude: numOrNull(rfLng),
     rf_altitude_m: numOrNull(rfAlt),
@@ -190,12 +216,6 @@ export function RfProfileModal({ open, onOpenChange, node }: RfProfileModalProps
   };
 
   const handleSave = async () => {
-    if (pattern === 'directional') {
-      if (azimuth.trim() === '' || beamwidth.trim() === '') {
-        toast.error('Directional pattern requires azimuth and beamwidth.');
-        return;
-      }
-    }
     try {
       await updateMutation.mutateAsync(buildBody());
       toast.success('RF profile saved');
@@ -237,21 +257,37 @@ export function RfProfileModal({ open, onOpenChange, node }: RfProfileModalProps
                 <div className="grid grid-cols-1 gap-3 sm:grid-cols-3">
                   <div>
                     <Label htmlFor="rf-lat">Latitude</Label>
-                    <Input id="rf-lat" value={rfLat} onChange={(e) => setRfLat(e.target.value)} />
+                    <Input
+                      id="rf-lat"
+                      className={inputSurfaceClass}
+                      value={rfLat}
+                      onChange={(e) => setRfLat(e.target.value)}
+                    />
                   </div>
                   <div>
                     <Label htmlFor="rf-lng">Longitude</Label>
-                    <Input id="rf-lng" value={rfLng} onChange={(e) => setRfLng(e.target.value)} />
+                    <Input
+                      id="rf-lng"
+                      className={inputSurfaceClass}
+                      value={rfLng}
+                      onChange={(e) => setRfLng(e.target.value)}
+                    />
                   </div>
                   <div>
                     <Label htmlFor="rf-alt">Altitude (m)</Label>
-                    <Input id="rf-alt" value={rfAlt} onChange={(e) => setRfAlt(e.target.value)} />
+                    <Input
+                      id="rf-alt"
+                      className={inputSurfaceClass}
+                      value={rfAlt}
+                      onChange={(e) => setRfAlt(e.target.value)}
+                    />
                   </div>
                 </div>
                 <div
                   ref={mapRef}
-                  className="map-container h-[220px] w-full rounded-md border"
-                  style={{ position: 'relative', zIndex: 1 }}
+                  data-testid="rf-profile-map"
+                  className="map-container h-[220px] w-full min-h-[220px] rounded-md border border-slate-300 dark:border-slate-500"
+                  style={{ position: 'relative', zIndex: 0 }}
                 />
               </div>
             </Card>
@@ -263,44 +299,44 @@ export function RfProfileModal({ open, onOpenChange, node }: RfProfileModalProps
               <div className="grid grid-cols-1 gap-3 px-6 pb-6 sm:grid-cols-2">
                 <div>
                   <Label>Height AGL (m)</Label>
-                  <Input value={antennaHeight} onChange={(e) => setAntennaHeight(e.target.value)} />
+                  <Input
+                    className={inputSurfaceClass}
+                    value={antennaHeight}
+                    onChange={(e) => setAntennaHeight(e.target.value)}
+                  />
                 </div>
                 <div>
                   <Label>Gain (dBi)</Label>
-                  <Input value={antennaGain} onChange={(e) => setAntennaGain(e.target.value)} />
+                  <Input
+                    className={inputSurfaceClass}
+                    value={antennaGain}
+                    onChange={(e) => setAntennaGain(e.target.value)}
+                  />
                 </div>
                 <div>
                   <Label>TX power (dBm)</Label>
-                  <Input value={txPower} onChange={(e) => setTxPower(e.target.value)} />
-                </div>
-                <div>
-                  <Label>Frequency (MHz)</Label>
-                  <Input value={freq} onChange={(e) => setFreq(e.target.value)} />
+                  <Input className={inputSurfaceClass} value={txPower} onChange={(e) => setTxPower(e.target.value)} />
                 </div>
                 <div className="sm:col-span-2">
-                  <Label>Pattern</Label>
-                  <Select value={pattern} onValueChange={(v) => setPattern(v as AntennaPattern)}>
-                    <SelectTrigger>
-                      <SelectValue />
+                  <Label htmlFor="rf-frequency-band">Frequency</Label>
+                  <Select
+                    value={freqBand === '' ? FREQ_BAND_UNSET : freqBand}
+                    onValueChange={(v) => setFreqBand(v === FREQ_BAND_UNSET ? '' : v)}
+                  >
+                    <SelectTrigger id="rf-frequency-band" className={inputSurfaceClass}>
+                      <SelectValue placeholder="Select band" />
                     </SelectTrigger>
                     <SelectContent>
-                      <SelectItem value="omni">Omni</SelectItem>
-                      <SelectItem value="directional">Directional</SelectItem>
+                      <SelectItem value={FREQ_BAND_UNSET}>Select band</SelectItem>
+                      {RF_FREQUENCY_BANDS.map((mhz) => (
+                        <SelectItem key={mhz} value={String(mhz)}>
+                          {mhz} MHz
+                        </SelectItem>
+                      ))}
                     </SelectContent>
                   </Select>
+                  <p className="mt-1 text-xs text-muted-foreground">ISM bands supported for propagation today.</p>
                 </div>
-                {pattern === 'directional' && (
-                  <>
-                    <div>
-                      <Label htmlFor="rf-azimuth">Azimuth (deg)</Label>
-                      <Input id="rf-azimuth" value={azimuth} onChange={(e) => setAzimuth(e.target.value)} />
-                    </div>
-                    <div>
-                      <Label htmlFor="rf-beamwidth">Beamwidth (deg)</Label>
-                      <Input id="rf-beamwidth" value={beamwidth} onChange={(e) => setBeamwidth(e.target.value)} />
-                    </div>
-                  </>
-                )}
               </div>
             </Card>
 

--- a/src/components/nodes/RfProfileModal.tsx
+++ b/src/components/nodes/RfProfileModal.tsx
@@ -1,0 +1,345 @@
+import { useEffect, useMemo, useRef, useState } from 'react';
+import { toast } from 'sonner';
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
+} from '@/components/ui/dialog';
+import { Button } from '@/components/ui/button';
+import { Label } from '@/components/ui/label';
+import { Input } from '@/components/ui/input';
+import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from '@/components/ui/select';
+import { Card, CardDescription, CardHeader, CardTitle } from '@/components/ui/card';
+import type { AntennaPattern, ObservedNode, RfProfileUpdateBody } from '@/lib/models';
+import { useMapTileUrl } from '@/hooks/useMapTileUrl';
+import { useRecomputeRfPropagation, useRfProfile, useUpdateRfProfile } from '@/hooks/api/useRfPropagation';
+import L from 'leaflet';
+import 'leaflet/dist/leaflet.css';
+
+export interface RfProfileModalProps {
+  open: boolean;
+  onOpenChange: (open: boolean) => void;
+  node: ObservedNode;
+}
+
+function numOrUndef(v: string): number | undefined {
+  const t = v.trim();
+  if (t === '') return undefined;
+  const n = Number(t);
+  return Number.isFinite(n) ? n : undefined;
+}
+
+function numOrNull(v: string): number | null {
+  const t = v.trim();
+  if (t === '') return null;
+  const n = Number(t);
+  return Number.isFinite(n) ? n : null;
+}
+
+export function RfProfileModal({ open, onOpenChange, node }: RfProfileModalProps) {
+  const nodeId = node.node_id;
+  const { data: profile, isLoading } = useRfProfile(nodeId, { enabled: open });
+  const updateMutation = useUpdateRfProfile(nodeId);
+  const recomputeMutation = useRecomputeRfPropagation(nodeId);
+  const { url: tileUrl, attribution } = useMapTileUrl();
+
+  const [antennaHeight, setAntennaHeight] = useState('');
+  const [antennaGain, setAntennaGain] = useState('');
+  const [txPower, setTxPower] = useState('');
+  const [freq, setFreq] = useState('');
+  const [pattern, setPattern] = useState<AntennaPattern>('omni');
+  const [azimuth, setAzimuth] = useState('');
+  const [beamwidth, setBeamwidth] = useState('');
+  const [rfLat, setRfLat] = useState('');
+  const [rfLng, setRfLng] = useState('');
+  const [rfAlt, setRfAlt] = useState('');
+  const [coordSnapshot, setCoordSnapshot] = useState<{ lat: string; lng: string; alt: string } | null>(null);
+  const [showRerenderPrompt, setShowRerenderPrompt] = useState(false);
+
+  const mapRef = useRef<HTMLDivElement>(null);
+  const mapInstanceRef = useRef<L.Map | null>(null);
+  const markerRef = useRef<L.Marker | null>(null);
+  const tileLayerRef = useRef<L.TileLayer | null>(null);
+
+  useEffect(() => {
+    if (!open || profile === undefined) return;
+    if (profile === null) {
+      setAntennaHeight('');
+      setAntennaGain('');
+      setTxPower('');
+      setFreq('');
+      setPattern('omni');
+      setAzimuth('');
+      setBeamwidth('');
+      setRfLat('');
+      setRfLng('');
+      setRfAlt('');
+      setCoordSnapshot({ lat: '', lng: '', alt: '' });
+      return;
+    }
+    setAntennaHeight(profile.antenna_height_m != null ? String(profile.antenna_height_m) : '');
+    setAntennaGain(profile.antenna_gain_dbi != null ? String(profile.antenna_gain_dbi) : '');
+    setTxPower(profile.tx_power_dbm != null ? String(profile.tx_power_dbm) : '');
+    setFreq(profile.rf_frequency_mhz != null ? String(profile.rf_frequency_mhz) : '');
+    setPattern((profile.antenna_pattern as AntennaPattern) ?? 'omni');
+    setAzimuth(profile.antenna_azimuth_deg != null ? String(profile.antenna_azimuth_deg) : '');
+    setBeamwidth(profile.antenna_beamwidth_deg != null ? String(profile.antenna_beamwidth_deg) : '');
+    const latS = profile.rf_latitude != null ? String(profile.rf_latitude) : '';
+    const lngS = profile.rf_longitude != null ? String(profile.rf_longitude) : '';
+    const altS = profile.rf_altitude_m != null ? String(profile.rf_altitude_m) : '';
+    setRfLat(latS);
+    setRfLng(lngS);
+    setRfAlt(altS);
+    setCoordSnapshot({ lat: latS, lng: lngS, alt: altS });
+    setShowRerenderPrompt(false);
+  }, [open, profile]);
+
+  const initialCenter = useMemo(() => {
+    const lat = node.latest_position?.latitude;
+    const lng = node.latest_position?.longitude;
+    if (lat != null && lng != null) return { lat, lng };
+    return { lat: 55.8642, lng: -4.2518 };
+  }, [node.latest_position?.latitude, node.latest_position?.longitude]);
+
+  // Intentionally omit rfLat/rfLng from deps: map is created once per open; marker syncs via a separate effect.
+  useEffect(() => {
+    if (!open || !mapRef.current || mapInstanceRef.current) return;
+    const startLat = numOrUndef(rfLat) ?? initialCenter.lat;
+    const startLng = numOrUndef(rfLng) ?? initialCenter.lng;
+    const map = L.map(mapRef.current).setView([startLat, startLng], 13);
+    const tileLayer = L.tileLayer(tileUrl, { attribution }).addTo(map);
+    tileLayerRef.current = tileLayer;
+    const marker = L.marker([startLat, startLng], { draggable: true }).addTo(map);
+    markerRef.current = marker;
+    marker.on('dragend', () => {
+      const p = marker.getLatLng();
+      setRfLat(String(p.lat));
+      setRfLng(String(p.lng));
+    });
+    map.on('click', (e) => {
+      marker.setLatLng(e.latlng);
+      setRfLat(String(e.latlng.lat));
+      setRfLng(String(e.latlng.lng));
+    });
+    mapInstanceRef.current = map;
+    const t = setTimeout(() => map.invalidateSize(), 100);
+    return () => {
+      clearTimeout(t);
+      markerRef.current?.remove();
+      markerRef.current = null;
+      mapInstanceRef.current?.remove();
+      mapInstanceRef.current = null;
+      tileLayerRef.current = null;
+      if (mapRef.current) mapRef.current.innerHTML = '';
+    };
+    // eslint-disable-next-line react-hooks/exhaustive-deps -- marker position synced in a follow-up effect
+  }, [open, initialCenter.lat, initialCenter.lng, tileUrl, attribution]);
+
+  useEffect(() => {
+    if (!open) return;
+    const map = mapInstanceRef.current;
+    const old = tileLayerRef.current;
+    if (!map || !old) return;
+    map.removeLayer(old);
+    const next = L.tileLayer(tileUrl, { attribution }).addTo(map);
+    tileLayerRef.current = next;
+  }, [open, tileUrl, attribution]);
+
+  useEffect(() => {
+    const marker = markerRef.current;
+    const lat = numOrUndef(rfLat);
+    const lng = numOrUndef(rfLng);
+    if (marker && lat != null && lng != null) {
+      marker.setLatLng([lat, lng]);
+    }
+  }, [rfLat, rfLng]);
+
+  const copyFromGps = () => {
+    const lat = node.latest_position?.latitude;
+    const lng = node.latest_position?.longitude;
+    const alt = node.latest_position?.altitude;
+    if (lat == null || lng == null) {
+      toast.message('No GPS position on latest status for this node.');
+      return;
+    }
+    setRfLat(String(lat));
+    setRfLng(String(lng));
+    if (alt != null) setRfAlt(String(alt));
+    toast.success('Copied coordinates from latest GPS');
+  };
+
+  const buildBody = (): RfProfileUpdateBody => ({
+    antenna_height_m: numOrNull(antennaHeight),
+    antenna_gain_dbi: numOrNull(antennaGain),
+    tx_power_dbm: numOrNull(txPower),
+    rf_frequency_mhz: numOrNull(freq),
+    antenna_pattern: pattern,
+    antenna_azimuth_deg: pattern === 'directional' ? numOrNull(azimuth) : null,
+    antenna_beamwidth_deg: pattern === 'directional' ? numOrNull(beamwidth) : null,
+    rf_latitude: numOrNull(rfLat),
+    rf_longitude: numOrNull(rfLng),
+    rf_altitude_m: numOrNull(rfAlt),
+  });
+
+  const coordsChangedVsSnapshot = () => {
+    if (!coordSnapshot) return false;
+    return rfLat !== coordSnapshot.lat || rfLng !== coordSnapshot.lng || rfAlt !== coordSnapshot.alt;
+  };
+
+  const handleSave = async () => {
+    if (pattern === 'directional') {
+      if (azimuth.trim() === '' || beamwidth.trim() === '') {
+        toast.error('Directional pattern requires azimuth and beamwidth.');
+        return;
+      }
+    }
+    try {
+      await updateMutation.mutateAsync(buildBody());
+      toast.success('RF profile saved');
+      if (coordsChangedVsSnapshot()) {
+        setShowRerenderPrompt(true);
+      } else {
+        onOpenChange(false);
+      }
+    } catch {
+      toast.error('Could not save RF profile.');
+    }
+  };
+
+  return (
+    <Dialog open={open} onOpenChange={onOpenChange}>
+      <DialogContent className="max-h-[90vh] overflow-y-auto sm:max-w-lg">
+        <DialogHeader>
+          <DialogTitle>RF propagation profile</DialogTitle>
+          <DialogDescription>
+            Private map location is visible only to you and staff. Antenna parameters are public on the node page.
+          </DialogDescription>
+        </DialogHeader>
+
+        {isLoading && <p className="text-sm text-muted-foreground">Loading…</p>}
+
+        {!isLoading && (
+          <div className="space-y-6">
+            <Card>
+              <CardHeader>
+                <CardTitle className="text-base">Private location (only you and staff)</CardTitle>
+                <CardDescription>Used for propagation modelling, not the same as live GPS.</CardDescription>
+              </CardHeader>
+              <div className="space-y-3 px-6 pb-6">
+                <div className="flex flex-wrap gap-2">
+                  <Button type="button" variant="secondary" size="sm" onClick={copyFromGps}>
+                    Copy from GPS
+                  </Button>
+                </div>
+                <div className="grid grid-cols-1 gap-3 sm:grid-cols-3">
+                  <div>
+                    <Label htmlFor="rf-lat">Latitude</Label>
+                    <Input id="rf-lat" value={rfLat} onChange={(e) => setRfLat(e.target.value)} />
+                  </div>
+                  <div>
+                    <Label htmlFor="rf-lng">Longitude</Label>
+                    <Input id="rf-lng" value={rfLng} onChange={(e) => setRfLng(e.target.value)} />
+                  </div>
+                  <div>
+                    <Label htmlFor="rf-alt">Altitude (m)</Label>
+                    <Input id="rf-alt" value={rfAlt} onChange={(e) => setRfAlt(e.target.value)} />
+                  </div>
+                </div>
+                <div
+                  ref={mapRef}
+                  className="map-container h-[220px] w-full rounded-md border"
+                  style={{ position: 'relative', zIndex: 1 }}
+                />
+              </div>
+            </Card>
+
+            <Card>
+              <CardHeader>
+                <CardTitle className="text-base">Antenna</CardTitle>
+              </CardHeader>
+              <div className="grid grid-cols-1 gap-3 px-6 pb-6 sm:grid-cols-2">
+                <div>
+                  <Label>Height AGL (m)</Label>
+                  <Input value={antennaHeight} onChange={(e) => setAntennaHeight(e.target.value)} />
+                </div>
+                <div>
+                  <Label>Gain (dBi)</Label>
+                  <Input value={antennaGain} onChange={(e) => setAntennaGain(e.target.value)} />
+                </div>
+                <div>
+                  <Label>TX power (dBm)</Label>
+                  <Input value={txPower} onChange={(e) => setTxPower(e.target.value)} />
+                </div>
+                <div>
+                  <Label>Frequency (MHz)</Label>
+                  <Input value={freq} onChange={(e) => setFreq(e.target.value)} />
+                </div>
+                <div className="sm:col-span-2">
+                  <Label>Pattern</Label>
+                  <Select value={pattern} onValueChange={(v) => setPattern(v as AntennaPattern)}>
+                    <SelectTrigger>
+                      <SelectValue />
+                    </SelectTrigger>
+                    <SelectContent>
+                      <SelectItem value="omni">Omni</SelectItem>
+                      <SelectItem value="directional">Directional</SelectItem>
+                    </SelectContent>
+                  </Select>
+                </div>
+                {pattern === 'directional' && (
+                  <>
+                    <div>
+                      <Label htmlFor="rf-azimuth">Azimuth (deg)</Label>
+                      <Input id="rf-azimuth" value={azimuth} onChange={(e) => setAzimuth(e.target.value)} />
+                    </div>
+                    <div>
+                      <Label htmlFor="rf-beamwidth">Beamwidth (deg)</Label>
+                      <Input id="rf-beamwidth" value={beamwidth} onChange={(e) => setBeamwidth(e.target.value)} />
+                    </div>
+                  </>
+                )}
+              </div>
+            </Card>
+
+            {showRerenderPrompt && (
+              <div className="rounded-md border bg-muted/40 p-3 text-sm">
+                <p className="mb-2 font-medium">Re-render propagation map now?</p>
+                <div className="flex gap-2">
+                  <Button
+                    type="button"
+                    size="sm"
+                    onClick={() => {
+                      void recomputeMutation.mutateAsync().then(() => {
+                        toast.success('Render queued');
+                        setShowRerenderPrompt(false);
+                        onOpenChange(false);
+                      });
+                    }}
+                    disabled={recomputeMutation.isPending}
+                  >
+                    Yes
+                  </Button>
+                  <Button type="button" size="sm" variant="outline" onClick={() => onOpenChange(false)}>
+                    No
+                  </Button>
+                </div>
+              </div>
+            )}
+          </div>
+        )}
+
+        <DialogFooter>
+          <Button type="button" variant="outline" onClick={() => onOpenChange(false)}>
+            Cancel
+          </Button>
+          <Button type="button" onClick={() => void handleSave()} disabled={updateMutation.isPending || isLoading}>
+            Save
+          </Button>
+        </DialogFooter>
+      </DialogContent>
+    </Dialog>
+  );
+}

--- a/src/components/nodes/RfPropagationMap.test.tsx
+++ b/src/components/nodes/RfPropagationMap.test.tsx
@@ -1,0 +1,38 @@
+import { describe, it, expect, vi } from 'vitest';
+import { render, waitFor } from '@testing-library/react';
+import L from 'leaflet';
+import { RfPropagationMap } from './RfPropagationMap';
+
+vi.mock('@/hooks/useMapTileUrl', () => ({
+  useMapTileUrl: () => ({
+    url: 'https://tile.openstreetmap.org/{z}/{x}/{y}.png',
+    attribution: 'OSM',
+  }),
+}));
+
+describe('RfPropagationMap', () => {
+  it('calls L.imageOverlay with south-west and north-east corners from bounds', async () => {
+    const spy = vi.spyOn(L, 'imageOverlay');
+    render(
+      <RfPropagationMap
+        assetUrl="https://api.example.com/map.png"
+        bounds={{ west: -4.5, south: 55.0, east: -4.0, north: 55.5 }}
+      />
+    );
+    await waitFor(() => {
+      expect(spy).toHaveBeenCalled();
+    });
+    const [url, latLngBounds] = spy.mock.calls[0] as [string, [[number, number], [number, number]]];
+    expect(url).toBe('https://api.example.com/map.png');
+    expect(latLngBounds).toEqual([
+      [55.0, -4.5],
+      [55.5, -4.0],
+    ]);
+    spy.mockRestore();
+  });
+
+  it('shows empty state when not ready', () => {
+    const { getByText } = render(<RfPropagationMap assetUrl={null} bounds={null} />);
+    expect(getByText(/map not rendered yet/i)).toBeInTheDocument();
+  });
+});

--- a/src/components/nodes/RfPropagationMap.tsx
+++ b/src/components/nodes/RfPropagationMap.tsx
@@ -1,0 +1,76 @@
+/**
+ * Minimal Leaflet map showing a single georeferenced PNG via L.imageOverlay.
+ * Bounds use API order west/south/east/north; Leaflet expects [[south, west], [north, east]].
+ */
+import { useMapTileUrl } from '@/hooks/useMapTileUrl';
+import L from 'leaflet';
+import { useEffect, useRef } from 'react';
+import 'leaflet/dist/leaflet.css';
+
+export interface RfPropagationMapProps {
+  assetUrl: string | null | undefined;
+  bounds: { west: number; south: number; east: number; north: number } | null | undefined;
+  /** Minimum height for the map container */
+  minHeight?: number;
+  className?: string;
+}
+
+export function RfPropagationMap({ assetUrl, bounds, minHeight = 280, className }: RfPropagationMapProps) {
+  const mapRef = useRef<HTMLDivElement>(null);
+  const mapInstanceRef = useRef<L.Map | null>(null);
+  const layersRef = useRef<L.Layer[]>([]);
+  const { url: tileUrl, attribution } = useMapTileUrl();
+
+  useEffect(() => {
+    const el = mapRef.current;
+    if (!el || !assetUrl || !bounds) return;
+
+    const map = L.map(el, { zoomControl: true }).setView(
+      [(bounds.south + bounds.north) / 2, (bounds.west + bounds.east) / 2],
+      10
+    );
+    mapInstanceRef.current = map;
+    L.tileLayer(tileUrl, { attribution }).addTo(map);
+
+    const sw: L.LatLngTuple = [bounds.south, bounds.west];
+    const ne: L.LatLngTuple = [bounds.north, bounds.east];
+    const overlay = L.imageOverlay(assetUrl, [sw, ne], { opacity: 0.85 }).addTo(map);
+    layersRef.current.push(overlay);
+
+    map.fitBounds(L.latLngBounds(sw, ne), { padding: [24, 24], maxZoom: 14 });
+    const t = setTimeout(() => map.invalidateSize(), 50);
+
+    return () => {
+      clearTimeout(t);
+      layersRef.current.forEach((layer) => {
+        try {
+          map.removeLayer(layer);
+        } catch {
+          /* noop */
+        }
+      });
+      layersRef.current = [];
+      map.remove();
+      mapInstanceRef.current = null;
+    };
+  }, [assetUrl, bounds, tileUrl, attribution]);
+
+  if (!assetUrl || !bounds) {
+    return (
+      <div
+        className={`flex items-center justify-center rounded-md border bg-muted/40 text-muted-foreground text-sm ${className ?? ''}`}
+        style={{ minHeight }}
+      >
+        Map not rendered yet
+      </div>
+    );
+  }
+
+  return (
+    <div
+      ref={mapRef}
+      className={`map-container w-full rounded-md border ${className ?? ''}`}
+      style={{ minHeight, position: 'relative', zIndex: 1 }}
+    />
+  );
+}

--- a/src/components/nodes/RfPropagationMapModal.test.tsx
+++ b/src/components/nodes/RfPropagationMapModal.test.tsx
@@ -1,0 +1,28 @@
+import { describe, it, expect, vi } from 'vitest';
+import { render, screen } from '@testing-library/react';
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import { RfPropagationMapModal } from './RfPropagationMapModal';
+
+const useRfPropagation = vi.fn();
+vi.mock('@/hooks/api/useRfPropagation', () => ({
+  useRfProfile: vi.fn(),
+  useRfPropagation: (...a: unknown[]) => useRfPropagation(...a),
+  useUpdateRfProfile: vi.fn(),
+  useRecomputeRfPropagation: vi.fn(() => ({ mutateAsync: vi.fn(), isPending: false })),
+}));
+
+describe('RfPropagationMapModal', () => {
+  it('shows empty state when propagation is not ready', () => {
+    useRfPropagation.mockReturnValue({
+      data: { status: 'pending', created_at: '2026-01-01' },
+      isLoading: false,
+    });
+    const client = new QueryClient();
+    render(
+      <QueryClientProvider client={client}>
+        <RfPropagationMapModal open onOpenChange={() => {}} nodeId={1} />
+      </QueryClientProvider>
+    );
+    expect(screen.getByText(/map not rendered yet/i)).toBeInTheDocument();
+  });
+});

--- a/src/components/nodes/RfPropagationMapModal.tsx
+++ b/src/components/nodes/RfPropagationMapModal.tsx
@@ -1,0 +1,45 @@
+/**
+ * Full-screen dialog with a Leaflet map + imageOverlay for a completed RF propagation render.
+ * Uses the same high z-index / min-height pattern as traceroute maps so tiles stack correctly in Radix Dialog.
+ */
+import { Dialog, DialogContent, DialogDescription, DialogHeader, DialogTitle } from '@/components/ui/dialog';
+import { RfPropagationMap } from '@/components/nodes/RfPropagationMap';
+import { useRfPropagation } from '@/hooks/api/useRfPropagation';
+import { isRfPropagationNone } from '@/lib/models';
+
+export interface RfPropagationMapModalProps {
+  open: boolean;
+  onOpenChange: (open: boolean) => void;
+  nodeId: number;
+  shortLabel?: string | null;
+}
+
+export function RfPropagationMapModal({ open, onOpenChange, nodeId, shortLabel }: RfPropagationMapModalProps) {
+  const { data, isLoading } = useRfPropagation(nodeId, { enabled: open });
+
+  const ready = data && !isRfPropagationNone(data) && data.status === 'ready' ? data : null;
+
+  return (
+    <Dialog open={open} onOpenChange={onOpenChange}>
+      <DialogContent className="max-w-3xl sm:max-w-4xl">
+        <DialogHeader>
+          <DialogTitle>Propagation map{shortLabel ? ` — ${shortLabel}` : ''}</DialogTitle>
+          <DialogDescription>Cached RF coverage preview when a render is available.</DialogDescription>
+        </DialogHeader>
+        <div className="min-h-[420px] w-full" style={{ position: 'relative', zIndex: 1 }}>
+          {isLoading && (
+            <div className="flex h-[400px] items-center justify-center text-muted-foreground text-sm">Loading…</div>
+          )}
+          {!isLoading && !ready && (
+            <div className="flex h-[400px] items-center justify-center rounded-md border bg-muted/30 text-muted-foreground text-sm">
+              Map not rendered yet
+            </div>
+          )}
+          {!isLoading && ready && (
+            <RfPropagationMap assetUrl={ready.asset_url} bounds={ready.bounds ?? null} minHeight={400} />
+          )}
+        </div>
+      </DialogContent>
+    </Dialog>
+  );
+}

--- a/src/components/nodes/RfPropagationSection.test.tsx
+++ b/src/components/nodes/RfPropagationSection.test.tsx
@@ -1,0 +1,102 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { render, screen } from '@testing-library/react';
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import type { ReactElement } from 'react';
+import type { ObservedNode } from '@/lib/models';
+import { RfPropagationSection } from './RfPropagationSection';
+
+const useRfProfile = vi.fn();
+const useRfPropagation = vi.fn();
+const useRecomputeRfPropagation = vi.fn();
+
+vi.mock('@/hooks/api/useRfPropagation', () => ({
+  useRfProfile: (...args: unknown[]) => useRfProfile(...args),
+  useRfPropagation: (...args: unknown[]) => useRfPropagation(...args),
+  useUpdateRfProfile: vi.fn(() => ({ mutateAsync: vi.fn(), isPending: false })),
+  useRecomputeRfPropagation: (...args: unknown[]) => useRecomputeRfPropagation(...args),
+}));
+
+function makeNode(overrides: Partial<ObservedNode> = {}): ObservedNode {
+  return {
+    internal_id: 1,
+    node_id: 200,
+    node_id_str: '!000000c8',
+    mac_addr: null,
+    long_name: 'Tower',
+    short_name: 'TWR',
+    hw_model: null,
+    public_key: null,
+    role: 2,
+    last_heard: null,
+    ...overrides,
+  } as ObservedNode;
+}
+
+function renderWithClient(ui: ReactElement) {
+  const client = new QueryClient({
+    defaultOptions: { queries: { retry: false } },
+  });
+  return render(<QueryClientProvider client={client}>{ui}</QueryClientProvider>);
+}
+
+describe('RfPropagationSection', () => {
+  beforeEach(() => {
+    useRecomputeRfPropagation.mockReturnValue({ mutateAsync: vi.fn(), isPending: false });
+  });
+
+  it('hides content for non-owner stranger without a profile', () => {
+    useRfProfile.mockReturnValue({ data: undefined, isLoading: false });
+    useRfPropagation.mockReturnValue({ data: { status: 'none' }, isLoading: false });
+    const { container } = renderWithClient(
+      <RfPropagationSection node={makeNode({ rf_profile_editable: false, has_rf_profile: false })} />
+    );
+    expect(container.firstChild).toBeNull();
+  });
+
+  it('shows public summary for stranger when has_rf_profile', () => {
+    useRfProfile.mockReturnValue({
+      data: { antenna_pattern: 'omni', tx_power_dbm: 20 },
+      isLoading: false,
+    });
+    useRfPropagation.mockReturnValue({ data: { status: 'none' }, isLoading: false });
+    renderWithClient(
+      <RfPropagationSection node={makeNode({ rf_profile_editable: false, has_rf_profile: true })} />
+    );
+    expect(screen.getByText(/RF propagation/i)).toBeInTheDocument();
+    expect(screen.getByText('20')).toBeInTheDocument();
+    expect(screen.queryByTitle('Edit RF profile')).not.toBeInTheDocument();
+    expect(screen.queryByRole('button', { name: /render now/i })).not.toBeInTheDocument();
+  });
+
+  it('shows settings and render controls for owner', () => {
+    useRfProfile.mockReturnValue({ data: null, isLoading: false });
+    useRfPropagation.mockReturnValue({ data: { status: 'pending' }, isLoading: false });
+    renderWithClient(
+      <RfPropagationSection node={makeNode({ rf_profile_editable: true, has_rf_profile: false })} />
+    );
+    expect(screen.getByTitle('Edit RF profile')).toBeInTheDocument();
+    expect(screen.getByRole('button', { name: /render now/i })).toBeInTheDocument();
+  });
+
+  it('renders Leaflet container when render is ready and node flags allow map', () => {
+    useRfProfile.mockReturnValue({
+      data: { antenna_pattern: 'omni' },
+      isLoading: false,
+    });
+    useRfPropagation.mockReturnValue({
+      data: {
+        status: 'ready',
+        asset_url: 'https://example.com/x.png',
+        bounds: { west: -5, south: 54, east: -3, north: 56 },
+        created_at: '2026-01-01T00:00:00Z',
+      },
+      isLoading: false,
+    });
+    renderWithClient(
+      <RfPropagationSection
+        node={makeNode({ rf_profile_editable: true, has_rf_profile: true, has_ready_rf_render: true })}
+      />
+    );
+    expect(document.querySelector('.leaflet-container')).not.toBeNull();
+  });
+});

--- a/src/components/nodes/RfPropagationSection.tsx
+++ b/src/components/nodes/RfPropagationSection.tsx
@@ -1,0 +1,146 @@
+import { useState } from 'react';
+import { Settings } from 'lucide-react';
+import { Card, CardContent, CardDescription, CardHeader, CardTitle } from '@/components/ui/card';
+import { Button } from '@/components/ui/button';
+import type { ObservedNode } from '@/lib/models';
+import { isRfPropagationNone } from '@/lib/models';
+import { useRfProfile, useRfPropagation, useRecomputeRfPropagation } from '@/hooks/api/useRfPropagation';
+import { RfProfileModal } from '@/components/nodes/RfProfileModal';
+import { RfPropagationMap } from '@/components/nodes/RfPropagationMap';
+
+export interface RfPropagationSectionProps {
+  node: ObservedNode;
+}
+
+export function RfPropagationSection({ node }: RfPropagationSectionProps) {
+  const nodeId = node.node_id;
+  const canEdit = node.rf_profile_editable === true;
+  const hasProfile = node.has_rf_profile === true;
+  const showSection = canEdit || hasProfile;
+
+  const [profileOpen, setProfileOpen] = useState(false);
+  const { data: profile } = useRfProfile(nodeId, { enabled: showSection });
+  const { data: propagation, isLoading: propLoading } = useRfPropagation(nodeId, { enabled: showSection });
+  const recompute = useRecomputeRfPropagation(nodeId);
+
+  if (!showSection) {
+    return null;
+  }
+
+  const canSeeMap = node.has_ready_rf_render === true;
+  const readyRow =
+    propagation && !isRfPropagationNone(propagation) && propagation.status === 'ready' ? propagation : null;
+
+  return (
+    <div className="mb-6">
+      <Card>
+        <CardHeader className="flex flex-row flex-wrap items-center justify-between gap-4">
+          <div>
+            <CardTitle>RF propagation</CardTitle>
+            <CardDescription>
+              Antenna and TX parameters for coverage modelling. Map appears when a render completes.
+            </CardDescription>
+          </div>
+          <div className="flex flex-wrap items-center gap-2">
+            {canEdit && (
+              <>
+                <Button
+                  type="button"
+                  variant="ghost"
+                  size="icon"
+                  onClick={() => setProfileOpen(true)}
+                  title="Edit RF profile"
+                >
+                  <Settings className="h-4 w-4" />
+                </Button>
+                <Button
+                  type="button"
+                  variant="secondary"
+                  size="sm"
+                  onClick={() => void recompute.mutateAsync()}
+                  disabled={recompute.isPending}
+                >
+                  Render now
+                </Button>
+              </>
+            )}
+          </div>
+        </CardHeader>
+        <CardContent className="space-y-4">
+          {profile && (
+            <div className="grid gap-2 text-sm sm:grid-cols-2">
+              <div>
+                <span className="text-muted-foreground">Antenna height (m): </span>
+                <span>{profile.antenna_height_m ?? '—'}</span>
+              </div>
+              <div>
+                <span className="text-muted-foreground">Gain (dBi): </span>
+                <span>{profile.antenna_gain_dbi ?? '—'}</span>
+              </div>
+              <div>
+                <span className="text-muted-foreground">TX power (dBm): </span>
+                <span>{profile.tx_power_dbm ?? '—'}</span>
+              </div>
+              <div>
+                <span className="text-muted-foreground">Frequency (MHz): </span>
+                <span>{profile.rf_frequency_mhz ?? '—'}</span>
+              </div>
+              <div>
+                <span className="text-muted-foreground">Pattern: </span>
+                <span>{profile.antenna_pattern ?? '—'}</span>
+              </div>
+            </div>
+          )}
+
+          {!profile && canEdit && (
+            <p className="text-sm text-muted-foreground">
+              Configure the RF profile (location and antenna) to queue propagation renders.
+            </p>
+          )}
+
+          {propLoading && (
+            <div className="flex min-h-[160px] items-center justify-center text-muted-foreground">
+              <div className="h-8 w-8 animate-spin rounded-full border-b-2 border-t-2 border-teal-500" />
+            </div>
+          )}
+
+          {!propLoading && propagation && isRfPropagationNone(propagation) && (
+            <p className="text-sm text-muted-foreground">No propagation render has been queued yet.</p>
+          )}
+
+          {!propLoading && propagation && !isRfPropagationNone(propagation) && propagation.status === 'pending' && (
+            <div className="flex min-h-[160px] flex-col items-center justify-center gap-2 text-muted-foreground">
+              <div className="h-8 w-8 animate-spin rounded-full border-b-2 border-t-2 border-teal-500" />
+              <p>Queued for rendering…</p>
+            </div>
+          )}
+
+          {!propLoading && propagation && !isRfPropagationNone(propagation) && propagation.status === 'running' && (
+            <div className="flex min-h-[160px] flex-col items-center justify-center gap-2 text-muted-foreground">
+              <div className="h-8 w-8 animate-spin rounded-full border-b-2 border-t-2 border-teal-500" />
+              <p>Rendering…</p>
+            </div>
+          )}
+
+          {!propLoading && propagation && !isRfPropagationNone(propagation) && propagation.status === 'failed' && (
+            <div className="space-y-2 rounded-md border border-destructive/40 bg-destructive/5 p-3 text-sm">
+              <p className="font-medium text-destructive">Render failed</p>
+              {propagation.error_message ? <p>{propagation.error_message}</p> : null}
+              {canEdit && (
+                <Button type="button" size="sm" variant="secondary" onClick={() => void recompute.mutateAsync()}>
+                  Render now
+                </Button>
+              )}
+            </div>
+          )}
+
+          {!propLoading && canSeeMap && readyRow?.asset_url && readyRow.bounds && (
+            <RfPropagationMap assetUrl={readyRow.asset_url} bounds={readyRow.bounds} minHeight={300} />
+          )}
+        </CardContent>
+      </Card>
+
+      {canEdit && <RfProfileModal open={profileOpen} onOpenChange={setProfileOpen} node={node} />}
+    </div>
+  );
+}

--- a/src/hooks/api/useRfPropagation.ts
+++ b/src/hooks/api/useRfPropagation.ts
@@ -1,0 +1,51 @@
+import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query';
+import { useMeshtasticApi } from './useApi';
+import type { RfProfileUpdateBody } from '@/lib/models';
+
+export function useRfProfile(nodeId: number | null, options?: { enabled?: boolean }) {
+  const api = useMeshtasticApi();
+  return useQuery({
+    queryKey: ['rf-profile', nodeId],
+    queryFn: () => api.getRfProfile(nodeId!),
+    enabled: nodeId != null && (options?.enabled ?? true),
+  });
+}
+
+export function useRfPropagation(nodeId: number | null, options?: { enabled?: boolean }) {
+  const api = useMeshtasticApi();
+  return useQuery({
+    queryKey: ['rf-propagation', nodeId],
+    queryFn: () => api.getRfPropagation(nodeId!),
+    enabled: nodeId != null && (options?.enabled ?? true),
+    refetchInterval: (q) => {
+      const d = q.state.data;
+      if (!d || d.status === 'none') return false;
+      if (d.status === 'pending' || d.status === 'running') return 5000;
+      return false;
+    },
+  });
+}
+
+export function useUpdateRfProfile(nodeId: number) {
+  const api = useMeshtasticApi();
+  const queryClient = useQueryClient();
+  return useMutation({
+    mutationFn: (body: RfProfileUpdateBody) => api.updateRfProfile(nodeId, body),
+    onSuccess: () => {
+      void queryClient.invalidateQueries({ queryKey: ['nodes', nodeId] });
+      void queryClient.invalidateQueries({ queryKey: ['rf-profile', nodeId] });
+    },
+  });
+}
+
+export function useRecomputeRfPropagation(nodeId: number) {
+  const api = useMeshtasticApi();
+  const queryClient = useQueryClient();
+  return useMutation({
+    mutationFn: () => api.recomputeRfPropagation(nodeId),
+    onSuccess: () => {
+      void queryClient.invalidateQueries({ queryKey: ['rf-propagation', nodeId] });
+      void queryClient.invalidateQueries({ queryKey: ['nodes', nodeId] });
+    },
+  });
+}

--- a/src/lib/api/meshtastic-api.ts
+++ b/src/lib/api/meshtastic-api.ts
@@ -33,6 +33,7 @@ import {
   StatsSnapshotsParams,
 } from '@/lib/types';
 import { parseNodeWatchFromAPI, parseObservedNodeFromAPI } from './api-utils';
+import type { RfProfile, RfProfileUpdateBody, RfPropagationPollResult, RfPropagationRenderRow } from '@/lib/models';
 
 export interface FeederReachFeeder {
   managed_node_id: string;
@@ -208,6 +209,31 @@ export class MeshtasticApi extends BaseApi {
   ): Promise<ObservedNode> {
     const node = await this.patch<ObservedNode>(`/nodes/observed-nodes/${nodeId}/environment-settings/`, body);
     return parseObservedNodeFromAPI(node);
+  }
+
+  /**
+   * Get RF propagation profile. Returns null when the API responds with 204 (no profile yet).
+   */
+  async getRfProfile(nodeId: number): Promise<RfProfile | null> {
+    const response = await this.axios.get<RfProfile>(`/nodes/observed-nodes/${nodeId}/rf-profile/`, {
+      validateStatus: (s) => s === 200 || s === 204,
+    });
+    if (response.status === 204) {
+      return null;
+    }
+    return response.data;
+  }
+
+  async updateRfProfile(nodeId: number, body: RfProfileUpdateBody): Promise<RfProfile> {
+    return this.patch<RfProfile>(`/nodes/observed-nodes/${nodeId}/rf-profile/`, body);
+  }
+
+  async getRfPropagation(nodeId: number): Promise<RfPropagationPollResult> {
+    return this.get<RfPropagationPollResult>(`/nodes/observed-nodes/${nodeId}/rf-propagation/`);
+  }
+
+  async recomputeRfPropagation(nodeId: number): Promise<RfPropagationRenderRow> {
+    return this.post<RfPropagationRenderRow>(`/nodes/observed-nodes/${nodeId}/rf-propagation/recompute/`);
   }
 
   /**

--- a/src/lib/models.ts
+++ b/src/lib/models.ts
@@ -22,6 +22,59 @@ export type EnvironmentExposureSlug = 'unknown' | 'indoor' | 'outdoor' | 'shelte
 /** API slugs for ObservedNode.weather_use */
 export type WeatherUseSlug = 'unknown' | 'include' | 'exclude';
 
+export type AntennaPattern = 'omni' | 'directional';
+
+/** RF propagation profile from GET/PATCH `/nodes/observed-nodes/{id}/rf-profile/` (snake_case from API). */
+export interface RfProfile {
+  antenna_height_m?: number | null;
+  antenna_gain_dbi?: number | null;
+  tx_power_dbm?: number | null;
+  rf_frequency_mhz?: number | null;
+  antenna_pattern?: AntennaPattern;
+  antenna_azimuth_deg?: number | null;
+  antenna_beamwidth_deg?: number | null;
+  /** Present only for claim owner or staff. */
+  rf_latitude?: number | null;
+  rf_longitude?: number | null;
+  rf_altitude_m?: number | null;
+  created_at?: string;
+  updated_at?: string;
+}
+
+export type RfProfileUpdateBody = Partial<
+  Pick<
+    RfProfile,
+    | 'antenna_height_m'
+    | 'antenna_gain_dbi'
+    | 'tx_power_dbm'
+    | 'rf_frequency_mhz'
+    | 'antenna_pattern'
+    | 'antenna_azimuth_deg'
+    | 'antenna_beamwidth_deg'
+    | 'rf_latitude'
+    | 'rf_longitude'
+    | 'rf_altitude_m'
+  >
+>;
+
+export type RfPropagationRenderStatus = 'none' | 'pending' | 'running' | 'ready' | 'failed';
+
+export interface RfPropagationRenderRow {
+  status: Exclude<RfPropagationRenderStatus, 'none'>;
+  input_hash?: string | null;
+  asset_url?: string | null;
+  bounds?: { west: number; south: number; east: number; north: number } | null;
+  error_message?: string;
+  created_at: string;
+  completed_at?: string | null;
+}
+
+export type RfPropagationPollResult = RfPropagationRenderRow | { status: 'none' };
+
+export function isRfPropagationNone(r: RfPropagationPollResult): r is { status: 'none' } {
+  return r.status === 'none';
+}
+
 // ObservedNode from Meshflow API v2
 export interface ObservedNode {
   internal_id: number;
@@ -40,6 +93,10 @@ export interface ObservedNode {
   weather_use?: WeatherUseSlug;
   /** True when the current user may PATCH environment-settings (staff or claim owner). */
   environment_settings_editable?: boolean;
+  /** True when the current user may PATCH rf-profile (staff or claim owner). */
+  rf_profile_editable?: boolean;
+  has_rf_profile?: boolean;
+  has_ready_rf_render?: boolean;
   // Additional fields for UI compatibility
   last_heard?: Date | null;
   latest_device_metrics?: DeviceMetrics | null;


### PR DESCRIPTION
## Summary

Adds RF propagation to node details: profile modal (private map location, antenna fields, ISM band select), propagation section with map overlay and settings, infrastructure card entry point, API hooks/types, and tests.

Closes #177.

## Related

- API: [meshflow-api#184](https://github.com/pskillen/meshflow-api/pull/184)

## Testing performed

- `npm test` (Vitest: RF propagation components, hooks, existing suite)
- Manual: RF profile modal, propagation map modal where applicable
