### PR TITLE
feat(nodes): RF propagation UI improvements

### DIFF
--- a/src/components/map/DeckMapboxMap.tsx
+++ b/src/components/map/DeckMapboxMap.tsx
@@ -65,9 +65,14 @@ export function DeckMapboxMap({
         initialViewState={initialViewState as DeckGLProps['initialViewState']}
         onClick={onClick}
         getTooltip={getTooltip}
-        style={{ width: '100%', height: '100%' }}
+        style={{ width: '100%', height: '100%', minHeight: '200px', minWidth: '0' }}
       >
-        <Map reuseMaps mapboxAccessToken={mapboxToken} mapStyle={mapStyle} style={{ width: '100%', height: '100%' }}>
+        <Map
+          reuseMaps={false}
+          mapboxAccessToken={mapboxToken}
+          mapStyle={mapStyle}
+          style={{ width: '100%', height: '100%', minHeight: '200px', minWidth: '0' }}
+        >
           {children}
         </Map>
       </DeckGL>

--- a/src/components/nodes/NodeDetailContent.tsx
+++ b/src/components/nodes/NodeDetailContent.tsx
@@ -185,6 +185,8 @@ export function NodeDetailContent({ nodeId, compact = false }: NodeDetailContent
   const hasApprovedClaim =
     (node.claim && node.claim.accepted_at) || (node.owner && currentUser && node.owner.id === currentUser.id);
 
+  const showRfPropagationBesideLocation = !compact && node.role != null && INFRASTRUCTURE_ROLE_IDS.has(node.role);
+
   return (
     <div className={compact ? 'px-2' : 'container mx-auto px-4 py-8'}>
       {!compact && (
@@ -478,7 +480,7 @@ export function NodeDetailContent({ nodeId, compact = false }: NodeDetailContent
           })()}
       </div>
 
-      <div className="mb-6">
+      <div className={showRfPropagationBesideLocation ? 'mb-6 grid grid-cols-1 gap-6 lg:grid-cols-2' : 'mb-6'}>
         <Card>
           <CardHeader>
             <CardTitle>Node Location</CardTitle>
@@ -530,13 +532,13 @@ export function NodeDetailContent({ nodeId, compact = false }: NodeDetailContent
             )}
           </CardContent>
         </Card>
+        {showRfPropagationBesideLocation ? <RfPropagationSection node={node} className="mb-0" /> : null}
       </div>
 
       {!compact && (
         <>
           <NodeMeshMonitoringSection node={node} />
           <TracerouteLinksSection nodeId={nodeId} isManagedNode={isManagedNode} />
-          {node.role != null && INFRASTRUCTURE_ROLE_IDS.has(node.role) && <RfPropagationSection node={node} />}
           <Suspense
             fallback={
               <div className="mb-6 flex min-h-[120px] items-center justify-center text-muted-foreground">

--- a/src/components/nodes/NodesMap.test.tsx
+++ b/src/components/nodes/NodesMap.test.tsx
@@ -1,0 +1,103 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { render, waitFor } from '@testing-library/react';
+import type { ObservedNode } from '@/lib/models';
+import { NodesMap } from './NodesMap';
+
+vi.mock('@/hooks/useMapTileUrl', () => ({
+  useMapTileUrl: () => ({
+    url: 'https://tile.example/{z}/{x}/{y}.png',
+    attribution: 'OSM',
+  }),
+}));
+
+const { mapMocks, createBounds } = vi.hoisted(() => {
+  const mapInstance = {
+    setView: vi.fn(),
+    fitBounds: vi.fn(),
+    remove: vi.fn(),
+    removeLayer: vi.fn(),
+    addLayer: vi.fn(),
+  };
+  mapInstance.setView.mockImplementation(() => mapInstance);
+  mapInstance.fitBounds.mockImplementation(() => mapInstance);
+  const { setView, fitBounds } = mapInstance;
+  const createBounds = () => {
+    let n = 0;
+    return {
+      extend: vi.fn(() => {
+        n++;
+      }),
+      isValid: vi.fn(() => n > 0),
+    };
+  };
+  return { mapMocks: { setView, fitBounds, mapInstance }, createBounds };
+});
+
+vi.mock('leaflet', () => ({
+  default: {
+    map: vi.fn(() => mapMocks.mapInstance),
+    tileLayer: vi.fn(() => ({ addTo: vi.fn().mockReturnThis() })),
+    divIcon: vi.fn(() => ({})),
+    marker: vi.fn(() => ({
+      bindPopup: vi.fn().mockReturnThis(),
+      addTo: vi.fn().mockReturnThis(),
+      remove: vi.fn(),
+    })),
+    latLngBounds: vi.fn(() => createBounds()),
+  },
+}));
+
+function nodeWithPosition(
+  id: number,
+  lat: number,
+  lng: number,
+  overrides: Partial<ObservedNode> = {}
+): ObservedNode {
+  return {
+    internal_id: id,
+    node_id: id,
+    node_id_str: `!${id.toString(16).padStart(8, '0')}`,
+    mac_addr: null,
+    long_name: 'A',
+    short_name: 'A',
+    hw_model: null,
+    public_key: null,
+    role: 2,
+    last_heard: null,
+    latest_position: {
+      latitude: lat,
+      longitude: lng,
+      altitude: 0,
+      logged_time: null,
+      reported_time: null,
+    },
+    ...overrides,
+  } as ObservedNode;
+}
+
+describe('NodesMap', () => {
+  beforeEach(() => {
+    mapMocks.setView.mockClear();
+    mapMocks.fitBounds.mockClear();
+  });
+
+  it('uses fixed zoom for a single node with position instead of maxZoom fitBounds', async () => {
+    render(<NodesMap nodes={[nodeWithPosition(1, 55.1, -4.2)]} />);
+    await waitFor(() => {
+      expect(mapMocks.fitBounds).not.toHaveBeenCalled();
+      expect(mapMocks.setView).toHaveBeenLastCalledWith([55.1, -4.2], 12);
+    });
+  });
+
+  it('uses fitBounds when multiple nodes have positions', async () => {
+    render(
+      <NodesMap
+        nodes={[
+          nodeWithPosition(1, 55.1, -4.2),
+          nodeWithPosition(2, 55.2, -4.3, { short_name: 'B', node_id_str: '!b' }),
+        ]}
+      />
+    );
+    await waitFor(() => expect(mapMocks.fitBounds).toHaveBeenCalled());
+  });
+});

--- a/src/components/nodes/NodesMap.tsx
+++ b/src/components/nodes/NodesMap.tsx
@@ -136,22 +136,25 @@ export function NodesMap({ nodes }: NodesMapProps) {
 
     const bounds = L.latLngBounds([]);
 
-    nodes.forEach((node) => {
-      if (node.latest_position?.latitude && node.latest_position?.longitude) {
-        const position: L.LatLngExpression = [node.latest_position.latitude, node.latest_position.longitude];
+    const nodesWithPosition = nodes.filter((n) => n.latest_position?.latitude && n.latest_position?.longitude);
 
-        const marker = L.marker(position, {
-          icon: createNodeIcon(node.short_name || node.node_id_str.toString(), getRoleColor(node.role), false),
-        })
-          .bindPopup(buildNodePopupHtml(node))
-          .addTo(map);
+    nodesWithPosition.forEach((node) => {
+      const position: L.LatLngExpression = [node.latest_position!.latitude!, node.latest_position!.longitude!];
 
-        markersRef.current.push(marker);
-        bounds.extend(position);
-      }
+      const marker = L.marker(position, {
+        icon: createNodeIcon(node.short_name || node.node_id_str.toString(), getRoleColor(node.role), false),
+      })
+        .bindPopup(buildNodePopupHtml(node))
+        .addTo(map);
+
+      markersRef.current.push(marker);
+      bounds.extend(position);
     });
 
-    if (bounds.isValid()) {
+    if (nodesWithPosition.length === 1) {
+      const only = nodesWithPosition[0];
+      map.setView([only.latest_position!.latitude!, only.latest_position!.longitude!], 12);
+    } else if (bounds.isValid()) {
       map.fitBounds(bounds, {
         padding: [50, 50],
         maxZoom: 15,

--- a/src/components/nodes/RfProfileModal.test.tsx
+++ b/src/components/nodes/RfProfileModal.test.tsx
@@ -1,5 +1,5 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest';
-import { render, screen } from '@testing-library/react';
+import { render, screen, waitFor } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
 import type { ReactElement } from 'react';
@@ -85,6 +85,91 @@ describe('RfProfileModal', () => {
     expect(latInput.value).toContain('12.34');
     expect(lngInput.value).toContain('56.78');
     expect(altInput.value).toContain('90');
+  });
+
+  it('closes profile dialog after save and opens re-render confirm when coords changed', async () => {
+    const onOpenChange = vi.fn();
+    const mutateAsync = vi.fn().mockResolvedValue({});
+    useUpdateRfProfile.mockReturnValue({ mutateAsync, isPending: false });
+    useRfProfile.mockReturnValue({
+      data: {
+        antenna_pattern: 'omni',
+        rf_latitude: 1,
+        rf_longitude: 2,
+        rf_altitude_m: 3,
+        rf_frequency_mhz: 868,
+      },
+      isLoading: false,
+    });
+    const client = new QueryClient({ defaultOptions: { queries: { retry: false } } });
+    render(
+      <QueryClientProvider client={client}>
+        <RfProfileModal open node={makeNode()} onOpenChange={onOpenChange} />
+      </QueryClientProvider>
+    );
+    const latInput = screen.getByLabelText(/latitude/i);
+    await userEvent.clear(latInput);
+    await userEvent.type(latInput, '9.5');
+    await userEvent.click(screen.getByRole('button', { name: /^save$/i }));
+    await waitFor(() => expect(mutateAsync).toHaveBeenCalled());
+    expect(onOpenChange).toHaveBeenCalledWith(false);
+    expect(screen.getByRole('heading', { name: /re-render propagation map/i })).toBeInTheDocument();
+  });
+
+  it('does not open re-render confirm when coords unchanged', async () => {
+    const onOpenChange = vi.fn();
+    const mutateAsync = vi.fn().mockResolvedValue({});
+    useUpdateRfProfile.mockReturnValue({ mutateAsync, isPending: false });
+    useRfProfile.mockReturnValue({
+      data: {
+        antenna_pattern: 'omni',
+        rf_latitude: 12.34,
+        rf_longitude: 56.78,
+        rf_altitude_m: 90,
+        rf_frequency_mhz: 868,
+      },
+      isLoading: false,
+    });
+    const client = new QueryClient({ defaultOptions: { queries: { retry: false } } });
+    render(
+      <QueryClientProvider client={client}>
+        <RfProfileModal open node={makeNode()} onOpenChange={onOpenChange} />
+      </QueryClientProvider>
+    );
+    await userEvent.click(screen.getByRole('button', { name: /^save$/i }));
+    await waitFor(() => expect(mutateAsync).toHaveBeenCalled());
+    expect(onOpenChange).toHaveBeenCalledWith(false);
+    expect(screen.queryByRole('heading', { name: /re-render propagation map/i })).not.toBeInTheDocument();
+  });
+
+  it('queues render when confirm Yes is clicked', async () => {
+    const onOpenChange = vi.fn();
+    const mutateAsync = vi.fn().mockResolvedValue({});
+    const recomputeAsync = vi.fn().mockResolvedValue({});
+    useUpdateRfProfile.mockReturnValue({ mutateAsync, isPending: false });
+    useRecomputeRfPropagation.mockReturnValue({ mutateAsync: recomputeAsync, isPending: false });
+    useRfProfile.mockReturnValue({
+      data: {
+        antenna_pattern: 'omni',
+        rf_latitude: 1,
+        rf_longitude: 2,
+        rf_altitude_m: 3,
+        rf_frequency_mhz: 868,
+      },
+      isLoading: false,
+    });
+    const client = new QueryClient({ defaultOptions: { queries: { retry: false } } });
+    render(
+      <QueryClientProvider client={client}>
+        <RfProfileModal open node={makeNode()} onOpenChange={onOpenChange} />
+      </QueryClientProvider>
+    );
+    await userEvent.clear(screen.getByLabelText(/latitude/i));
+    await userEvent.type(screen.getByLabelText(/latitude/i), '9.5');
+    await userEvent.click(screen.getByRole('button', { name: /^save$/i }));
+    await waitFor(() => expect(mutateAsync).toHaveBeenCalled());
+    await userEvent.click(screen.getByRole('button', { name: /yes, queue render/i }));
+    await waitFor(() => expect(recomputeAsync).toHaveBeenCalled());
   });
 
   it('shows frequency band selector and map container (omni-only UI)', async () => {

--- a/src/components/nodes/RfProfileModal.tsx
+++ b/src/components/nodes/RfProfileModal.tsx
@@ -71,12 +71,16 @@ export function RfProfileModal({ open, onOpenChange, node }: RfProfileModalProps
   const [rfLng, setRfLng] = useState('');
   const [rfAlt, setRfAlt] = useState('');
   const [coordSnapshot, setCoordSnapshot] = useState<{ lat: string; lng: string; alt: string } | null>(null);
-  const [showRerenderPrompt, setShowRerenderPrompt] = useState(false);
+  const [confirmRerenderOpen, setConfirmRerenderOpen] = useState(false);
 
   const mapRef = useRef<HTMLDivElement>(null);
   const mapInstanceRef = useRef<L.Map | null>(null);
   const markerRef = useRef<L.Marker | null>(null);
   const tileLayerRef = useRef<L.TileLayer | null>(null);
+
+  useEffect(() => {
+    if (open) setConfirmRerenderOpen(false);
+  }, [open]);
 
   useEffect(() => {
     if (!open || profile === undefined) return;
@@ -102,7 +106,6 @@ export function RfProfileModal({ open, onOpenChange, node }: RfProfileModalProps
     setRfLng(lngS);
     setRfAlt(altS);
     setCoordSnapshot({ lat: latS, lng: lngS, alt: altS });
-    setShowRerenderPrompt(false);
   }, [open, profile]);
 
   const initialCenter = useMemo(() => {
@@ -219,163 +222,189 @@ export function RfProfileModal({ open, onOpenChange, node }: RfProfileModalProps
     try {
       await updateMutation.mutateAsync(buildBody());
       toast.success('RF profile saved');
-      if (coordsChangedVsSnapshot()) {
-        setShowRerenderPrompt(true);
-      } else {
-        onOpenChange(false);
-      }
+      const needsRerender = coordsChangedVsSnapshot();
+      onOpenChange(false);
+      if (needsRerender) setConfirmRerenderOpen(true);
     } catch {
       toast.error('Could not save RF profile.');
     }
   };
 
   return (
-    <Dialog open={open} onOpenChange={onOpenChange}>
-      <DialogContent className="max-h-[90vh] overflow-y-auto sm:max-w-lg">
-        <DialogHeader>
-          <DialogTitle>RF propagation profile</DialogTitle>
-          <DialogDescription>
-            Private map location is visible only to you and staff. Antenna parameters are public on the node page.
-          </DialogDescription>
-        </DialogHeader>
+    <>
+      <Dialog open={open} onOpenChange={onOpenChange}>
+        <DialogContent className="max-h-[90vh] overflow-y-auto sm:max-w-lg">
+          <DialogHeader>
+            <DialogTitle>RF propagation profile</DialogTitle>
+            <DialogDescription>
+              Private map location is visible only to you and staff. Antenna parameters are public on the node page.
+            </DialogDescription>
+          </DialogHeader>
 
-        {isLoading && <p className="text-sm text-muted-foreground">Loading…</p>}
+          {isLoading && <p className="text-sm text-muted-foreground">Loading…</p>}
 
-        {!isLoading && (
-          <div className="space-y-6">
-            <Card>
-              <CardHeader>
-                <CardTitle className="text-base">Private location (only you and staff)</CardTitle>
-                <CardDescription>Used for propagation modelling, not the same as live GPS.</CardDescription>
-              </CardHeader>
-              <div className="space-y-3 px-6 pb-6">
-                <div className="flex flex-wrap gap-2">
-                  <Button type="button" variant="secondary" size="sm" onClick={copyFromGps}>
-                    Copy from GPS
-                  </Button>
-                </div>
-                <div className="grid grid-cols-1 gap-3 sm:grid-cols-3">
-                  <div>
-                    <Label htmlFor="rf-lat">Latitude</Label>
-                    <Input
-                      id="rf-lat"
-                      className={inputSurfaceClass}
-                      value={rfLat}
-                      onChange={(e) => setRfLat(e.target.value)}
-                    />
+          {!isLoading && (
+            <div className="space-y-6">
+              <Card>
+                <CardHeader>
+                  <CardTitle className="text-base">Private location (only you and staff)</CardTitle>
+                  <CardDescription>Used for propagation modelling, not the same as live GPS.</CardDescription>
+                </CardHeader>
+                <div className="space-y-3 px-6 pb-6">
+                  <div className="flex flex-wrap gap-2">
+                    <Button type="button" variant="secondary" size="sm" onClick={copyFromGps}>
+                      Copy from GPS
+                    </Button>
                   </div>
-                  <div>
-                    <Label htmlFor="rf-lng">Longitude</Label>
-                    <Input
-                      id="rf-lng"
-                      className={inputSurfaceClass}
-                      value={rfLng}
-                      onChange={(e) => setRfLng(e.target.value)}
-                    />
+                  <div className="grid grid-cols-1 gap-3 sm:grid-cols-3">
+                    <div>
+                      <Label htmlFor="rf-lat">Latitude</Label>
+                      <Input
+                        id="rf-lat"
+                        type="number"
+                        inputMode="decimal"
+                        step="any"
+                        className={inputSurfaceClass}
+                        value={rfLat}
+                        onChange={(e) => setRfLat(e.target.value)}
+                      />
+                    </div>
+                    <div>
+                      <Label htmlFor="rf-lng">Longitude</Label>
+                      <Input
+                        id="rf-lng"
+                        type="number"
+                        inputMode="decimal"
+                        step="any"
+                        className={inputSurfaceClass}
+                        value={rfLng}
+                        onChange={(e) => setRfLng(e.target.value)}
+                      />
+                    </div>
+                    <div>
+                      <Label htmlFor="rf-alt">Altitude (m)</Label>
+                      <Input
+                        id="rf-alt"
+                        type="number"
+                        inputMode="decimal"
+                        step="any"
+                        className={inputSurfaceClass}
+                        value={rfAlt}
+                        onChange={(e) => setRfAlt(e.target.value)}
+                      />
+                    </div>
                   </div>
-                  <div>
-                    <Label htmlFor="rf-alt">Altitude (m)</Label>
-                    <Input
-                      id="rf-alt"
-                      className={inputSurfaceClass}
-                      value={rfAlt}
-                      onChange={(e) => setRfAlt(e.target.value)}
-                    />
-                  </div>
-                </div>
-                <div
-                  ref={mapRef}
-                  data-testid="rf-profile-map"
-                  className="map-container h-[220px] w-full min-h-[220px] rounded-md border border-slate-300 dark:border-slate-500"
-                  style={{ position: 'relative', zIndex: 0 }}
-                />
-              </div>
-            </Card>
-
-            <Card>
-              <CardHeader>
-                <CardTitle className="text-base">Antenna</CardTitle>
-              </CardHeader>
-              <div className="grid grid-cols-1 gap-3 px-6 pb-6 sm:grid-cols-2">
-                <div>
-                  <Label>Height AGL (m)</Label>
-                  <Input
-                    className={inputSurfaceClass}
-                    value={antennaHeight}
-                    onChange={(e) => setAntennaHeight(e.target.value)}
+                  <div
+                    ref={mapRef}
+                    data-testid="rf-profile-map"
+                    className="map-container h-[220px] w-full min-h-[220px] rounded-md border border-slate-300 dark:border-slate-500"
+                    style={{ position: 'relative', zIndex: 0 }}
                   />
                 </div>
-                <div>
-                  <Label>Gain (dBi)</Label>
-                  <Input
-                    className={inputSurfaceClass}
-                    value={antennaGain}
-                    onChange={(e) => setAntennaGain(e.target.value)}
-                  />
-                </div>
-                <div>
-                  <Label>TX power (dBm)</Label>
-                  <Input className={inputSurfaceClass} value={txPower} onChange={(e) => setTxPower(e.target.value)} />
-                </div>
-                <div className="sm:col-span-2">
-                  <Label htmlFor="rf-frequency-band">Frequency</Label>
-                  <Select
-                    value={freqBand === '' ? FREQ_BAND_UNSET : freqBand}
-                    onValueChange={(v) => setFreqBand(v === FREQ_BAND_UNSET ? '' : v)}
-                  >
-                    <SelectTrigger id="rf-frequency-band" className={inputSurfaceClass}>
-                      <SelectValue placeholder="Select band" />
-                    </SelectTrigger>
-                    <SelectContent>
-                      <SelectItem value={FREQ_BAND_UNSET}>Select band</SelectItem>
-                      {RF_FREQUENCY_BANDS.map((mhz) => (
-                        <SelectItem key={mhz} value={String(mhz)}>
-                          {mhz} MHz
-                        </SelectItem>
-                      ))}
-                    </SelectContent>
-                  </Select>
-                  <p className="mt-1 text-xs text-muted-foreground">ISM bands supported for propagation today.</p>
-                </div>
-              </div>
-            </Card>
+              </Card>
 
-            {showRerenderPrompt && (
-              <div className="rounded-md border bg-muted/40 p-3 text-sm">
-                <p className="mb-2 font-medium">Re-render propagation map now?</p>
-                <div className="flex gap-2">
-                  <Button
-                    type="button"
-                    size="sm"
-                    onClick={() => {
-                      void recomputeMutation.mutateAsync().then(() => {
-                        toast.success('Render queued');
-                        setShowRerenderPrompt(false);
-                        onOpenChange(false);
-                      });
-                    }}
-                    disabled={recomputeMutation.isPending}
-                  >
-                    Yes
-                  </Button>
-                  <Button type="button" size="sm" variant="outline" onClick={() => onOpenChange(false)}>
-                    No
-                  </Button>
+              <Card>
+                <CardHeader>
+                  <CardTitle className="text-base">Antenna</CardTitle>
+                </CardHeader>
+                <div className="grid grid-cols-1 gap-3 px-6 pb-6 sm:grid-cols-2">
+                  <div>
+                    <Label>Height AGL (m)</Label>
+                    <Input
+                      type="number"
+                      inputMode="decimal"
+                      step="any"
+                      className={inputSurfaceClass}
+                      value={antennaHeight}
+                      onChange={(e) => setAntennaHeight(e.target.value)}
+                    />
+                  </div>
+                  <div>
+                    <Label>Gain (dBi)</Label>
+                    <Input
+                      type="number"
+                      inputMode="decimal"
+                      step="any"
+                      className={inputSurfaceClass}
+                      value={antennaGain}
+                      onChange={(e) => setAntennaGain(e.target.value)}
+                    />
+                  </div>
+                  <div>
+                    <Label>TX power (dBm)</Label>
+                    <Input
+                      type="number"
+                      inputMode="decimal"
+                      step="any"
+                      className={inputSurfaceClass}
+                      value={txPower}
+                      onChange={(e) => setTxPower(e.target.value)}
+                    />
+                  </div>
+                  <div className="sm:col-span-2">
+                    <Label htmlFor="rf-frequency-band">Frequency</Label>
+                    <Select
+                      value={freqBand === '' ? FREQ_BAND_UNSET : freqBand}
+                      onValueChange={(v) => setFreqBand(v === FREQ_BAND_UNSET ? '' : v)}
+                    >
+                      <SelectTrigger id="rf-frequency-band" className={inputSurfaceClass}>
+                        <SelectValue placeholder="Select band" />
+                      </SelectTrigger>
+                      <SelectContent>
+                        <SelectItem value={FREQ_BAND_UNSET}>Select band</SelectItem>
+                        {RF_FREQUENCY_BANDS.map((mhz) => (
+                          <SelectItem key={mhz} value={String(mhz)}>
+                            {mhz} MHz
+                          </SelectItem>
+                        ))}
+                      </SelectContent>
+                    </Select>
+                    <p className="mt-1 text-xs text-muted-foreground">ISM bands supported for propagation today.</p>
+                  </div>
                 </div>
-              </div>
-            )}
-          </div>
-        )}
+              </Card>
+            </div>
+          )}
 
-        <DialogFooter>
-          <Button type="button" variant="outline" onClick={() => onOpenChange(false)}>
-            Cancel
-          </Button>
-          <Button type="button" onClick={() => void handleSave()} disabled={updateMutation.isPending || isLoading}>
-            Save
-          </Button>
-        </DialogFooter>
-      </DialogContent>
-    </Dialog>
+          <DialogFooter>
+            <Button type="button" variant="outline" onClick={() => onOpenChange(false)}>
+              Cancel
+            </Button>
+            <Button type="button" onClick={() => void handleSave()} disabled={updateMutation.isPending || isLoading}>
+              Save
+            </Button>
+          </DialogFooter>
+        </DialogContent>
+      </Dialog>
+
+      <Dialog open={confirmRerenderOpen} onOpenChange={setConfirmRerenderOpen}>
+        <DialogContent className="sm:max-w-md">
+          <DialogHeader>
+            <DialogTitle>Re-render propagation map?</DialogTitle>
+            <DialogDescription>
+              You changed the private map location. Queue a new coverage render now, or skip and render later from the
+              node page.
+            </DialogDescription>
+          </DialogHeader>
+          <DialogFooter className="gap-2 sm:gap-0">
+            <Button type="button" variant="outline" onClick={() => setConfirmRerenderOpen(false)}>
+              Not now
+            </Button>
+            <Button
+              type="button"
+              onClick={() => {
+                void recomputeMutation.mutateAsync().then(() => {
+                  toast.success('Render queued');
+                  setConfirmRerenderOpen(false);
+                });
+              }}
+              disabled={recomputeMutation.isPending}
+            >
+              Yes, queue render
+            </Button>
+          </DialogFooter>
+        </DialogContent>
+      </Dialog>
+    </>
   );
 }

--- a/src/components/nodes/RfProfileModal.tsx
+++ b/src/components/nodes/RfProfileModal.tsx
@@ -115,55 +115,104 @@ export function RfProfileModal({ open, onOpenChange, node }: RfProfileModalProps
     return { lat: 55.8642, lng: -4.2518 };
   }, [node.latest_position?.latitude, node.latest_position?.longitude]);
 
-  // Map mounts only after `!isLoading` so `mapRef` exists; tear down fully when dialog closes.
+  const destroyRfMap = () => {
+    markerRef.current?.remove();
+    markerRef.current = null;
+    if (mapInstanceRef.current) {
+      mapInstanceRef.current.remove();
+      mapInstanceRef.current = null;
+    }
+    tileLayerRef.current = null;
+    if (mapRef.current) mapRef.current.innerHTML = '';
+  };
+
+  // Leaflet must not initialize while the dialog container has 0×0 size (Radix zoom animation),
+  // or tiles never paint. Wait for layout via ResizeObserver + invalidateSize after open.
   useEffect(() => {
     if (!open) {
-      markerRef.current?.remove();
-      markerRef.current = null;
-      if (mapInstanceRef.current) {
-        mapInstanceRef.current.remove();
-        mapInstanceRef.current = null;
-      }
-      tileLayerRef.current = null;
-      if (mapRef.current) mapRef.current.innerHTML = '';
+      destroyRfMap();
       return;
     }
     if (isLoading || profile === undefined) return;
+
     const el = mapRef.current;
-    if (!el || mapInstanceRef.current) return;
+    if (!el) return;
 
-    const startLat = profile !== null && profile.rf_latitude != null ? profile.rf_latitude : initialCenter.lat;
-    const startLng = profile !== null && profile.rf_longitude != null ? profile.rf_longitude : initialCenter.lng;
+    let disposed = false;
 
-    const map = L.map(el).setView([startLat, startLng], 13);
-    const tileLayer = L.tileLayer(tileUrl, { attribution }).addTo(map);
-    tileLayerRef.current = tileLayer;
-    const marker = L.marker([startLat, startLng], { draggable: true }).addTo(map);
-    markerRef.current = marker;
-    marker.on('dragend', () => {
-      const p = marker.getLatLng();
-      setRfLat(String(p.lat));
-      setRfLng(String(p.lng));
+    const tryCreateMap = () => {
+      if (disposed || mapInstanceRef.current) return;
+      if (el.clientWidth < 8 || el.clientHeight < 8) return;
+
+      const startLat = profile !== null && profile.rf_latitude != null ? profile.rf_latitude : initialCenter.lat;
+      const startLng = profile !== null && profile.rf_longitude != null ? profile.rf_longitude : initialCenter.lng;
+
+      const map = L.map(el).setView([startLat, startLng], 13);
+      const tileLayer = L.tileLayer(tileUrl, { attribution }).addTo(map);
+      tileLayerRef.current = tileLayer;
+      const marker = L.marker([startLat, startLng], { draggable: true }).addTo(map);
+      markerRef.current = marker;
+      marker.on('dragend', () => {
+        const p = marker.getLatLng();
+        setRfLat(String(p.lat));
+        setRfLng(String(p.lng));
+      });
+      map.on('click', (e) => {
+        marker.setLatLng(e.latlng);
+        setRfLat(String(e.latlng.lat));
+        setRfLng(String(e.latlng.lng));
+      });
+      mapInstanceRef.current = map;
+
+      const bump = () => map.invalidateSize();
+      requestAnimationFrame(() => {
+        bump();
+        requestAnimationFrame(bump);
+      });
+      const timings = window.setTimeout(() => {
+        bump();
+      }, 220);
+      const timings2 = window.setTimeout(() => bump(), 600);
+
+      return () => {
+        window.clearTimeout(timings);
+        window.clearTimeout(timings2);
+      };
+    };
+
+    let timeoutCleanups: (() => void) | undefined;
+
+    const ro = new ResizeObserver(() => {
+      if (disposed) return;
+      const map = mapInstanceRef.current;
+      if (map) {
+        map.invalidateSize();
+      } else {
+        timeoutCleanups?.();
+        timeoutCleanups = tryCreateMap();
+      }
     });
-    map.on('click', (e) => {
-      marker.setLatLng(e.latlng);
-      setRfLat(String(e.latlng.lat));
-      setRfLng(String(e.latlng.lng));
-    });
-    mapInstanceRef.current = map;
+    ro.observe(el);
 
-    const t1 = window.setTimeout(() => map.invalidateSize(), 100);
-    const t2 = window.setTimeout(() => map.invalidateSize(), 400);
+    timeoutCleanups?.();
+    timeoutCleanups = tryCreateMap();
+
+    let pollUntil = 0;
+    const poll = window.setInterval(() => {
+      if (disposed || mapInstanceRef.current || pollUntil++ > 80) {
+        window.clearInterval(poll);
+        return;
+      }
+      timeoutCleanups?.();
+      timeoutCleanups = tryCreateMap();
+    }, 50);
 
     return () => {
-      window.clearTimeout(t1);
-      window.clearTimeout(t2);
-      markerRef.current?.remove();
-      markerRef.current = null;
-      map.remove();
-      mapInstanceRef.current = null;
-      tileLayerRef.current = null;
-      el.innerHTML = '';
+      disposed = true;
+      window.clearInterval(poll);
+      timeoutCleanups?.();
+      ro.disconnect();
+      destroyRfMap();
     };
   }, [open, isLoading, profile, initialCenter.lat, initialCenter.lng, tileUrl, attribution]);
 
@@ -297,8 +346,8 @@ export function RfProfileModal({ open, onOpenChange, node }: RfProfileModalProps
                   <div
                     ref={mapRef}
                     data-testid="rf-profile-map"
-                    className="map-container h-[220px] w-full min-h-[220px] rounded-md border border-slate-300 dark:border-slate-500"
-                    style={{ position: 'relative', zIndex: 0 }}
+                    className="map-container z-0 h-[220px] min-h-[220px] min-w-[200px] w-full rounded-md border border-slate-300 dark:border-slate-500"
+                    style={{ position: 'relative', isolation: 'isolate' }}
                   />
                 </div>
               </Card>

--- a/src/components/nodes/RfPropagationSection.test.tsx
+++ b/src/components/nodes/RfPropagationSection.test.tsx
@@ -136,7 +136,7 @@ describe('RfPropagationSection', () => {
     expect(screen.queryByRole('button', { name: /^dismiss$/i })).not.toBeInTheDocument();
   });
 
-  it('renders Leaflet container when render is ready and node flags allow map', () => {
+  it('renders Leaflet container when render is ready (without has_ready_rf_render on node)', () => {
     useRfProfile.mockReturnValue({
       data: { antenna_pattern: 'omni' },
       isLoading: false,
@@ -152,7 +152,11 @@ describe('RfPropagationSection', () => {
     });
     renderWithClient(
       <RfPropagationSection
-        node={makeNode({ rf_profile_editable: true, has_rf_profile: true, has_ready_rf_render: true })}
+        node={makeNode({
+          rf_profile_editable: true,
+          has_rf_profile: true,
+          has_ready_rf_render: false,
+        })}
       />
     );
     expect(document.querySelector('.leaflet-container')).not.toBeNull();

--- a/src/components/nodes/RfPropagationSection.tsx
+++ b/src/components/nodes/RfPropagationSection.tsx
@@ -15,9 +15,11 @@ import { RfPropagationMap } from '@/components/nodes/RfPropagationMap';
 
 export interface RfPropagationSectionProps {
   node: ObservedNode;
+  /** Outer wrapper classes (default `mb-6`). Use `mb-0` when nested in a layout grid. */
+  className?: string;
 }
 
-export function RfPropagationSection({ node }: RfPropagationSectionProps) {
+export function RfPropagationSection({ node, className = 'mb-6' }: RfPropagationSectionProps) {
   const nodeId = node.node_id;
   const canEdit = node.rf_profile_editable === true;
   const hasProfile = node.has_rf_profile === true;
@@ -33,12 +35,11 @@ export function RfPropagationSection({ node }: RfPropagationSectionProps) {
     return null;
   }
 
-  const canSeeMap = node.has_ready_rf_render === true;
   const readyRow =
     propagation && !isRfPropagationNone(propagation) && propagation.status === 'ready' ? propagation : null;
 
   return (
-    <div className="mb-6">
+    <div className={className}>
       <Card>
         <CardHeader className="flex flex-row flex-wrap items-center justify-between gap-4">
           <div>
@@ -173,7 +174,7 @@ export function RfPropagationSection({ node }: RfPropagationSectionProps) {
             </div>
           )}
 
-          {!propLoading && canSeeMap && readyRow?.asset_url && readyRow.bounds && (
+          {!propLoading && readyRow?.asset_url && readyRow.bounds && (
             <RfPropagationMap assetUrl={readyRow.asset_url} bounds={readyRow.bounds} minHeight={300} />
           )}
         </CardContent>


### PR DESCRIPTION
# Summary

Addresses meshtastic-bot-ui#185:

- Show coverage map as soon as propagation poll returns `ready` (no `has_ready_rf_render` gate).
- Place RF propagation section in a 2-column grid beside Node Location on infrastructure node details (non-compact).
- Single-node `NodesMap` uses zoom 12 instead of `fitBounds` max zoom.
- RF profile modal always closes on successful save; optional re-render confirmation in a follow-up dialog.
- Numeric inputs for coords and antenna fields (`type="number"`, `inputMode="decimal"`, `step="any"`).

Paired API PR for transparent PNG overlay: pskillen/meshflow-api#189 (meshflow-api#188).

## Testing performed

- `npm run format` / `npm run lint` / `npm run test` (90 tests)

Closes #185