### PR TITLE
feat(nodes): tabbed details, RF map maximise, stale times, traceroute fix

### DIFF
--- a/.cursorignore
+++ b/.cursorignore
@@ -1,0 +1,45 @@
+# Dependencies
+node_modules/
+
+# Package manager caches (omit installed trees / store blobs)
+.npm/
+.pnpm-store/
+.yarn/cache/
+.yarn/unplugged/
+.yarn/build-state.yml
+.yarn/install-state.gz
+
+# Bundler / transpiler output
+dist/
+dist-ssr/
+build/
+out/
+.vite/
+.parcel-cache/
+.turbo/
+*.tsbuildinfo
+
+# Test & browser runner output
+coverage/
+playwright-report/
+test-results/
+blob-report/
+reports/
+.vitest/
+
+# Logs
+logs/
+*.log
+npm-debug.log*
+yarn-debug.log*
+yarn-error.log*
+pnpm-debug.log*
+lerna-debug.log*
+
+# Tooling caches
+.eslintcache
+.stylelintcache
+*.local
+
+# Local scratch
+tmp/

--- a/src/components/map/DeckMapboxMap.tsx
+++ b/src/components/map/DeckMapboxMap.tsx
@@ -10,16 +10,8 @@ import { useConfig } from '@/providers/ConfigProvider';
 import { useMapboxStyle } from '@/hooks/useMapboxStyle';
 import { cn } from '@/lib/utils';
 
