### PR TITLE
feat(rf-propagation): inline Cancel/Dismiss button for non-ready renders

### DIFF
--- a/src/components/nodes/RfPropagationSection.test.tsx
+++ b/src/components/nodes/RfPropagationSection.test.tsx
@@ -1,5 +1,5 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest';
-import { render, screen } from '@testing-library/react';
+import { render, screen, fireEvent } from '@testing-library/react';
 import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
 import type { ReactElement } from 'react';
 import type { ObservedNode } from '@/lib/models';
@@ -8,12 +8,14 @@ import { RfPropagationSection } from './RfPropagationSection';
 const useRfProfile = vi.fn();
 const useRfPropagation = vi.fn();
 const useRecomputeRfPropagation = vi.fn();
+const useDismissRfPropagation = vi.fn();
 
 vi.mock('@/hooks/api/useRfPropagation', () => ({
   useRfProfile: (...args: unknown[]) => useRfProfile(...args),
   useRfPropagation: (...args: unknown[]) => useRfPropagation(...args),
   useUpdateRfProfile: vi.fn(() => ({ mutateAsync: vi.fn(), isPending: false })),
   useRecomputeRfPropagation: (...args: unknown[]) => useRecomputeRfPropagation(...args),
+  useDismissRfPropagation: (...args: unknown[]) => useDismissRfPropagation(...args),
 }));
 
 function makeNode(overrides: Partial<ObservedNode> = {}): ObservedNode {
@@ -42,6 +44,7 @@ function renderWithClient(ui: ReactElement) {
 describe('RfPropagationSection', () => {
   beforeEach(() => {
     useRecomputeRfPropagation.mockReturnValue({ mutateAsync: vi.fn(), isPending: false });
+    useDismissRfPropagation.mockReturnValue({ mutateAsync: vi.fn(), isPending: false });
   });
 
   it('hides content for non-owner stranger without a profile', () => {
@@ -76,6 +79,61 @@ describe('RfPropagationSection', () => {
     );
     expect(screen.getByTitle('Edit RF profile')).toBeInTheDocument();
     expect(screen.getByRole('button', { name: /render now/i })).toBeInTheDocument();
+  });
+
+  it('shows Cancel button while pending and calls dismiss on click', () => {
+    useRfProfile.mockReturnValue({ data: null, isLoading: false });
+    useRfPropagation.mockReturnValue({ data: { status: 'pending' }, isLoading: false });
+    const dismissMutate = vi.fn();
+    useDismissRfPropagation.mockReturnValue({ mutateAsync: dismissMutate, isPending: false });
+
+    renderWithClient(
+      <RfPropagationSection node={makeNode({ rf_profile_editable: true, has_rf_profile: false })} />
+    );
+
+    const cancel = screen.getByRole('button', { name: /^cancel$/i });
+    fireEvent.click(cancel);
+    expect(dismissMutate).toHaveBeenCalledTimes(1);
+  });
+
+  it('shows Cancel button while running', () => {
+    useRfProfile.mockReturnValue({ data: null, isLoading: false });
+    useRfPropagation.mockReturnValue({ data: { status: 'running' }, isLoading: false });
+    renderWithClient(
+      <RfPropagationSection node={makeNode({ rf_profile_editable: true, has_rf_profile: true })} />
+    );
+    expect(screen.getByText(/Rendering…/i)).toBeInTheDocument();
+    expect(screen.getByRole('button', { name: /^cancel$/i })).toBeInTheDocument();
+  });
+
+  it('shows Dismiss button when failed and calls dismiss on click', () => {
+    useRfProfile.mockReturnValue({ data: null, isLoading: false });
+    useRfPropagation.mockReturnValue({
+      data: { status: 'failed', error_message: 'engine 422' },
+      isLoading: false,
+    });
+    const dismissMutate = vi.fn();
+    useDismissRfPropagation.mockReturnValue({ mutateAsync: dismissMutate, isPending: false });
+
+    renderWithClient(
+      <RfPropagationSection node={makeNode({ rf_profile_editable: true, has_rf_profile: true })} />
+    );
+
+    expect(screen.getByText(/Render failed/i)).toBeInTheDocument();
+    expect(screen.getByText(/engine 422/)).toBeInTheDocument();
+    const dismissBtn = screen.getByRole('button', { name: /^dismiss$/i });
+    fireEvent.click(dismissBtn);
+    expect(dismissMutate).toHaveBeenCalledTimes(1);
+  });
+
+  it('hides Cancel/Dismiss buttons for non-editors', () => {
+    useRfProfile.mockReturnValue({ data: { antenna_pattern: 'omni' }, isLoading: false });
+    useRfPropagation.mockReturnValue({ data: { status: 'pending' }, isLoading: false });
+    renderWithClient(
+      <RfPropagationSection node={makeNode({ rf_profile_editable: false, has_rf_profile: true })} />
+    );
+    expect(screen.queryByRole('button', { name: /^cancel$/i })).not.toBeInTheDocument();
+    expect(screen.queryByRole('button', { name: /^dismiss$/i })).not.toBeInTheDocument();
   });
 
   it('renders Leaflet container when render is ready and node flags allow map', () => {

--- a/src/components/nodes/RfPropagationSection.tsx
+++ b/src/components/nodes/RfPropagationSection.tsx
@@ -4,7 +4,12 @@ import { Card, CardContent, CardDescription, CardHeader, CardTitle } from '@/com
 import { Button } from '@/components/ui/button';
 import type { ObservedNode } from '@/lib/models';
 import { isRfPropagationNone } from '@/lib/models';
-import { useRfProfile, useRfPropagation, useRecomputeRfPropagation } from '@/hooks/api/useRfPropagation';
+import {
+  useRfProfile,
+  useRfPropagation,
+  useRecomputeRfPropagation,
+  useDismissRfPropagation,
+} from '@/hooks/api/useRfPropagation';
 import { RfProfileModal } from '@/components/nodes/RfProfileModal';
 import { RfPropagationMap } from '@/components/nodes/RfPropagationMap';
 
@@ -22,6 +27,7 @@ export function RfPropagationSection({ node }: RfPropagationSectionProps) {
   const { data: profile } = useRfProfile(nodeId, { enabled: showSection });
   const { data: propagation, isLoading: propLoading } = useRfPropagation(nodeId, { enabled: showSection });
   const recompute = useRecomputeRfPropagation(nodeId);
+  const dismiss = useDismissRfPropagation(nodeId);
 
   if (!showSection) {
     return null;
@@ -109,16 +115,38 @@ export function RfPropagationSection({ node }: RfPropagationSectionProps) {
           )}
 
           {!propLoading && propagation && !isRfPropagationNone(propagation) && propagation.status === 'pending' && (
-            <div className="flex min-h-[160px] flex-col items-center justify-center gap-2 text-muted-foreground">
+            <div className="flex min-h-[160px] flex-col items-center justify-center gap-3 text-muted-foreground">
               <div className="h-8 w-8 animate-spin rounded-full border-b-2 border-t-2 border-teal-500" />
               <p>Queued for rendering…</p>
+              {canEdit && (
+                <Button
+                  type="button"
+                  size="sm"
+                  variant="outline"
+                  onClick={() => void dismiss.mutateAsync()}
+                  disabled={dismiss.isPending}
+                >
+                  Cancel
+                </Button>
+              )}
             </div>
           )}
 
           {!propLoading && propagation && !isRfPropagationNone(propagation) && propagation.status === 'running' && (
-            <div className="flex min-h-[160px] flex-col items-center justify-center gap-2 text-muted-foreground">
+            <div className="flex min-h-[160px] flex-col items-center justify-center gap-3 text-muted-foreground">
               <div className="h-8 w-8 animate-spin rounded-full border-b-2 border-t-2 border-teal-500" />
               <p>Rendering…</p>
+              {canEdit && (
+                <Button
+                  type="button"
+                  size="sm"
+                  variant="outline"
+                  onClick={() => void dismiss.mutateAsync()}
+                  disabled={dismiss.isPending}
+                >
+                  Cancel
+                </Button>
+              )}
             </div>
           )}
 
@@ -127,9 +155,20 @@ export function RfPropagationSection({ node }: RfPropagationSectionProps) {
               <p className="font-medium text-destructive">Render failed</p>
               {propagation.error_message ? <p>{propagation.error_message}</p> : null}
               {canEdit && (
-                <Button type="button" size="sm" variant="secondary" onClick={() => void recompute.mutateAsync()}>
-                  Render now
-                </Button>
+                <div className="flex flex-wrap gap-2">
+                  <Button type="button" size="sm" variant="secondary" onClick={() => void recompute.mutateAsync()}>
+                    Render now
+                  </Button>
+                  <Button
+                    type="button"
+                    size="sm"
+                    variant="outline"
+                    onClick={() => void dismiss.mutateAsync()}
+                    disabled={dismiss.isPending}
+                  >
+                    Dismiss
+                  </Button>
+                </div>
               )}
             </div>
           )}

--- a/src/hooks/api/useRfPropagation.ts
+++ b/src/hooks/api/useRfPropagation.ts
@@ -49,3 +49,15 @@ export function useRecomputeRfPropagation(nodeId: number) {
     },
   });
 }
+
+export function useDismissRfPropagation(nodeId: number) {
+  const api = useMeshtasticApi();
+  const queryClient = useQueryClient();
+  return useMutation({
+    mutationFn: () => api.dismissRfPropagation(nodeId),
+    onSuccess: () => {
+      void queryClient.invalidateQueries({ queryKey: ['rf-propagation', nodeId] });
+      void queryClient.invalidateQueries({ queryKey: ['nodes', nodeId] });
+    },
+  });
+}

--- a/src/lib/api/meshtastic-api.ts
+++ b/src/lib/api/meshtastic-api.ts
@@ -236,6 +236,10 @@ export class MeshtasticApi extends BaseApi {
     return this.post<RfPropagationRenderRow>(`/nodes/observed-nodes/${nodeId}/rf-propagation/recompute/`);
   }
 
+  async dismissRfPropagation(nodeId: number): Promise<{ deleted: number }> {
+    return this.post<{ deleted: number }>(`/nodes/observed-nodes/${nodeId}/rf-propagation/dismiss/`);
+  }
+
   /**
    * Search for observed nodes
    */


### PR DESCRIPTION
# Summary

Adds an inline Cancel/Dismiss action to the RF propagation section so operators can abort stuck or queued renders, and discard failed ones, without waiting on retention.

- **`pending`/`running` state**: a `Cancel` button appears below the spinner.
- **`failed` state**: a `Dismiss` button sits next to `Render now` inside the existing error card.
- Both buttons hit the new `POST /api/observed-nodes/{node_id}/rf-propagation/dismiss/` endpoint (one endpoint, one action — see [meshflow-api#185](https://github.com/pskillen/meshflow-api/pull/185)). The endpoint deletes every non-`ready` row for the node; the worker is resilient to the row vanishing mid-flight.
- Buttons are gated behind `rf_profile_editable` so non-owners can't see them.
- Propagation query is invalidated on success so the UI returns to the "no render queued yet" state.

New API method `dismissRfPropagation(nodeId)` and matching `useDismissRfPropagation` hook follow the existing recompute pattern.

Stacked on #183 (Plan 1) — merge that first, or rebase onto `main` after it lands.

Refs #177.

## Related

- API: [meshflow-api#185](https://github.com/pskillen/meshflow-api/pull/185)

## Testing performed

- `npm test` (Vitest: 85 passed, 4 new tests in `RfPropagationSection.test.tsx` covering the Cancel/Dismiss button visibility per status, click dispatch, and non-editor hiding).
- `npm run lint` / `tsc --noEmit` — clean.
- Manual: queued a render against the preprod stack, confirmed Cancel removes the row and falls back to "no render queued yet"; reproduced the engine `422` failure path, confirmed Dismiss clears the error card.