-/**
- * react-map-gl allows `bounds` + `fitBoundsOptions` on initial view state; DeckGL's typings
- * only list lon/lat/zoom. The Map child still applies bounds correctly at runtime.
- */
-export type DeckMapboxInitialViewState =
-  | NonNullable<DeckGLProps['initialViewState']>
-  | {
-      bounds: [number, number, number, number];
-      fitBoundsOptions?: { padding?: number; maxZoom?: number; minZoom?: number };
-    };
+/** DeckGL `initialViewState` (longitude, latitude, zoom, etc.). */
+export type DeckMapboxInitialViewState = NonNullable<DeckGLProps['initialViewState']>;
 
 export type DeckMapboxMapProps = {
   layers: Layer[];
@@ -62,7 +54,7 @@ export function DeckMapboxMap({
       <DeckGL
         controller
         layers={layers}
-        initialViewState={initialViewState as DeckGLProps['initialViewState']}
+        initialViewState={initialViewState}
         onClick={onClick}
         getTooltip={getTooltip}
         style={{ width: '100%', height: '100%', minHeight: '200px', minWidth: '0' }}

--- a/src/components/nodes/MetricsCard.tsx
+++ b/src/components/nodes/MetricsCard.tsx
@@ -1,6 +1,6 @@
 import type { ReactNode } from 'react';
-import { formatDistanceToNow } from 'date-fns';
 import { Card, CardContent, CardDescription, CardHeader, CardTitle } from '@/components/ui/card';
+import { StaleReportedTime } from '@/components/nodes/StaleReportedTime';
 
 export interface MetricItem {
   label: string;
@@ -31,7 +31,7 @@ export function MetricsCard({ title, reportedTime, metrics, headerActions }: Met
         <div className="min-w-0 flex-1 space-y-1.5">
           <CardTitle>{title}</CardTitle>
           <CardDescription>
-            {reportedTime ? formatDistanceToNow(new Date(reportedTime), { addSuffix: true }) : '—'}
+            <StaleReportedTime at={reportedTime} />
           </CardDescription>
         </div>
         {headerActions ? <div className="shrink-0 pt-0.5">{headerActions}</div> : null}

--- a/src/components/nodes/NodeDetailContent.tabs.test.tsx
+++ b/src/components/nodes/NodeDetailContent.tabs.test.tsx
@@ -1,0 +1,144 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { Suspense } from 'react';
+import { MemoryRouter, Route, Routes, useLocation, useParams } from 'react-router-dom';
+import type { ObservedNode } from '@/lib/models';
+import { useNodeDetailPageTabs } from '@/pages/nodes/useNodeDetailPageTabs';
+import { NodeDetailContent } from './NodeDetailContent';
+
+vi.mock('@/components/nodes/NodesMap', () => ({
+  NodesMap: () => <div data-testid="nodes-map" />,
+}));
+
+vi.mock('@/components/nodes/RfPropagationSection', () => ({
+  RfPropagationSection: () => <div data-testid="rf-propagation" />,
+}));
+
+vi.mock('@/components/nodes/NodeStatsSection', () => ({
+  NodeStatsSection: () => <div data-testid="node-stats-mock">Node Statistics</div>,
+}));
+
+vi.mock('@/components/nodes/NodeMeshMonitoringSection', () => ({
+  NodeMeshMonitoringSection: () => <div data-testid="mesh-monitoring-mock">Mesh monitoring</div>,
+}));
+
+vi.mock('@/components/nodes/NodeTracerouteHistorySection', () => ({
+  NodeTracerouteHistorySection: () => <div data-testid="traceroute-history-mock">Traceroutes to this node</div>,
+}));
+
+vi.mock('@/hooks/api/useNodeTracerouteLinks', () => ({
+  useNodeTracerouteLinks: () => ({
+    data: { edges: [], nodes: [], snr_history: [] },
+    isLoading: false,
+    error: null,
+  }),
+}));
+
+vi.mock('@/hooks/api/useNodes', () => ({
+  useNodeSuspense: vi.fn(),
+  useManagedNodesSuspense: vi.fn(),
+}));
+
+vi.mock('@/hooks/useRecentNodes', () => ({
+  useRecentNodes: () => ({ recentNodes: [], addRecentNode: vi.fn() }),
+}));
+
+vi.mock('@/lib/auth/authService', () => ({
+  authService: {
+    getCurrentUser: () => ({ id: 1, username: 'tester' }),
+  },
+}));
+
+import { useNodeSuspense, useManagedNodesSuspense } from '@/hooks/api/useNodes';
+
+const mockedUseNodeSuspense = vi.mocked(useNodeSuspense);
+const mockedUseManagedNodesSuspense = vi.mocked(useManagedNodesSuspense);
+
+const minimalNode: ObservedNode = {
+  internal_id: 1,
+  node_id: 100,
+  node_id_str: '!00000064',
+  mac_addr: null,
+  long_name: 'Long Name',
+  short_name: 'SN',
+  hw_model: 'TBEAM',
+  public_key: null,
+  role: null,
+  claim: null,
+  owner: null,
+  last_heard: null,
+  latest_position: null,
+  latest_device_metrics: null,
+  latest_environment_metrics: null,
+  latest_power_metrics: null,
+  environment_settings_editable: false,
+  environment_exposure: undefined,
+  weather_use: undefined,
+};
+
+function NodeDetailTabbedPage() {
+  const { id } = useParams<{ id: string }>();
+  const nodeId = parseInt(id || '0', 10);
+  const { activeTab, onTabChange } = useNodeDetailPageTabs();
+  return (
+    <Suspense fallback={null}>
+      <NodeDetailContent nodeId={nodeId} activeTab={activeTab} onTabChange={onTabChange} />
+    </Suspense>
+  );
+}
+
+function PageWithSearchEcho() {
+  const { search } = useLocation();
+  return (
+    <>
+      <span data-testid="url-search">{search}</span>
+      <NodeDetailTabbedPage />
+    </>
+  );
+}
+
+describe('NodeDetailContent tabbed layout', () => {
+  beforeEach(() => {
+    mockedUseNodeSuspense.mockReturnValue(minimalNode);
+    mockedUseManagedNodesSuspense.mockReturnValue({
+      managedNodes: [],
+      totalManagedNodes: 0,
+      fetchNextPage: vi.fn(),
+      hasNextPage: false,
+    });
+  });
+
+  it('shows statistics panel when URL has tab=statistics', () => {
+    render(
+      <MemoryRouter initialEntries={['/nodes/100?tab=statistics']}>
+        <Routes>
+          <Route path="/nodes/:id" element={<PageWithSearchEcho />} />
+        </Routes>
+      </MemoryRouter>
+    );
+    expect(screen.getByTestId('node-detail-panel-statistics')).toBeInTheDocument();
+    expect(screen.getByTestId('node-stats-mock')).toBeInTheDocument();
+    expect(screen.queryByTestId('node-detail-panel-overview')).not.toBeInTheDocument();
+  });
+
+  it('switching tab updates the URL', async () => {
+    const user = userEvent.setup();
+    render(
+      <MemoryRouter initialEntries={['/nodes/100']}>
+        <Routes>
+          <Route path="/nodes/:id" element={<PageWithSearchEcho />} />
+        </Routes>
+      </MemoryRouter>
+    );
+    expect(screen.getByTestId('node-detail-panel-overview')).toBeInTheDocument();
+    expect(screen.getByTestId('url-search')).toHaveTextContent('');
+
+    await user.click(screen.getByTestId('node-detail-tab-statistics'));
+    expect(screen.getByTestId('url-search')).toHaveTextContent('?tab=statistics');
+    expect(screen.getByTestId('node-stats-mock')).toBeInTheDocument();
+
+    await user.click(screen.getByTestId('node-detail-tab-overview'));
+    expect(screen.getByTestId('url-search')).toHaveTextContent('');
+  });
+});

--- a/src/components/nodes/NodeDetailContent.tsx
+++ b/src/components/nodes/NodeDetailContent.tsx
@@ -20,18 +20,23 @@ import { Badge } from '@/components/ui/badge';
 import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from '@/components/ui/select';
 import { authService } from '@/lib/auth/authService';
 import { getRoleLabel, INFRASTRUCTURE_ROLE_IDS } from '@/lib/meshtastic';
-import type { EnvironmentExposureSlug, LatestEnvironmentMetrics, WeatherUseSlug } from '@/lib/models';
+import type { EnvironmentExposureSlug, LatestEnvironmentMetrics, ObservedNode, WeatherUseSlug } from '@/lib/models';
 import { NodeEnvironmentSettingsDialog } from '@/components/nodes/NodeEnvironmentSettingsDialog';
 import { NodeMeshMonitoringSection } from '@/components/nodes/NodeMeshMonitoringSection';
 import { NodeTracerouteHistorySection } from '@/components/nodes/NodeTracerouteHistorySection';
 import { RfPropagationSection } from '@/components/nodes/RfPropagationSection';
 import { Tooltip, TooltipContent, TooltipProvider, TooltipTrigger } from '@/components/ui/tooltip';
 import { STRATEGY_META, type TracerouteStrategyValue } from '@/lib/traceroute-strategy';
+import { Tabs, TabsList, TabsTrigger } from '@/components/ui/tabs';
+import type { NodeDetailTab } from '@/lib/node-detail-tab';
 
 interface NodeDetailContentProps {
   nodeId: number;
   /** When true, hide the "Back to Nodes" link (e.g. when shown in slide-over) */
   compact?: boolean;
+  /** Full page only — from `NodeDetails` reading `?tab=` */
+  activeTab?: NodeDetailTab;
+  onTabChange?: (tab: NodeDetailTab) => void;
 }
 
 type TracerouteTimeRange = '24h' | '7d' | '30d';
@@ -56,6 +61,93 @@ function hasEnvironmentSensorMetrics(env: LatestEnvironmentMetrics | null | unde
     const v = env[k];
     return v != null;
   });
+}
+
+function NodeLocationCard({
+  node,
+  nodeId,
+  compact,
+  mapTabLink,
+}: {
+  node: ObservedNode;
+  nodeId: number;
+  compact: boolean;
+  mapTabLink?: boolean;
+}) {
+  const pos = node.latest_position;
+  const hasPositions =
+    pos &&
+    typeof pos.latitude === 'number' &&
+    pos.latitude !== 0 &&
+    typeof pos.longitude === 'number' &&
+    pos.longitude !== 0;
+
+  return (
+    <Card data-testid="node-detail-location-card">
+      <CardHeader>
+        <div className="flex flex-wrap items-start justify-between gap-2">
+          <div className="min-w-0 flex-1">
+            <CardTitle>Node Location</CardTitle>
+            {hasPositions ? (
+              <CardDescription>
+                GPS position broadcast by the node — last reported{' '}
+                {pos?.reported_time ? formatDistanceToNow(pos.reported_time, { addSuffix: true }) : '—'}
+              </CardDescription>
+            ) : (
+              <CardDescription>
+                No GPS position data. A node can be active (Last Heard) without broadcasting its location.
+              </CardDescription>
+            )}
+          </div>
+          {mapTabLink && (
+            <Link
+              to={`/nodes/${nodeId}?tab=map`}
+              className="shrink-0 text-sm text-teal-600 underline-offset-4 hover:underline dark:text-teal-400"
+              data-testid="node-detail-map-tab-link"
+            >
+              Open map view
+            </Link>
+          )}
+        </div>
+      </CardHeader>
+      <CardContent>
+        {hasPositions && pos ? (
+          <>
+            <div className="mb-2 flex flex-wrap items-end gap-4 md:flex-nowrap">
+              <div className="flex flex-col items-start">
+                <span className="text-xs font-medium uppercase tracking-wide text-muted-foreground">Lat</span>
+                <span className="font-mono text-base">{pos.latitude!.toFixed(6)}°</span>
+              </div>
+              <span className="mx-2 hidden h-6 border-l border-slate-200 dark:border-slate-700 md:inline-block"></span>
+              <div className="flex flex-col items-start">
+                <span className="text-xs font-medium uppercase tracking-wide text-muted-foreground">Long</span>
+                <span className="font-mono text-base">{pos.longitude!.toFixed(6)}°</span>
+              </div>
+              <span className="mx-2 hidden h-6 border-l border-slate-200 dark:border-slate-700 md:inline-block"></span>
+              <div className="flex flex-col items-start">
+                <span className="text-xs font-medium uppercase tracking-wide text-muted-foreground">Alt</span>
+                <span className="font-mono text-base">
+                  {pos.altitude != null ? `${pos.altitude.toFixed(1)}m` : '—'}
+                </span>
+              </div>
+              {pos.location_source && (
+                <span className="ml-4 rounded border border-slate-200 bg-muted px-2 py-0.5 text-xs text-muted-foreground dark:border-slate-700">
+                  {pos.location_source}
+                </span>
+              )}
+            </div>
+            <div className={`w-full ${compact ? 'h-[200px]' : 'h-[400px]'}`}>
+              <NodesMap nodes={[node]} />
+            </div>
+          </>
+        ) : (
+          <div className="flex h-[200px] w-full items-center justify-center rounded-md bg-muted">
+            <p className="text-muted-foreground">No location data available</p>
+          </div>
+        )}
+      </CardContent>
+    </Card>
+  );
 }
 
 function TracerouteLinksSection({ nodeId, isManagedNode }: { nodeId: number; isManagedNode: boolean }) {
@@ -107,19 +199,19 @@ function TracerouteLinksSection({ nodeId, isManagedNode }: { nodeId: number; isM
         </CardHeader>
         <CardContent>
           {error && (
-            <div className="flex min-h-[200px] items-center justify-center text-destructive text-sm">
+            <div className="flex min-h-[200px] items-center justify-center text-sm text-destructive">
               Failed to load traceroute links: {error instanceof Error ? error.message : 'Unknown error'}
             </div>
           )}
           {isLoading && (
             <div className="flex min-h-[300px] items-center justify-center text-muted-foreground">
-              <div className="animate-spin rounded-full h-8 w-8 border-t-2 border-b-2 border-teal-500" />
+              <div className="h-8 w-8 animate-spin rounded-full border-b-2 border-t-2 border-teal-500" />
             </div>
           )}
           {!error && !isLoading && !hasData && (
             <div className="flex min-h-[200px] flex-col items-center justify-center gap-2 text-muted-foreground">
               <p>No traceroute data for this node</p>
-              <Link to="/traceroutes/map/heat" className="text-sm text-teal-600 dark:text-teal-400 hover:underline">
+              <Link to="/traceroutes/map/heat" className="text-sm text-teal-600 hover:underline dark:text-teal-400">
                 View Traceroute Heatmap
               </Link>
             </div>
@@ -148,7 +240,7 @@ function TracerouteLinksSection({ nodeId, isManagedNode }: { nodeId: number; isM
   );
 }
 
-export function NodeDetailContent({ nodeId, compact = false }: NodeDetailContentProps) {
+export function NodeDetailContent({ nodeId, compact = false, activeTab, onTabChange }: NodeDetailContentProps) {
   const node = useNodeSuspense(nodeId);
   const { recentNodes, addRecentNode } = useRecentNodes();
   const [settingsOpen, setSettingsOpen] = useState(false);
@@ -171,31 +263,271 @@ export function NodeDetailContent({ nodeId, compact = false }: NodeDetailContent
     }
   }, [nodeId, addRecentNode, node]);
 
-  const pos = node.latest_position;
-  const hasPositions =
-    pos &&
-    typeof pos.latitude === 'number' &&
-    pos.latitude !== 0 &&
-    typeof pos.longitude === 'number' &&
-    pos.longitude !== 0;
-
   const currentUser = authService.getCurrentUser();
   const roleLabel = getRoleLabel(node.role);
   const hasPendingClaim = node.claim && !node.claim.accepted_at;
   const hasApprovedClaim =
     (node.claim && node.claim.accepted_at) || (node.owner && currentUser && node.owner.id === currentUser.id);
 
-  const showRfPropagationBesideLocation = !compact && node.role != null && INFRASTRUCTURE_ROLE_IDS.has(node.role);
+  const fullPageTabs = !compact && activeTab !== undefined && onTabChange !== undefined;
+  const showRfPropagation = !compact && node.role != null && INFRASTRUCTURE_ROLE_IDS.has(node.role);
+
+  useEffect(() => {
+    if (fullPageTabs && activeTab === 'monitoring' && !currentUser) {
+      onTabChange('overview');
+    }
+  }, [fullPageTabs, activeTab, currentUser, onTabChange]);
+
+  const effectiveTab: NodeDetailTab =
+    fullPageTabs && activeTab === 'monitoring' && !currentUser ? 'overview' : (activeTab ?? 'overview');
+
+  const showMonitoringTab = Boolean(currentUser);
+
+  const renderFeederGeoCard = () =>
+    managedForThisNode?.geo_classification ? (
+      <Card className="mb-6" data-testid="node-detail-feeder-geo">
+        <CardHeader>
+          <CardTitle>Traceroute feeder classification</CardTitle>
+          <CardDescription>
+            Geometry vs constellation envelope — drives which automated target strategies apply.
+          </CardDescription>
+        </CardHeader>
+        <CardContent>
+          <div className="flex flex-wrap items-center gap-2">
+            <Badge variant="outline">
+              {managedForThisNode.geo_classification.tier === 'perimeter'
+                ? `Perimeter${
+                    managedForThisNode.geo_classification.bearing_octant
+                      ? ` (${managedForThisNode.geo_classification.bearing_octant})`
+                      : ''
+                  }`
+                : 'Internal'}
+            </Badge>
+            <TooltipProvider delayDuration={200}>
+              {managedForThisNode.geo_classification.applicable_strategies.map((s) => (
+                <Tooltip key={s}>
+                  <TooltipTrigger asChild>
+                    <Badge variant="secondary" className="cursor-help">
+                      {STRATEGY_META[s as TracerouteStrategyValue]?.label ?? s}
+                    </Badge>
+                  </TooltipTrigger>
+                  <TooltipContent side="top" className="max-w-xs text-sm">
+                    {STRATEGY_META[s as TracerouteStrategyValue]?.shortDescription ?? s}
+                  </TooltipContent>
+                </Tooltip>
+              ))}
+            </TooltipProvider>
+          </div>
+        </CardContent>
+      </Card>
+    ) : null;
+
+  const renderMetricsGrid = () => (
+    <div className={`mb-6 grid grid-cols-1 ${compact ? 'gap-4' : 'gap-6 md:grid-cols-2'}`}>
+      <Card>
+        <CardHeader>
+          <CardTitle>Basic Information</CardTitle>
+          <CardDescription>Static node details</CardDescription>
+        </CardHeader>
+        <CardContent>
+          <div className="space-y-2">
+            <p>
+              <span className="font-medium">Node ID:</span> <span className="font-mono">{node.node_id_str}</span>
+            </p>
+            <p>
+              <span className="font-medium">Hardware Model:</span> {node.hw_model ?? '—'}
+            </p>
+            {roleLabel && (
+              <p>
+                <span className="font-medium">Role:</span> {roleLabel}
+              </p>
+            )}
+            {node.mac_addr && (
+              <p>
+                <span className="font-medium">MAC Address:</span> <span className="font-mono">{node.mac_addr}</span>
+              </p>
+            )}
+            {node.public_key && (
+              <p className="flex flex-wrap items-center gap-2">
+                <span className="shrink-0 font-medium">Public Key:</span>
+                <span className="break-all font-mono text-sm">{node.public_key}</span>
+                <Button
+                  variant="ghost"
+                  size="sm"
+                  className="h-7 shrink-0 px-2"
+                  onClick={() => handleCopyToClipboard(node.public_key!)}
+                  title="Copy public key"
+                >
+                  <Copy className="mr-1 h-3 w-3" />
+                  Copy
+                </Button>
+              </p>
+            )}
+            {(node.is_licensed === true || node.is_licensed === false) && (
+              <p>
+                <span className="font-medium">Licensed Operator:</span> {node.is_licensed ? 'Yes' : 'No'}
+              </p>
+            )}
+            {(node.is_unmessagable === true || node.is_unmessagable === false) && (
+              <p>
+                <span className="font-medium">Messagable:</span> {node.is_unmessagable ? 'No' : 'Yes'}
+              </p>
+            )}
+            <p>
+              <span className="font-medium">Last Heard:</span>{' '}
+              {node.last_heard ? formatDistanceToNow(node.last_heard, { addSuffix: true }) : 'Never'}
+              <span className="mt-0.5 block text-xs text-muted-foreground">
+                Last time any packet was received from this node (telemetry, messages, etc.)
+              </span>
+            </p>
+            {node.inferred_max_hops != null && (
+              <p>
+                <span className="font-medium">Inferred Max Hops:</span> {node.inferred_max_hops}
+                <span className="mt-0.5 block text-xs text-muted-foreground">
+                  Inferred from packets; recommended is 7
+                </span>
+              </p>
+            )}
+          </div>
+        </CardContent>
+      </Card>
+
+      {node.latest_device_metrics && (
+        <Card>
+          <CardHeader>
+            <div>
+              <CardTitle>Device Metrics</CardTitle>
+              <CardDescription>
+                Battery, voltage, channel utilisation — last reported{' '}
+                {node.latest_device_metrics.reported_time
+                  ? formatDistanceToNow(node.latest_device_metrics.reported_time, { addSuffix: true })
+                  : '—'}
+              </CardDescription>
+            </div>
+          </CardHeader>
+          <CardContent>
+            <div className="space-y-4">
+              <BatteryGauge
+                batteryLevel={node.latest_device_metrics.battery_level ?? null}
+                voltage={node.latest_device_metrics.voltage ?? null}
+              />
+              <PercentGauge
+                value={node.latest_device_metrics.channel_utilization ?? null}
+                label="Channel Utilization"
+              />
+              <PercentGauge value={node.latest_device_metrics.air_util_tx ?? null} label="Air Utilization" />
+              <p>
+                <span className="font-medium">Uptime:</span>{' '}
+                {node.latest_device_metrics.uptime_seconds != null
+                  ? formatUptimeSeconds(node.latest_device_metrics.uptime_seconds)
+                  : '—'}
+              </p>
+            </div>
+          </CardContent>
+        </Card>
+      )}
+
+      {hasEnvironmentSensorMetrics(node.latest_environment_metrics) && (
+        <>
+          <MetricsCard
+            title="Environment Metrics"
+            reportedTime={node.latest_environment_metrics?.reported_time}
+            headerActions={
+              node.environment_settings_editable ? (
+                <Button
+                  type="button"
+                  variant="outline"
+                  size="icon"
+                  aria-label="Environment metrics settings"
+                  onClick={() => setSettingsOpen(true)}
+                >
+                  <Settings className="h-4 w-4" />
+                </Button>
+              ) : undefined
+            }
+            metrics={[
+              { label: 'Sensor placement', value: node.environment_exposure },
+              { label: 'Use for weather', value: node.weather_use },
+              ...(node.latest_environment_metrics
+                ? [
+                    { label: 'Temperature', value: node.latest_environment_metrics.temperature, unit: '°C' },
+                    {
+                      label: 'Relative Humidity',
+                      value: node.latest_environment_metrics.relative_humidity,
+                      unit: '%',
+                    },
+                    {
+                      label: 'Barometric Pressure',
+                      value: node.latest_environment_metrics.barometric_pressure,
+                      unit: 'hPa',
+                    },
+                    { label: 'Gas Resistance', value: node.latest_environment_metrics.gas_resistance, unit: 'Ω' },
+                    { label: 'IAQ', value: node.latest_environment_metrics.iaq },
+                    { label: 'Lux', value: node.latest_environment_metrics.lux, unit: 'lx' },
+                    { label: 'Wind Direction', value: node.latest_environment_metrics.wind_direction, unit: '°' },
+                    { label: 'Wind Speed', value: node.latest_environment_metrics.wind_speed, unit: 'm/s' },
+                    { label: 'Radiation', value: node.latest_environment_metrics.radiation },
+                    { label: 'Rainfall 1h', value: node.latest_environment_metrics.rainfall_1h, unit: 'mm' },
+                    { label: 'Rainfall 24h', value: node.latest_environment_metrics.rainfall_24h, unit: 'mm' },
+                  ]
+                : []),
+            ]}
+          />
+          {node.environment_settings_editable && (
+            <NodeEnvironmentSettingsDialog
+              open={settingsOpen}
+              onOpenChange={setSettingsOpen}
+              nodeId={nodeId}
+              initialEnvironmentExposure={(node.environment_exposure ?? 'unknown') as EnvironmentExposureSlug}
+              initialWeatherUse={(node.weather_use ?? 'unknown') as WeatherUseSlug}
+            />
+          )}
+        </>
+      )}
+
+      {node.latest_power_metrics &&
+        (() => {
+          const pm = node.latest_power_metrics;
+          const channelMetrics = [1, 2, 3, 4, 5, 6, 7, 8]
+            .map((n) => {
+              const v = (pm as Record<string, number | null | undefined>)[`ch${n}_voltage`];
+              const c = (pm as Record<string, number | null | undefined>)[`ch${n}_current`];
+              if (v != null || c != null) {
+                const parts = [];
+                if (v != null) parts.push(`${v.toFixed(2)}V`);
+                if (c != null) parts.push(`${c.toFixed(2)}A`);
+                return { label: `Ch${n}`, value: parts.join(' / ') };
+              }
+              return null;
+            })
+            .filter(Boolean) as { label: string; value: string }[];
+          return channelMetrics.length > 0 ? (
+            <MetricsCard
+              title="Power Metrics"
+              reportedTime={node.latest_power_metrics.reported_time}
+              metrics={channelMetrics}
+            />
+          ) : null;
+        })()}
+    </div>
+  );
+
+  const renderLegacyLocationBlock = () => (
+    <div className={showRfPropagation ? 'mb-6 grid grid-cols-1 gap-6 lg:grid-cols-2' : 'mb-6'}>
+      <NodeLocationCard node={node} nodeId={nodeId} compact={compact} />
+      {showRfPropagation ? <RfPropagationSection node={node} className="mb-0" /> : null}
+    </div>
+  );
 
   return (
     <div className={compact ? 'px-2' : 'container mx-auto px-4 py-8'}>
       {!compact && (
-        <Link to="/nodes" replace={true} className="text-teal-600 dark:text-teal-400 hover:underline mb-4 inline-block">
+        <Link to="/nodes" replace={true} className="mb-4 inline-block text-teal-600 hover:underline dark:text-teal-400">
           ← Back to Nodes
         </Link>
       )}
 
-      <div className={`flex justify-between items-start ${compact ? 'mb-4' : 'mb-6'}`}>
+      <div className={`flex items-start justify-between ${compact ? 'mb-4' : 'mb-6'}`}>
         <div>
           <h1 className={`font-bold ${compact ? 'text-xl' : 'text-3xl'}`}>{node.short_name}</h1>
           <p className="text-slate-600 dark:text-slate-400">{node.long_name}</p>
@@ -222,11 +554,11 @@ export function NodeDetailContent({ nodeId, compact = false }: NodeDetailContent
             </div>
           )}
         </div>
-        <div className="flex flex-shrink-0 items-start gap-2">
+        <div className="flex shrink-0 items-start gap-2">
           {(!node.owner || hasPendingClaim) && (
             <Link
               to={`/nodes/${nodeId}/claim`}
-              className="px-4 py-2 bg-teal-600 dark:bg-teal-500 text-white rounded-md hover:bg-teal-700 dark:hover:bg-teal-600 transition-colors text-sm whitespace-nowrap"
+              className="whitespace-nowrap rounded-md bg-teal-600 px-4 py-2 text-sm text-white transition-colors hover:bg-teal-700 dark:bg-teal-500 dark:hover:bg-teal-600"
             >
               {hasPendingClaim ? 'View Claim' : 'Claim Node'}
             </Link>
@@ -236,7 +568,7 @@ export function NodeDetailContent({ nodeId, compact = false }: NodeDetailContent
 
       {!compact && recentNodes.length > 1 && (
         <div className="mb-6">
-          <div className="text-sm text-slate-500 dark:text-slate-400 mb-2">Recently viewed:</div>
+          <div className="mb-2 text-sm text-slate-500 dark:text-slate-400">Recently viewed:</div>
           <div className="flex flex-wrap gap-2">
             {recentNodes
               .filter((recentNode) => recentNode.node_id !== nodeId)
@@ -245,7 +577,7 @@ export function NodeDetailContent({ nodeId, compact = false }: NodeDetailContent
                   key={recentNode.node_id}
                   to={`/nodes/${recentNode.node_id}`}
                   replace={true}
-                  className="px-3 py-1 bg-slate-100 dark:bg-slate-800 hover:bg-slate-200 dark:hover:bg-slate-700 text-teal-600 dark:text-teal-400 rounded-full text-sm"
+                  className="rounded-full bg-slate-100 px-3 py-1 text-sm text-teal-600 hover:bg-slate-200 dark:bg-slate-800 dark:text-teal-400 dark:hover:bg-slate-700"
                 >
                   {recentNode.short_name}
                 </Link>
@@ -254,308 +586,110 @@ export function NodeDetailContent({ nodeId, compact = false }: NodeDetailContent
         </div>
       )}
 
-      {managedForThisNode?.geo_classification && (
-        <Card className="mb-6" data-testid="node-detail-feeder-geo">
-          <CardHeader>
-            <CardTitle>Traceroute feeder classification</CardTitle>
-            <CardDescription>
-              Geometry vs constellation envelope — drives which automated target strategies apply.
-            </CardDescription>
-          </CardHeader>
-          <CardContent>
-            <div className="flex flex-wrap gap-2 items-center">
-              <Badge variant="outline">
-                {managedForThisNode.geo_classification.tier === 'perimeter'
-                  ? `Perimeter${
-                      managedForThisNode.geo_classification.bearing_octant
-                        ? ` (${managedForThisNode.geo_classification.bearing_octant})`
-                        : ''
-                    }`
-                  : 'Internal'}
-              </Badge>
-              <TooltipProvider delayDuration={200}>
-                {managedForThisNode.geo_classification.applicable_strategies.map((s) => (
-                  <Tooltip key={s}>
-                    <TooltipTrigger asChild>
-                      <Badge variant="secondary" className="cursor-help">
-                        {STRATEGY_META[s as TracerouteStrategyValue]?.label ?? s}
-                      </Badge>
-                    </TooltipTrigger>
-                    <TooltipContent side="top" className="max-w-xs text-sm">
-                      {STRATEGY_META[s as TracerouteStrategyValue]?.shortDescription ?? s}
-                    </TooltipContent>
-                  </Tooltip>
-                ))}
-              </TooltipProvider>
-            </div>
-          </CardContent>
-        </Card>
-      )}
-
-      <div className={`grid grid-cols-1 ${compact ? 'gap-4' : 'md:grid-cols-2 gap-6'} mb-6`}>
-        <Card>
-          <CardHeader>
-            <CardTitle>Basic Information</CardTitle>
-            <CardDescription>Static node details</CardDescription>
-          </CardHeader>
-          <CardContent>
-            <div className="space-y-2">
-              <p>
-                <span className="font-medium">Node ID:</span> <span className="font-mono">{node.node_id_str}</span>
-              </p>
-              <p>
-                <span className="font-medium">Hardware Model:</span> {node.hw_model ?? '—'}
-              </p>
-              {roleLabel && (
-                <p>
-                  <span className="font-medium">Role:</span> {roleLabel}
-                </p>
-              )}
-              {node.mac_addr && (
-                <p>
-                  <span className="font-medium">MAC Address:</span> <span className="font-mono">{node.mac_addr}</span>
-                </p>
-              )}
-              {node.public_key && (
-                <p className="flex flex-wrap items-center gap-2">
-                  <span className="font-medium shrink-0">Public Key:</span>
-                  <span className="font-mono text-sm break-all">{node.public_key}</span>
-                  <Button
-                    variant="ghost"
-                    size="sm"
-                    className="h-7 px-2 shrink-0"
-                    onClick={() => handleCopyToClipboard(node.public_key!)}
-                    title="Copy public key"
-                  >
-                    <Copy className="h-3 w-3 mr-1" />
-                    Copy
-                  </Button>
-                </p>
-              )}
-              {(node.is_licensed === true || node.is_licensed === false) && (
-                <p>
-                  <span className="font-medium">Licensed Operator:</span> {node.is_licensed ? 'Yes' : 'No'}
-                </p>
-              )}
-              {(node.is_unmessagable === true || node.is_unmessagable === false) && (
-                <p>
-                  <span className="font-medium">Messagable:</span> {node.is_unmessagable ? 'No' : 'Yes'}
-                </p>
-              )}
-              <p>
-                <span className="font-medium">Last Heard:</span>{' '}
-                {node.last_heard ? formatDistanceToNow(node.last_heard, { addSuffix: true }) : 'Never'}
-                <span className="block text-xs text-muted-foreground mt-0.5">
-                  Last time any packet was received from this node (telemetry, messages, etc.)
-                </span>
-              </p>
-              {node.inferred_max_hops != null && (
-                <p>
-                  <span className="font-medium">Inferred Max Hops:</span> {node.inferred_max_hops}
-                  <span className="block text-xs text-muted-foreground mt-0.5">
-                    Inferred from packets; recommended is 7
-                  </span>
-                </p>
-              )}
-            </div>
-          </CardContent>
-        </Card>
-
-        {node.latest_device_metrics && (
-          <Card>
-            <CardHeader>
-              <div>
-                <CardTitle>Device Metrics</CardTitle>
-                <CardDescription>
-                  Battery, voltage, channel utilisation — last reported{' '}
-                  {node.latest_device_metrics.reported_time
-                    ? formatDistanceToNow(node.latest_device_metrics.reported_time, { addSuffix: true })
-                    : '—'}
-                </CardDescription>
-              </div>
-            </CardHeader>
-            <CardContent>
-              <div className="space-y-4">
-                <BatteryGauge
-                  batteryLevel={node.latest_device_metrics.battery_level ?? null}
-                  voltage={node.latest_device_metrics.voltage ?? null}
-                />
-                <PercentGauge
-                  value={node.latest_device_metrics.channel_utilization ?? null}
-                  label="Channel Utilization"
-                />
-                <PercentGauge value={node.latest_device_metrics.air_util_tx ?? null} label="Air Utilization" />
-                <p>
-                  <span className="font-medium">Uptime:</span>{' '}
-                  {node.latest_device_metrics.uptime_seconds != null
-                    ? formatUptimeSeconds(node.latest_device_metrics.uptime_seconds)
-                    : '—'}
-                </p>
-              </div>
-            </CardContent>
-          </Card>
-        )}
-
-        {hasEnvironmentSensorMetrics(node.latest_environment_metrics) && (
-          <>
-            <MetricsCard
-              title="Environment Metrics"
-              reportedTime={node.latest_environment_metrics?.reported_time}
-              headerActions={
-                node.environment_settings_editable ? (
-                  <Button
-                    type="button"
-                    variant="outline"
-                    size="icon"
-                    aria-label="Environment metrics settings"
-                    onClick={() => setSettingsOpen(true)}
-                  >
-                    <Settings className="h-4 w-4" />
-                  </Button>
-                ) : undefined
-              }
-              metrics={[
-                { label: 'Sensor placement', value: node.environment_exposure },
-                { label: 'Use for weather', value: node.weather_use },
-                ...(node.latest_environment_metrics
-                  ? [
-                      { label: 'Temperature', value: node.latest_environment_metrics.temperature, unit: '°C' },
-                      {
-                        label: 'Relative Humidity',
-                        value: node.latest_environment_metrics.relative_humidity,
-                        unit: '%',
-                      },
-                      {
-                        label: 'Barometric Pressure',
-                        value: node.latest_environment_metrics.barometric_pressure,
-                        unit: 'hPa',
-                      },
-                      { label: 'Gas Resistance', value: node.latest_environment_metrics.gas_resistance, unit: 'Ω' },
-                      { label: 'IAQ', value: node.latest_environment_metrics.iaq },
-                      { label: 'Lux', value: node.latest_environment_metrics.lux, unit: 'lx' },
-                      { label: 'Wind Direction', value: node.latest_environment_metrics.wind_direction, unit: '°' },
-                      { label: 'Wind Speed', value: node.latest_environment_metrics.wind_speed, unit: 'm/s' },
-                      { label: 'Radiation', value: node.latest_environment_metrics.radiation },
-                      { label: 'Rainfall 1h', value: node.latest_environment_metrics.rainfall_1h, unit: 'mm' },
-                      { label: 'Rainfall 24h', value: node.latest_environment_metrics.rainfall_24h, unit: 'mm' },
-                    ]
-                  : []),
-              ]}
-            />
-            {node.environment_settings_editable && (
-              <NodeEnvironmentSettingsDialog
-                open={settingsOpen}
-                onOpenChange={setSettingsOpen}
-                nodeId={nodeId}
-                initialEnvironmentExposure={(node.environment_exposure ?? 'unknown') as EnvironmentExposureSlug}
-                initialWeatherUse={(node.weather_use ?? 'unknown') as WeatherUseSlug}
-              />
-            )}
-          </>
-        )}
-
-        {node.latest_power_metrics &&
-          (() => {
-            const pm = node.latest_power_metrics;
-            const channelMetrics = [1, 2, 3, 4, 5, 6, 7, 8]
-              .map((n) => {
-                const v = (pm as Record<string, number | null | undefined>)[`ch${n}_voltage`];
-                const c = (pm as Record<string, number | null | undefined>)[`ch${n}_current`];
-                if (v != null || c != null) {
-                  const parts = [];
-                  if (v != null) parts.push(`${v.toFixed(2)}V`);
-                  if (c != null) parts.push(`${c.toFixed(2)}A`);
-                  return { label: `Ch${n}`, value: parts.join(' / ') };
-                }
-                return null;
-              })
-              .filter(Boolean) as { label: string; value: string }[];
-            return channelMetrics.length > 0 ? (
-              <MetricsCard
-                title="Power Metrics"
-                reportedTime={node.latest_power_metrics.reported_time}
-                metrics={channelMetrics}
-              />
-            ) : null;
-          })()}
-      </div>
-
-      <div className={showRfPropagationBesideLocation ? 'mb-6 grid grid-cols-1 gap-6 lg:grid-cols-2' : 'mb-6'}>
-        <Card>
-          <CardHeader>
-            <CardTitle>Node Location</CardTitle>
-            {hasPositions ? (
-              <CardDescription>
-                GPS position broadcast by the node — last reported{' '}
-                {pos?.reported_time ? formatDistanceToNow(pos.reported_time, { addSuffix: true }) : '—'}
-              </CardDescription>
-            ) : (
-              <CardDescription>
-                No GPS position data. A node can be active (Last Heard) without broadcasting its location.
-              </CardDescription>
-            )}
-          </CardHeader>
-          <CardContent>
-            {hasPositions && pos ? (
-              <>
-                <div className="flex flex-wrap md:flex-nowrap gap-4 mb-2 items-end">
-                  <div className="flex flex-col items-start">
-                    <span className="text-xs text-muted-foreground font-medium uppercase tracking-wide">Lat</span>
-                    <span className="text-base font-mono">{pos.latitude!.toFixed(6)}°</span>
-                  </div>
-                  <span className="hidden md:inline-block h-6 border-l border-slate-200 dark:border-slate-700 mx-2"></span>
-                  <div className="flex flex-col items-start">
-                    <span className="text-xs text-muted-foreground font-medium uppercase tracking-wide">Long</span>
-                    <span className="text-base font-mono">{pos.longitude!.toFixed(6)}°</span>
-                  </div>
-                  <span className="hidden md:inline-block h-6 border-l border-slate-200 dark:border-slate-700 mx-2"></span>
-                  <div className="flex flex-col items-start">
-                    <span className="text-xs text-muted-foreground font-medium uppercase tracking-wide">Alt</span>
-                    <span className="text-base font-mono">
-                      {pos.altitude != null ? `${pos.altitude.toFixed(1)}m` : '—'}
-                    </span>
-                  </div>
-                  {pos.location_source && (
-                    <span className="ml-4 px-2 py-0.5 rounded bg-muted text-xs text-muted-foreground border border-slate-200 dark:border-slate-700">
-                      {pos.location_source}
-                    </span>
-                  )}
-                </div>
-                <div className={`w-full ${compact ? 'h-[200px]' : 'h-[400px]'}`}>
-                  <NodesMap nodes={[node]} />
-                </div>
-              </>
-            ) : (
-              <div className="h-[200px] w-full flex items-center justify-center bg-muted rounded-md">
-                <p className="text-muted-foreground">No location data available</p>
-              </div>
-            )}
-          </CardContent>
-        </Card>
-        {showRfPropagationBesideLocation ? <RfPropagationSection node={node} className="mb-0" /> : null}
-      </div>
-
-      {!compact && (
+      {fullPageTabs && onTabChange ? (
         <>
-          <NodeMeshMonitoringSection node={node} />
-          <TracerouteLinksSection nodeId={nodeId} isManagedNode={isManagedNode} />
-          <Suspense
-            fallback={
-              <div className="mb-6 flex min-h-[120px] items-center justify-center text-muted-foreground">
-                <div className="animate-spin rounded-full h-8 w-8 border-t-2 border-b-2 border-teal-500" />
-              </div>
-            }
+          <Tabs
+            value={effectiveTab}
+            onValueChange={(v) => onTabChange(v as NodeDetailTab)}
+            className="mb-6"
+            data-testid="node-detail-tabs"
           >
-            <NodeTracerouteHistorySection nodeId={nodeId} observedNode={node} />
-          </Suspense>
-          <NodeStatsSection nodeId={nodeId} node={node} isManagedNode={isManagedNode} />
-        </>
-      )}
+            <TabsList className="mb-4 flex h-auto min-h-9 w-full flex-wrap justify-start gap-1">
+              <TabsTrigger value="overview" data-testid="node-detail-tab-overview">
+                Overview
+              </TabsTrigger>
+              <TabsTrigger value="map" data-testid="node-detail-tab-map">
+                Map
+              </TabsTrigger>
+              <TabsTrigger value="traceroutes" data-testid="node-detail-tab-traceroutes">
+                Traceroutes
+              </TabsTrigger>
+              <TabsTrigger value="statistics" data-testid="node-detail-tab-statistics">
+                Statistics
+              </TabsTrigger>
+              {showMonitoringTab && (
+                <TabsTrigger value="monitoring" data-testid="node-detail-tab-monitoring">
+                  Monitoring
+                </TabsTrigger>
+              )}
+            </TabsList>
 
-      {compact && (
-        <Link to={`/nodes/${nodeId}`} className="text-teal-600 dark:text-teal-400 hover:underline text-sm">
-          View full details →
-        </Link>
+            {effectiveTab === 'overview' && (
+              <div data-testid="node-detail-panel-overview">
+                {renderFeederGeoCard()}
+                {renderMetricsGrid()}
+                <div className="mb-6">
+                  <NodeLocationCard node={node} nodeId={nodeId} compact={false} mapTabLink />
+                </div>
+              </div>
+            )}
+
+            {effectiveTab === 'map' && (
+              <div data-testid="node-detail-panel-map">
+                <div className={showRfPropagation ? 'mb-6 grid grid-cols-1 gap-6 lg:grid-cols-2' : 'mb-6'}>
+                  <NodeLocationCard node={node} nodeId={nodeId} compact={false} />
+                  {showRfPropagation ? <RfPropagationSection node={node} className="mb-0" /> : null}
+                </div>
+              </div>
+            )}
+
+            {effectiveTab === 'traceroutes' && (
+              <div data-testid="node-detail-panel-traceroutes">
+                <TracerouteLinksSection nodeId={nodeId} isManagedNode={isManagedNode} />
+                <Suspense
+                  fallback={
+                    <div className="mb-6 flex min-h-[120px] items-center justify-center text-muted-foreground">
+                      <div className="h-8 w-8 animate-spin rounded-full border-b-2 border-t-2 border-teal-500" />
+                    </div>
+                  }
+                >
+                  <NodeTracerouteHistorySection nodeId={nodeId} observedNode={node} />
+                </Suspense>
+              </div>
+            )}
+
+            {effectiveTab === 'statistics' && (
+              <div data-testid="node-detail-panel-statistics">
+                <NodeStatsSection nodeId={nodeId} node={node} isManagedNode={isManagedNode} />
+              </div>
+            )}
+
+            {effectiveTab === 'monitoring' && showMonitoringTab && (
+              <div data-testid="node-detail-panel-monitoring">
+                <NodeMeshMonitoringSection node={node} />
+              </div>
+            )}
+          </Tabs>
+        </>
+      ) : (
+        <>
+          {renderFeederGeoCard()}
+          {renderMetricsGrid()}
+          {renderLegacyLocationBlock()}
+
+          {!compact && (
+            <>
+              <NodeMeshMonitoringSection node={node} />
+              <TracerouteLinksSection nodeId={nodeId} isManagedNode={isManagedNode} />
+              <Suspense
+                fallback={
+                  <div className="mb-6 flex min-h-[120px] items-center justify-center text-muted-foreground">
+                    <div className="h-8 w-8 animate-spin rounded-full border-b-2 border-t-2 border-teal-500" />
+                  </div>
+                }
+              >
+                <NodeTracerouteHistorySection nodeId={nodeId} observedNode={node} />
+              </Suspense>
+              <NodeStatsSection nodeId={nodeId} node={node} isManagedNode={isManagedNode} />
+            </>
+          )}
+
+          {compact && (
+            <Link to={`/nodes/${nodeId}`} className="text-sm text-teal-600 hover:underline dark:text-teal-400">
+              View full details →
+            </Link>
+          )}
+        </>
       )}
     </div>
   );

--- a/src/components/nodes/NodeDetailContent.tsx
+++ b/src/components/nodes/NodeDetailContent.tsx
@@ -2,7 +2,6 @@ import { Link } from 'react-router-dom';
 import { useNodeSuspense, useManagedNodesSuspense } from '@/hooks/api/useNodes';
 import { useNodeTracerouteLinks } from '@/hooks/api/useNodeTracerouteLinks';
 import { useRecentNodes } from '@/hooks/useRecentNodes';
-import { formatDistanceToNow } from 'date-fns';
 import { subDays, subHours } from 'date-fns';
 import { formatUptimeSeconds } from '@/lib/utils';
 import { NodeStatsSection } from '@/components/nodes/NodeStatsSection';
@@ -12,6 +11,7 @@ import { LinkSNRCharts } from '@/components/nodes/LinkSNRCharts';
 import { BatteryGauge } from '@/components/nodes/BatteryGauge';
 import { MetricsCard } from '@/components/nodes/MetricsCard';
 import { PercentGauge } from '@/components/nodes/PercentGauge';
+import { StaleReportedTime } from '@/components/nodes/StaleReportedTime';
 import { Card, CardHeader, CardTitle, CardContent, CardDescription } from '@/components/ui/card';
 import { Suspense, useEffect, useMemo, useState } from 'react';
 import { Button } from '@/components/ui/button';
@@ -90,8 +90,7 @@ function NodeLocationCard({
             <CardTitle>Node Location</CardTitle>
             {hasPositions ? (
               <CardDescription>
-                GPS position broadcast by the node — last reported{' '}
-                {pos?.reported_time ? formatDistanceToNow(pos.reported_time, { addSuffix: true }) : '—'}
+                GPS position broadcast by the node — last reported <StaleReportedTime at={pos?.reported_time} />
               </CardDescription>
             ) : (
               <CardDescription>
@@ -375,7 +374,7 @@ export function NodeDetailContent({ nodeId, compact = false, activeTab, onTabCha
             )}
             <p>
               <span className="font-medium">Last Heard:</span>{' '}
-              {node.last_heard ? formatDistanceToNow(node.last_heard, { addSuffix: true }) : 'Never'}
+              <StaleReportedTime at={node.last_heard ?? null} fallback="Never" />
               <span className="mt-0.5 block text-xs text-muted-foreground">
                 Last time any packet was received from this node (telemetry, messages, etc.)
               </span>
@@ -399,9 +398,7 @@ export function NodeDetailContent({ nodeId, compact = false, activeTab, onTabCha
               <CardTitle>Device Metrics</CardTitle>
               <CardDescription>
                 Battery, voltage, channel utilisation — last reported{' '}
-                {node.latest_device_metrics.reported_time
-                  ? formatDistanceToNow(node.latest_device_metrics.reported_time, { addSuffix: true })
-                  : '—'}
+                <StaleReportedTime at={node.latest_device_metrics.reported_time} />
               </CardDescription>
             </div>
           </CardHeader>

--- a/src/components/nodes/NodeTracerouteLinksMap.test.tsx
+++ b/src/components/nodes/NodeTracerouteLinksMap.test.tsx
@@ -1,0 +1,96 @@
+import { MemoryRouter } from 'react-router-dom';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { render, screen } from '@testing-library/react';
+
+import type { NodeTracerouteLinkEdge, NodeTracerouteLinkNode } from '@/hooks/api/useNodeTracerouteLinks';
+import { NodeTracerouteLinksMap } from './NodeTracerouteLinksMap';
+
+vi.mock('react-map-gl', async (importOriginal) => {
+  const mod = await importOriginal<typeof import('react-map-gl')>();
+  return {
+    ...mod,
+    Popup: ({ children }: { children?: React.ReactNode }) => <div data-testid="popup-mock">{children}</div>,
+  };
+});
+
+vi.mock('@/providers/ConfigProvider', () => ({
+  useConfig: () => ({ mapboxToken: 'pk.test', apiUrl: '' }),
+}));
+
+type CapturedDeckProps = {
+  initialViewState: Record<string, unknown>;
+  layers: unknown[];
+};
+
+const deckCaptures: CapturedDeckProps[] = [];
+
+vi.mock('@/components/map/DeckMapboxMap', () => ({
+  DeckMapboxMap: (props: CapturedDeckProps) => {
+    deckCaptures.push(props);
+    return <div data-testid="deck-mapbox-mock">map</div>;
+  },
+}));
+
+const nodeA: NodeTracerouteLinkNode = {
+  node_id: 0x11a,
+  node_id_str: '!0000011a',
+  short_name: 'A',
+  long_name: 'Node A',
+  lat: 55.9,
+  lng: -4.2,
+};
+
+const nodeB: NodeTracerouteLinkNode = {
+  node_id: 0x11b,
+  node_id_str: '!0000011b',
+  short_name: 'B',
+  long_name: 'Node B',
+  lat: 55.95,
+  lng: -4.15,
+};
+
+const edge: NodeTracerouteLinkEdge = {
+  from_node_id: nodeA.node_id,
+  to_node_id: nodeB.node_id,
+  from_lng: -4.2,
+  from_lat: 55.9,
+  to_lng: -4.15,
+  to_lat: 55.95,
+  avg_snr_in: 5,
+  avg_snr_out: 6,
+  count: 3,
+};
+
+describe('NodeTracerouteLinksMap', () => {
+  beforeEach(() => {
+    deckCaptures.length = 0;
+  });
+
+  it('passes lon/lat/zoom initialViewState when multiple nodes have positions (not bounds)', () => {
+    render(
+      <MemoryRouter>
+        <NodeTracerouteLinksMap edges={[edge]} nodes={[nodeA, nodeB]} focusNodeId={nodeA.node_id} />
+      </MemoryRouter>
+    );
+
+    expect(screen.getByTestId('deck-mapbox-mock')).toBeInTheDocument();
+    expect(deckCaptures).toHaveLength(1);
+    const vs = deckCaptures[0].initialViewState;
+    expect(vs).not.toHaveProperty('bounds');
+    expect(vs).not.toHaveProperty('fitBoundsOptions');
+    expect(typeof vs.longitude).toBe('number');
+    expect(typeof vs.latitude).toBe('number');
+    expect(typeof vs.zoom).toBe('number');
+    expect(vs.zoom).toBeLessThanOrEqual(14);
+  });
+
+  it('falls back to default center when no nodes have coordinates', () => {
+    render(
+      <MemoryRouter>
+        <NodeTracerouteLinksMap edges={[]} nodes={[]} focusNodeId={1} />
+      </MemoryRouter>
+    );
+    const vs = deckCaptures[0].initialViewState;
+    expect(vs).toEqual({ longitude: -4.2518, latitude: 55.8642, zoom: 8 });
+  });
+});

--- a/src/components/nodes/NodeTracerouteLinksMap.tsx
+++ b/src/components/nodes/NodeTracerouteLinksMap.tsx
@@ -7,6 +7,7 @@ import { X } from 'lucide-react';
 import type { NodeTracerouteLinkEdge, NodeTracerouteLinkNode } from '@/hooks/api/useNodeTracerouteLinks';
 
 import { DeckMapboxMap } from '@/components/map/DeckMapboxMap';
+import { viewStateFromLngLatBBox } from '@/lib/deck-fit-bounds';
 
 const DEFAULT_CENTER = { longitude: -4.2518, latitude: 55.8642, zoom: 8 };
 const FOCUS_NODE_COLOR: [number, number, number, number] = [34, 197, 94, 255]; // green - focus
@@ -126,14 +127,14 @@ export function NodeTracerouteLinksMap({ edges, nodes, focusNodeId, showLabels =
     const lats = nodes.map((n) => n.lat).filter((v) => typeof v === 'number');
     const lngs = nodes.map((n) => n.lng).filter((v) => typeof v === 'number');
     if (lats.length > 0 && lngs.length > 0) {
-      const padding = 0.02;
-      const bounds: [number, number, number, number] = [
-        Math.min(...lngs) - padding,
-        Math.min(...lats) - padding,
-        Math.max(...lngs) + padding,
-        Math.max(...lats) + padding,
+      const paddingDeg = 0.02;
+      const bbox: [number, number, number, number] = [
+        Math.min(...lngs) - paddingDeg,
+        Math.min(...lats) - paddingDeg,
+        Math.max(...lngs) + paddingDeg,
+        Math.max(...lats) + paddingDeg,
       ];
-      return { bounds, fitBoundsOptions: { padding: 40, maxZoom: 14 } };
+      return viewStateFromLngLatBBox(bbox, { padding: 40, maxZoom: 14 });
     }
     const focusNode = nodes.find((n) => n.node_id === focusNodeId);
     if (focusNode && focusNode.lat != null && focusNode.lng != null) {

--- a/src/components/nodes/RfPropagationMapModal.test.tsx
+++ b/src/components/nodes/RfPropagationMapModal.test.tsx
@@ -25,4 +25,28 @@ describe('RfPropagationMapModal', () => {
     );
     expect(screen.getByText(/map not rendered yet/i)).toBeInTheDocument();
   });
+
+  it('does not enable propagation fetch when assetUrl and bounds are passed', () => {
+    useRfPropagation.mockReturnValue({
+      data: undefined,
+      isLoading: false,
+    });
+    const client = new QueryClient();
+    render(
+      <QueryClientProvider client={client}>
+        <RfPropagationMapModal
+          open
+          onOpenChange={() => {}}
+          assetUrl="https://example.com/m.png"
+          bounds={{ west: -1, south: 50, east: 1, north: 52 }}
+          layout="maximised"
+        />
+      </QueryClientProvider>
+    );
+    expect(useRfPropagation).toHaveBeenCalledWith(
+      0,
+      expect.objectContaining({ enabled: false })
+    );
+    expect(screen.getByRole('dialog').querySelector('.map-container')).not.toBeNull();
+  });
 });

--- a/src/components/nodes/RfPropagationMapModal.tsx
+++ b/src/components/nodes/RfPropagationMapModal.tsx
@@ -1,42 +1,91 @@
 /**
- * Full-screen dialog with a Leaflet map + imageOverlay for a completed RF propagation render.
- * Uses the same high z-index / min-height pattern as traceroute maps so tiles stack correctly in Radix Dialog.
+ * Dialog with Leaflet map + imageOverlay for a completed RF propagation render.
+ * Two modes: fetch by `nodeId` when opened (infrastructure cards), or pass `assetUrl` + `bounds`
+ * from a parent that already has the data (node details maximise — no refetch).
+ * Uses high z-index / min-height pattern so tiles stack correctly in Radix Dialog.
  */
 import { Dialog, DialogContent, DialogDescription, DialogHeader, DialogTitle } from '@/components/ui/dialog';
 import { RfPropagationMap } from '@/components/nodes/RfPropagationMap';
 import { useRfPropagation } from '@/hooks/api/useRfPropagation';
 import { isRfPropagationNone } from '@/lib/models';
+import { cn } from '@/lib/utils';
 
-export interface RfPropagationMapModalProps {
+export type RfPropagationMapBounds = {
+  west: number;
+  south: number;
+  east: number;
+  north: number;
+};
+
+export type RfPropagationMapModalLayout = 'default' | 'maximised';
+
+export type RfPropagationMapModalProps = {
   open: boolean;
   onOpenChange: (open: boolean) => void;
-  nodeId: number;
+  /** When both are set, the modal uses this render directly and does not refetch. */
+  assetUrl?: string | null;
+  bounds?: RfPropagationMapBounds | null;
+  /** When not using inline `assetUrl` + `bounds`, fetch propagation for this node while open. */
+  nodeId?: number;
   shortLabel?: string | null;
-}
+  /** Larger dialog for node-details maximise. */
+  layout?: RfPropagationMapModalLayout;
+};
 
-export function RfPropagationMapModal({ open, onOpenChange, nodeId, shortLabel }: RfPropagationMapModalProps) {
-  const { data, isLoading } = useRfPropagation(nodeId, { enabled: open });
+export function RfPropagationMapModal({
+  open,
+  onOpenChange,
+  nodeId,
+  assetUrl,
+  bounds,
+  shortLabel,
+  layout = 'default',
+}: RfPropagationMapModalProps) {
+  const hasInlineRender = Boolean(assetUrl && bounds);
+  const fetchEnabled = open && nodeId != null && nodeId > 0 && !hasInlineRender;
+  const { data, isLoading } = useRfPropagation(nodeId ?? 0, { enabled: fetchEnabled });
 
-  const ready = data && !isRfPropagationNone(data) && data.status === 'ready' ? data : null;
+  const readyFromQuery = data && !isRfPropagationNone(data) && data.status === 'ready' ? data : null;
+  const mapAsset = hasInlineRender ? assetUrl! : readyFromQuery?.asset_url;
+  const mapBounds = hasInlineRender ? bounds! : (readyFromQuery?.bounds ?? null);
+
+  const showLoading = fetchEnabled && isLoading;
+  const showMap = Boolean(mapAsset && mapBounds);
+  const showEmpty = !showLoading && !showMap;
+
+  const isMaximised = layout === 'maximised';
+  const mapMinHeight = isMaximised ? 560 : 400;
+  const mapWrapperClass = isMaximised ? 'min-h-[70vh] h-[80dvh] w-full' : 'min-h-[420px] w-full';
 
   return (
     <Dialog open={open} onOpenChange={onOpenChange}>
-      <DialogContent className="max-w-3xl sm:max-w-4xl">
+      <DialogContent
+        className={cn(
+          isMaximised
+            ? 'max-h-[95dvh] w-[min(100vw-1.5rem,1400px)] max-w-[min(100vw-1.5rem,1400px)] gap-3 p-4 sm:p-6'
+            : 'max-w-3xl sm:max-w-4xl'
+        )}
+      >
         <DialogHeader>
           <DialogTitle>Propagation map{shortLabel ? ` — ${shortLabel}` : ''}</DialogTitle>
           <DialogDescription>Cached RF coverage preview when a render is available.</DialogDescription>
         </DialogHeader>
-        <div className="min-h-[420px] w-full" style={{ position: 'relative', zIndex: 1 }}>
-          {isLoading && (
+        <div className={cn(mapWrapperClass)} style={{ position: 'relative', zIndex: 1 }}>
+          {showLoading && (
             <div className="flex h-[400px] items-center justify-center text-muted-foreground text-sm">Loading…</div>
           )}
-          {!isLoading && !ready && (
+          {showEmpty && (
             <div className="flex h-[400px] items-center justify-center rounded-md border bg-muted/30 text-muted-foreground text-sm">
               Map not rendered yet
             </div>
           )}
-          {!isLoading && ready && (
-            <RfPropagationMap assetUrl={ready.asset_url} bounds={ready.bounds ?? null} minHeight={400} />
+          {showMap && (
+            <RfPropagationMap
+              assetUrl={mapAsset}
+              bounds={mapBounds}
+              minHeight={mapMinHeight}
+              className={isMaximised ? 'h-full min-h-[65vh]' : undefined}
+            />
           )}
         </div>
       </DialogContent>

--- a/src/components/nodes/RfPropagationSection.test.tsx
+++ b/src/components/nodes/RfPropagationSection.test.tsx
@@ -161,4 +161,33 @@ describe('RfPropagationSection', () => {
     );
     expect(document.querySelector('.leaflet-container')).not.toBeNull();
   });
+
+  it('opens maximised propagation dialog with map when Maximise is clicked', () => {
+    useRfProfile.mockReturnValue({
+      data: { antenna_pattern: 'omni' },
+      isLoading: false,
+    });
+    useRfPropagation.mockReturnValue({
+      data: {
+        status: 'ready',
+        asset_url: 'https://example.com/x.png',
+        bounds: { west: -5, south: 54, east: -3, north: 56 },
+        created_at: '2026-01-01T00:00:00Z',
+      },
+      isLoading: false,
+    });
+    renderWithClient(
+      <RfPropagationSection
+        node={makeNode({
+          rf_profile_editable: true,
+          has_rf_profile: true,
+        })}
+      />
+    );
+
+    fireEvent.click(screen.getByRole('button', { name: /maximise/i }));
+    const dialog = screen.getByRole('dialog');
+    expect(dialog).toBeInTheDocument();
+    expect(dialog.querySelector('.map-container')).not.toBeNull();
+  });
 });

--- a/src/components/nodes/RfPropagationSection.tsx
+++ b/src/components/nodes/RfPropagationSection.tsx
@@ -1,5 +1,5 @@
 import { useState } from 'react';
-import { Settings } from 'lucide-react';
+import { Maximize2, Settings } from 'lucide-react';
 import { Card, CardContent, CardDescription, CardHeader, CardTitle } from '@/components/ui/card';
 import { Button } from '@/components/ui/button';
 import type { ObservedNode } from '@/lib/models';
@@ -12,6 +12,7 @@ import {
 } from '@/hooks/api/useRfPropagation';
 import { RfProfileModal } from '@/components/nodes/RfProfileModal';
 import { RfPropagationMap } from '@/components/nodes/RfPropagationMap';
+import { RfPropagationMapModal } from '@/components/nodes/RfPropagationMapModal';
 
 export interface RfPropagationSectionProps {
   node: ObservedNode;
@@ -26,6 +27,7 @@ export function RfPropagationSection({ node, className = 'mb-6' }: RfPropagation
   const showSection = canEdit || hasProfile;
 
   const [profileOpen, setProfileOpen] = useState(false);
+  const [maximiseOpen, setMaximiseOpen] = useState(false);
   const { data: profile } = useRfProfile(nodeId, { enabled: showSection });
   const { data: propagation, isLoading: propLoading } = useRfPropagation(nodeId, { enabled: showSection });
   const recompute = useRecomputeRfPropagation(nodeId);
@@ -49,6 +51,18 @@ export function RfPropagationSection({ node, className = 'mb-6' }: RfPropagation
             </CardDescription>
           </div>
           <div className="flex flex-wrap items-center gap-2">
+            {readyRow?.asset_url && readyRow.bounds && (
+              <Button
+                type="button"
+                variant="outline"
+                size="sm"
+                onClick={() => setMaximiseOpen(true)}
+                title="Open propagation map in a large view"
+              >
+                <Maximize2 className="mr-1.5 h-3.5 w-3.5" />
+                Maximise
+              </Button>
+            )}
             {canEdit && (
               <>
                 <Button
@@ -181,6 +195,17 @@ export function RfPropagationSection({ node, className = 'mb-6' }: RfPropagation
       </Card>
 
       {canEdit && <RfProfileModal open={profileOpen} onOpenChange={setProfileOpen} node={node} />}
+
+      {readyRow?.asset_url && readyRow.bounds && (
+        <RfPropagationMapModal
+          open={maximiseOpen}
+          onOpenChange={setMaximiseOpen}
+          assetUrl={readyRow.asset_url}
+          bounds={readyRow.bounds}
+          shortLabel={node.short_name ?? node.long_name}
+          layout="maximised"
+        />
+      )}
     </div>
   );
 }

--- a/src/components/nodes/StaleReportedTime.tsx
+++ b/src/components/nodes/StaleReportedTime.tsx
@@ -1,0 +1,46 @@
+import { format, formatDistanceToNow } from 'date-fns';
+import { reportedTimeFreshness } from '@/lib/reported-time-stale';
+import { cn } from '@/lib/utils';
+
+type StaleReportedTimeProps = {
+  at: Date | string | number | null | undefined;
+  /** When `at` is null/undefined/invalid */
+  fallback?: string;
+  className?: string;
+};
+
+/**
+ * Relative time ("x ago") with yellow border if over 24h old, red if over 7 days.
+ * `title` shows absolute local time for hover/accessibility.
+ */
+export function StaleReportedTime({ at, fallback = '—', className }: StaleReportedTimeProps) {
+  if (at == null) {
+    return <span className={className}>{fallback}</span>;
+  }
+
+  const d = at instanceof Date ? at : new Date(at);
+  if (Number.isNaN(d.getTime())) {
+    return <span className={className}>{fallback}</span>;
+  }
+
+  const relative = formatDistanceToNow(d, { addSuffix: true });
+  const title = format(d, 'PPpp');
+  const freshness = reportedTimeFreshness(d);
+
+  const staleClasses =
+    freshness === 'stale24h'
+      ? 'border border-yellow-500/70 bg-yellow-500/10 text-yellow-900 dark:border-yellow-500/60 dark:bg-yellow-500/15 dark:text-yellow-100'
+      : freshness === 'stale7d'
+        ? 'border border-red-500/70 bg-red-500/10 text-red-900 dark:border-red-500/60 dark:bg-red-500/15 dark:text-red-100'
+        : null;
+
+  return (
+    <time
+      dateTime={d.toISOString()}
+      title={title}
+      className={cn(staleClasses && 'inline-block rounded px-1.5 py-0.5', staleClasses, className)}
+    >
+      {relative}
+    </time>
+  );
+}

--- a/src/lib/deck-fit-bounds.test.ts
+++ b/src/lib/deck-fit-bounds.test.ts
@@ -1,0 +1,17 @@
+import { describe, it, expect } from 'vitest';
+import { viewStateFromLngLatBBox } from './deck-fit-bounds';
+
+describe('viewStateFromLngLatBBox', () => {
+  it('returns longitude, latitude, and zoom within maxZoom', () => {
+    const vs = viewStateFromLngLatBBox([-4.3, 55.85, -4.1, 55.95], { padding: 40, maxZoom: 14 });
+    expect(typeof vs.longitude).toBe('number');
+    expect(typeof vs.latitude).toBe('number');
+    expect(typeof vs.zoom).toBe('number');
+    expect(Number.isFinite(vs.longitude)).toBe(true);
+    expect(Number.isFinite(vs.latitude)).toBe(true);
+    expect(Number.isFinite(vs.zoom)).toBe(true);
+    expect(vs.zoom).toBeLessThanOrEqual(14);
+    expect(vs.longitude).toBeCloseTo(-4.2, 0);
+    expect(vs.latitude).toBeCloseTo(55.9, 0);
+  });
+});

--- a/src/lib/deck-fit-bounds.ts
+++ b/src/lib/deck-fit-bounds.ts
@@ -1,0 +1,42 @@
+import { WebMercatorViewport } from '@deck.gl/core';
+
+/** Nominal map size for fitBounds (actual canvas may differ slightly). */
+const NOMINAL_WIDTH = 800;
+const NOMINAL_HEIGHT = 320;
+
+export type LngLatBBox = [west: number, south: number, east: number, north: number];
+
+/**
+ * Convert geographic bounds to DeckGL `initialViewState` lon/lat/zoom.
+ * Uses {@link https://deck.gl/docs/api-reference/core/web-mercator-viewport | WebMercatorViewport.fitBounds}.
+ */
+export function viewStateFromLngLatBBox(
+  bbox: LngLatBBox,
+  options: { padding?: number; maxZoom?: number } = {}
+): { longitude: number; latitude: number; zoom: number } {
+  const [west, south, east, north] = bbox;
+  const padding = options.padding ?? 40;
+  const maxZoom = options.maxZoom ?? 14;
+
+  const base = new WebMercatorViewport({
+    width: NOMINAL_WIDTH,
+    height: NOMINAL_HEIGHT,
+    longitude: 0,
+    latitude: 0,
+    zoom: 1,
+  });
+
+  const fitted = base.fitBounds(
+    [
+      [west, south],
+      [east, north],
+    ],
+    { padding, maxZoom, width: NOMINAL_WIDTH, height: NOMINAL_HEIGHT }
+  );
+
+  return {
+    longitude: fitted.longitude,
+    latitude: fitted.latitude,
+    zoom: fitted.zoom,
+  };
+}

--- a/src/lib/node-detail-tab.test.ts
+++ b/src/lib/node-detail-tab.test.ts
@@ -1,0 +1,27 @@
+import { describe, it, expect } from 'vitest';
+import { isValidNodeDetailTab, parseNodeDetailTab } from './node-detail-tab';
+
+describe('node-detail-tab', () => {
+  it('parseNodeDetailTab returns overview for null', () => {
+    expect(parseNodeDetailTab(null)).toBe('overview');
+  });
+
+  it('parseNodeDetailTab returns known tabs', () => {
+    expect(parseNodeDetailTab('map')).toBe('map');
+    expect(parseNodeDetailTab('traceroutes')).toBe('traceroutes');
+    expect(parseNodeDetailTab('statistics')).toBe('statistics');
+    expect(parseNodeDetailTab('monitoring')).toBe('monitoring');
+    expect(parseNodeDetailTab('overview')).toBe('overview');
+  });
+
+  it('parseNodeDetailTab falls back for unknown values', () => {
+    expect(parseNodeDetailTab('nope')).toBe('overview');
+    expect(parseNodeDetailTab('')).toBe('overview');
+  });
+
+  it('isValidNodeDetailTab', () => {
+    expect(isValidNodeDetailTab('map')).toBe(true);
+    expect(isValidNodeDetailTab(null)).toBe(false);
+    expect(isValidNodeDetailTab('bad')).toBe(false);
+  });
+});

--- a/src/lib/node-detail-tab.ts
+++ b/src/lib/node-detail-tab.ts
@@ -1,0 +1,15 @@
+export const NODE_DETAIL_TAB_IDS = ['overview', 'map', 'traceroutes', 'statistics', 'monitoring'] as const;
+
+export type NodeDetailTab = (typeof NODE_DETAIL_TAB_IDS)[number];
+
+const ALLOWED = new Set<string>(NODE_DETAIL_TAB_IDS);
+
+export function isValidNodeDetailTab(value: string | null | undefined): value is NodeDetailTab {
+  return value != null && ALLOWED.has(value);
+}
+
+/** Map `?tab=` query to a tab id; unknown values fall back to `overview`. */
+export function parseNodeDetailTab(param: string | null): NodeDetailTab {
+  if (isValidNodeDetailTab(param)) return param;
+  return 'overview';
+}

--- a/src/lib/reported-time-stale.test.ts
+++ b/src/lib/reported-time-stale.test.ts
@@ -1,0 +1,33 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { reportedTimeFreshness } from './reported-time-stale';
+
+describe('reportedTimeFreshness', () => {
+  beforeEach(() => {
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date('2026-06-15T12:00:00.000Z'));
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  it('returns fresh within 24h', () => {
+    expect(reportedTimeFreshness(new Date('2026-06-15T10:00:00.000Z'))).toBe('fresh');
+    expect(reportedTimeFreshness(new Date('2026-06-14T12:00:00.000Z'))).toBe('fresh');
+  });
+
+  it('returns stale24h strictly after 24h and within 7d', () => {
+    expect(reportedTimeFreshness(new Date('2026-06-14T11:59:59.000Z'))).toBe('stale24h');
+    expect(reportedTimeFreshness(new Date('2026-06-10T12:00:00.000Z'))).toBe('stale24h');
+  });
+
+  it('returns stale7d strictly after 7 days', () => {
+    expect(reportedTimeFreshness(new Date('2026-06-08T12:00:00.000Z'))).toBe('stale24h');
+    expect(reportedTimeFreshness(new Date('2026-06-08T11:59:59.999Z'))).toBe('stale7d');
+    expect(reportedTimeFreshness(new Date('2025-01-01T00:00:00.000Z'))).toBe('stale7d');
+  });
+
+  it('returns null for invalid date', () => {
+    expect(reportedTimeFreshness('not-a-date')).toBe(null);
+  });
+});

--- a/src/lib/reported-time-stale.ts
+++ b/src/lib/reported-time-stale.ts
@@ -1,0 +1,14 @@
+const DAY_MS = 86_400_000;
+
+export type ReportedTimeFreshness = 'fresh' | 'stale24h' | 'stale7d';
+
+/** Stale if strictly over 24h (yellow) or over 7 days (red). */
+export function reportedTimeFreshness(at: Date | string | number): ReportedTimeFreshness | null {
+  const d = at instanceof Date ? at : new Date(at);
+  if (Number.isNaN(d.getTime())) return null;
+  const ageMs = Date.now() - d.getTime();
+  if (ageMs <= 0) return 'fresh';
+  if (ageMs > 7 * DAY_MS) return 'stale7d';
+  if (ageMs > DAY_MS) return 'stale24h';
+  return 'fresh';
+}

--- a/src/pages/nodes/NodeDetails.tsx
+++ b/src/pages/nodes/NodeDetails.tsx
@@ -1,20 +1,22 @@
+import { Suspense } from 'react';
 import { useParams } from 'react-router-dom';
 import { NodeDetailContent } from '@/components/nodes/NodeDetailContent';
-import { Suspense } from 'react';
+import { useNodeDetailPageTabs } from '@/pages/nodes/useNodeDetailPageTabs';
 
 export function NodeDetails() {
   const { id } = useParams<{ id: string }>();
   const nodeId = parseInt(id || '0', 10);
+  const { activeTab, onTabChange } = useNodeDetailPageTabs();
 
   return (
     <Suspense
       fallback={
-        <div className="flex items-center justify-center min-h-screen">
-          <div className="animate-spin rounded-full h-12 w-12 border-t-2 border-b-2 border-teal-500"></div>
+        <div className="flex min-h-screen items-center justify-center">
+          <div className="h-12 w-12 animate-spin rounded-full border-b-2 border-t-2 border-teal-500"></div>
         </div>
       }
     >
-      <NodeDetailContent nodeId={nodeId} />
+      <NodeDetailContent nodeId={nodeId} activeTab={activeTab} onTabChange={onTabChange} />
     </Suspense>
   );
 }

--- a/src/pages/nodes/useNodeDetailPageTabs.test.tsx
+++ b/src/pages/nodes/useNodeDetailPageTabs.test.tsx
@@ -1,0 +1,79 @@
+import { describe, it, expect } from 'vitest';
+import { render, screen, waitFor } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { MemoryRouter, Route, Routes, useLocation } from 'react-router-dom';
+import { useNodeDetailPageTabs } from './useNodeDetailPageTabs';
+
+function TabHarness() {
+  const { activeTab, onTabChange } = useNodeDetailPageTabs();
+  return (
+    <div>
+      <span data-testid="active-tab">{activeTab}</span>
+      <button type="button" onClick={() => onTabChange('map')}>
+        go map
+      </button>
+      <button type="button" onClick={() => onTabChange('overview')}>
+        go overview
+      </button>
+    </div>
+  );
+}
+
+function SearchEcho() {
+  const { search } = useLocation();
+  return <span data-testid="url-search">{search}</span>;
+}
+
+function HarnessRoute() {
+  return (
+    <>
+      <TabHarness />
+      <SearchEcho />
+    </>
+  );
+}
+
+describe('useNodeDetailPageTabs', () => {
+  it('reads tab from search params', () => {
+    render(
+      <MemoryRouter initialEntries={['/nodes/42?tab=statistics']}>
+        <Routes>
+          <Route path="/nodes/:id" element={<HarnessRoute />} />
+        </Routes>
+      </MemoryRouter>
+    );
+    expect(screen.getByTestId('active-tab')).toHaveTextContent('statistics');
+    expect(screen.getByTestId('url-search')).toHaveTextContent('?tab=statistics');
+  });
+
+  it('removes invalid tab from URL', async () => {
+    render(
+      <MemoryRouter initialEntries={['/nodes/1?tab=not-a-tab']}>
+        <Routes>
+          <Route path="/nodes/:id" element={<HarnessRoute />} />
+        </Routes>
+      </MemoryRouter>
+    );
+    expect(screen.getByTestId('active-tab')).toHaveTextContent('overview');
+    await waitFor(() => {
+      expect(screen.getByTestId('url-search')).toHaveTextContent('');
+    });
+  });
+
+  it('onTabChange updates search params', async () => {
+    const user = userEvent.setup();
+    render(
+      <MemoryRouter initialEntries={['/nodes/7']}>
+        <Routes>
+          <Route path="/nodes/:id" element={<HarnessRoute />} />
+        </Routes>
+      </MemoryRouter>
+    );
+    expect(screen.getByTestId('active-tab')).toHaveTextContent('overview');
+    expect(screen.getByTestId('url-search')).toHaveTextContent('');
+    await user.click(screen.getByRole('button', { name: 'go map' }));
+    expect(screen.getByTestId('url-search')).toHaveTextContent('?tab=map');
+    await user.click(screen.getByRole('button', { name: 'go overview' }));
+    expect(screen.getByTestId('url-search')).toHaveTextContent('');
+  });
+});

--- a/src/pages/nodes/useNodeDetailPageTabs.ts
+++ b/src/pages/nodes/useNodeDetailPageTabs.ts
@@ -1,0 +1,32 @@
+import { useCallback, useEffect } from 'react';
+import { useSearchParams } from 'react-router-dom';
+import { isValidNodeDetailTab, parseNodeDetailTab, type NodeDetailTab } from '@/lib/node-detail-tab';
+
+export function useNodeDetailPageTabs() {
+  const [searchParams, setSearchParams] = useSearchParams();
+  const rawTab = searchParams.get('tab');
+  const activeTab = parseNodeDetailTab(rawTab);
+
+  useEffect(() => {
+    if (rawTab != null && !isValidNodeDetailTab(rawTab)) {
+      const next = new URLSearchParams(searchParams);
+      next.delete('tab');
+      setSearchParams(next, { replace: true });
+    }
+  }, [rawTab, searchParams, setSearchParams]);
+
+  const onTabChange = useCallback(
+    (tab: NodeDetailTab) => {
+      const next = new URLSearchParams(searchParams);
+      if (tab === 'overview') {
+        next.delete('tab');
+      } else {
+        next.set('tab', tab);
+      }
+      setSearchParams(next, { replace: true });
+    },
+    [searchParams, setSearchParams]
+  );
+
+  return { activeTab, onTabChange };
+}


### PR DESCRIPTION
## Summary

- **Node details tabs (#189):** Full `/nodes/:id` page uses URL-synced tabs (`?tab=overview|map|traceroutes|statistics|monitoring`) via `useNodeDetailPageTabs`; heavy panels mount only when active. Compact slide-over unchanged. Adds `.cursorignore` for the UI repo.
- **Stale reported times:** Last heard, location, device metrics, and `MetricsCard` timestamps show yellow border when over 24h old, red when over 7 days (`StaleReportedTime`, `reportedTimeFreshness`).
- **Traceroute links map (#186):** `NodeTracerouteLinksMap` no longer passes `bounds`/`fitBoundsOptions` to DeckGL; uses `WebMercatorViewport.fitBounds` via `viewStateFromLngLatBBox`. `DeckMapboxMap` types updated to match Deck-only view state.
- **RF propagation maximise (#188):** When a render is ready, the RF propagation card shows **Maximise**, opening `RfPropagationMapModal` with `layout=maximised` and the same `asset_url`/`bounds` from the section (no refetch). Infrastructure propagation links still use `nodeId` fetch only.

## Testing performed

- `npm run format`
- `npm test` (Vitest)
- `npm run build`

Closes #189
Closes #186
Closes #188