### PR TITLE
feat(nodes): My Nodes refresh, outgoing traceroutes on managed node detail (#192)

### DIFF
--- a/src/components/nodes/MyNodeCard.test.tsx
+++ b/src/components/nodes/MyNodeCard.test.tsx
@@ -1,0 +1,107 @@
+import type { ComponentProps } from 'react';
+import { describe, it, expect, vi } from 'vitest';
+import { render, screen } from '@testing-library/react';
+import { MemoryRouter } from 'react-router-dom';
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import type { ObservedNode } from '@/lib/models';
+
+import { MyNodeCard } from './MyNodeCard';
+
+vi.mock('@/components/nodes/MeshWatchControls', () => ({
+  MeshWatchControls: () => <div data-testid="mesh-watch">watch</div>,
+}));
+
+function makeNode(overrides: Partial<ObservedNode> = {}): ObservedNode {
+  return {
+    internal_id: 1,
+    node_id: 100,
+    node_id_str: '!00000064',
+    mac_addr: null,
+    long_name: 'Long',
+    short_name: 'SN',
+    hw_model: null,
+    public_key: null,
+    role: 2,
+    last_heard: new Date('2026-04-21T10:00:00Z'),
+    latest_position: null,
+    owner: { id: 1, username: 'me' },
+    ...overrides,
+  } as ObservedNode;
+}
+
+function renderCard(props: Partial<ComponentProps<typeof MyNodeCard>> = {}) {
+  const client = new QueryClient();
+  const node = props.node ?? makeNode();
+  return render(
+    <QueryClientProvider client={client}>
+      <MemoryRouter>
+        <MyNodeCard
+          node={node}
+          isManaged={props.isManaged ?? false}
+          isClaimed={props.isClaimed ?? true}
+          showClaimedBadge={props.showClaimedBadge}
+          managedLiveness={props.managedLiveness}
+          watch={props.watch}
+          watchesQuery={props.watchesQuery ?? { isLoading: false, isError: false }}
+          onConvert={props.onConvert ?? vi.fn()}
+          onShowSetupInstructions={props.onShowSetupInstructions ?? vi.fn()}
+        />
+      </MemoryRouter>
+    </QueryClientProvider>
+  );
+}
+
+describe('MyNodeCard', () => {
+  it('hides Claimed badge when showClaimedBadge is false', () => {
+    renderCard({ showClaimedBadge: false, isClaimed: true });
+    expect(screen.queryByText('Claimed')).not.toBeInTheDocument();
+  });
+
+  it('shows Claimed badge by default when claimed', () => {
+    renderCard({ isClaimed: true });
+    expect(screen.getByText('Claimed')).toBeInTheDocument();
+  });
+
+  it('shows No GPS position when coords missing', () => {
+    renderCard({ node: makeNode({ latest_position: null }) });
+    expect(screen.getByText('No GPS position')).toBeInTheDocument();
+  });
+
+  it('shows GPS position recent for fresh reported_time', () => {
+    renderCard({
+      node: makeNode({
+        latest_position: {
+          latitude: 55,
+          longitude: -4,
+          reported_time: new Date('2026-04-21T11:00:00Z'),
+          logged_time: null,
+          altitude: null,
+          location_source: 'gps',
+        },
+      }),
+    });
+    expect(screen.getByText('GPS position recent')).toBeInTheDocument();
+  });
+
+  it('renders managed liveness warning when severity is warn', () => {
+    renderCard({
+      isManaged: true,
+      managedLiveness: {
+        severity: 'warn',
+        message: 'Radio has not been heard — test message.',
+      },
+    });
+    expect(screen.getByRole('alert')).toBeInTheDocument();
+    expect(screen.getByText('Attention')).toBeInTheDocument();
+    expect(screen.getByText(/Radio has not been heard/)).toBeInTheDocument();
+  });
+
+  it('does not render liveness alert when severity is ok', () => {
+    renderCard({
+      isManaged: true,
+      managedLiveness: { severity: 'ok', message: null },
+    });
+    expect(screen.queryByText('Attention')).not.toBeInTheDocument();
+    expect(screen.queryByText('Connectivity issue')).not.toBeInTheDocument();
+  });
+});

--- a/src/components/nodes/MyNodeCard.tsx
+++ b/src/components/nodes/MyNodeCard.tsx
@@ -1,6 +1,6 @@
 import { Link } from 'react-router-dom';
-import { formatDistanceToNow, subDays } from 'date-fns';
-import { MoreVertical, Radio, Settings, ChevronRight, FileText } from 'lucide-react';
+import { formatDistanceToNow } from 'date-fns';
+import { MoreVertical, Radio, Settings, ChevronRight, FileText, AlertTriangle, AlertCircle } from 'lucide-react';
 import type { UseQueryResult } from '@tanstack/react-query';
 
 import { MeshWatchControls } from '@/components/nodes/MeshWatchControls';
@@ -8,6 +8,7 @@ import { BatteryGauge } from '@/components/nodes/BatteryGauge';
 import { Badge } from '@/components/ui/badge';
 import { Button } from '@/components/ui/button';
 import { Card, CardContent, CardFooter, CardHeader } from '@/components/ui/card';
+import { Alert, AlertDescription, AlertTitle } from '@/components/ui/alert';
 import {
   DropdownMenu,
   DropdownMenuContent,
@@ -16,29 +17,17 @@ import {
 } from '@/components/ui/dropdown-menu';
 import { Tooltip, TooltipContent, TooltipProvider, TooltipTrigger } from '@/components/ui/tooltip';
 import type { ObservedNode, NodeWatch, PaginatedResponse } from '@/lib/models';
-
-const POSITION_STALE_DAYS = 7;
-
-function getPositionHint(node: ObservedNode): string {
-  const pos = node.latest_position as {
-    latitude?: number;
-    longitude?: number;
-    reported_time?: Date | string;
-  } | null;
-  if (!pos) return 'No fix';
-  const lat = pos.latitude;
-  const lon = pos.longitude;
-  if (lat == null || lon == null || lat === 0 || lon === 0) return 'No fix';
-  const reported = pos.reported_time ? new Date(pos.reported_time) : null;
-  if (!reported) return 'Has fix';
-  const cutoff = subDays(new Date(), POSITION_STALE_DAYS);
-  return reported >= cutoff ? 'Recent fix' : 'Stale fix';
-}
+import type { ManagedLiveness } from '@/lib/my-nodes-grouping';
+import { getPositionHint } from '@/lib/my-nodes-grouping';
 
 export interface MyNodeCardProps {
   node: ObservedNode;
   isManaged: boolean;
   isClaimed: boolean;
+  /** When false, hides the Claimed badge (e.g. on My Nodes where every card is the user’s). Default true. */
+  showClaimedBadge?: boolean;
+  /** When set and not `ok`, shows a prominent liveness warning (managed nodes on My Nodes). */
+  managedLiveness?: Pick<ManagedLiveness, 'severity' | 'message'> | null;
   watch: NodeWatch | undefined;
   watchesQuery: Pick<UseQueryResult<PaginatedResponse<NodeWatch>>, 'isLoading' | 'isError'>;
   onConvert: () => void;
@@ -49,6 +38,8 @@ export function MyNodeCard({
   node,
   isManaged,
   isClaimed,
+  showClaimedBadge = true,
+  managedLiveness = null,
   watch,
   watchesQuery,
   onConvert,
@@ -60,9 +51,13 @@ export function MyNodeCard({
   const metricsReported = metrics?.reported_time ? new Date(metrics.reported_time) : null;
   const positionHint = getPositionHint(node);
   const displayName = node.short_name || node.node_id_str;
+  const liveness =
+    managedLiveness != null && managedLiveness.severity !== 'ok' && managedLiveness.message != null
+      ? managedLiveness
+      : null;
 
   return (
-    <Card className="min-w-0 flex flex-col h-full border bg-card shadow-sm">
+    <Card className="min-w-0 flex flex-col h-full border bg-card shadow-sm dark:border-border/80 dark:border-2 dark:shadow-md">
       <CardHeader className="pb-2 space-y-0">
         <div className="flex items-start justify-between gap-2">
           <div className="min-w-0 flex-1">
@@ -100,20 +95,53 @@ export function MyNodeCard({
         </div>
       </CardHeader>
       <CardContent className="flex-1 space-y-3 pt-0">
+        {liveness ? (
+          <Alert
+            variant={liveness.severity === 'destructive' ? 'destructive' : 'default'}
+            className={
+              liveness.severity === 'destructive'
+                ? undefined
+                : 'border-amber-500/70 bg-amber-50 text-amber-950 dark:border-amber-500/50 dark:bg-amber-950/35 dark:text-amber-50 [&>svg]:text-amber-700 dark:[&>svg]:text-amber-400'
+            }
+          >
+            {liveness.severity === 'destructive' ? (
+              <AlertCircle className="h-4 w-4" />
+            ) : (
+              <AlertTriangle className="h-4 w-4" />
+            )}
+            <AlertTitle className="leading-snug">
+              {liveness.severity === 'destructive' ? 'Connectivity issue' : 'Attention'}
+            </AlertTitle>
+            <AlertDescription>{liveness.message}</AlertDescription>
+          </Alert>
+        ) : null}
         <div className="flex flex-wrap gap-1.5">
           {isManaged ? (
             <Badge variant="outline" className="text-xs">
               Managed
             </Badge>
           ) : null}
-          {isClaimed ? (
+          {isClaimed && showClaimedBadge ? (
             <Badge variant="outline" className="text-xs">
               Claimed
             </Badge>
           ) : null}
-          <Badge variant="secondary" className="text-xs">
-            {positionHint}
-          </Badge>
+          <TooltipProvider delayDuration={300}>
+            <Tooltip>
+              <TooltipTrigger asChild>
+                <span className="inline-flex max-w-full">
+                  <Badge variant="secondary" className="text-xs cursor-default">
+                    {positionHint.label}
+                  </Badge>
+                </span>
+              </TooltipTrigger>
+              {positionHint.tooltip ? (
+                <TooltipContent side="bottom" className="max-w-xs">
+                  {positionHint.tooltip}
+                </TooltipContent>
+              ) : null}
+            </Tooltip>
+          </TooltipProvider>
         </div>
         <p className="text-sm text-muted-foreground">
           Last heard{' '}

--- a/src/components/nodes/NodeDetailContent.tsx
+++ b/src/components/nodes/NodeDetailContent.tsx
@@ -24,9 +24,8 @@ import type { EnvironmentExposureSlug, LatestEnvironmentMetrics, ObservedNode, W
 import { NodeEnvironmentSettingsDialog } from '@/components/nodes/NodeEnvironmentSettingsDialog';
 import { NodeMeshMonitoringSection } from '@/components/nodes/NodeMeshMonitoringSection';
 import { NodeTracerouteHistorySection } from '@/components/nodes/NodeTracerouteHistorySection';
+import { NodeOutgoingTraceroutesSection } from '@/components/nodes/NodeOutgoingTraceroutesSection';
 import { RfPropagationSection } from '@/components/nodes/RfPropagationSection';
-import { Tooltip, TooltipContent, TooltipProvider, TooltipTrigger } from '@/components/ui/tooltip';
-import { STRATEGY_META, type TracerouteStrategyValue } from '@/lib/traceroute-strategy';
 import { Tabs, TabsList, TabsTrigger } from '@/components/ui/tabs';
 import type { NodeDetailTab } from '@/lib/node-detail-tab';
 
@@ -281,45 +280,6 @@ export function NodeDetailContent({ nodeId, compact = false, activeTab, onTabCha
     fullPageTabs && activeTab === 'monitoring' && !currentUser ? 'overview' : (activeTab ?? 'overview');
 
   const showMonitoringTab = Boolean(currentUser);
-
-  const renderFeederGeoCard = () =>
-    managedForThisNode?.geo_classification ? (
-      <Card className="mb-6" data-testid="node-detail-feeder-geo">
-        <CardHeader>
-          <CardTitle>Traceroute feeder classification</CardTitle>
-          <CardDescription>
-            Geometry vs constellation envelope — drives which automated target strategies apply.
-          </CardDescription>
-        </CardHeader>
-        <CardContent>
-          <div className="flex flex-wrap items-center gap-2">
-            <Badge variant="outline">
-              {managedForThisNode.geo_classification.tier === 'perimeter'
-                ? `Perimeter${
-                    managedForThisNode.geo_classification.bearing_octant
-                      ? ` (${managedForThisNode.geo_classification.bearing_octant})`
-                      : ''
-                  }`
-                : 'Internal'}
-            </Badge>
-            <TooltipProvider delayDuration={200}>
-              {managedForThisNode.geo_classification.applicable_strategies.map((s) => (
-                <Tooltip key={s}>
-                  <TooltipTrigger asChild>
-                    <Badge variant="secondary" className="cursor-help">
-                      {STRATEGY_META[s as TracerouteStrategyValue]?.label ?? s}
-                    </Badge>
-                  </TooltipTrigger>
-                  <TooltipContent side="top" className="max-w-xs text-sm">
-                    {STRATEGY_META[s as TracerouteStrategyValue]?.shortDescription ?? s}
-                  </TooltipContent>
-                </Tooltip>
-              ))}
-            </TooltipProvider>
-          </div>
-        </CardContent>
-      </Card>
-    ) : null;
 
   const renderMetricsGrid = () => (
     <div className={`mb-6 grid grid-cols-1 ${compact ? 'gap-4' : 'gap-6 md:grid-cols-2'}`}>
@@ -613,7 +573,6 @@ export function NodeDetailContent({ nodeId, compact = false, activeTab, onTabCha
 
             {effectiveTab === 'overview' && (
               <div data-testid="node-detail-panel-overview">
-                {renderFeederGeoCard()}
                 {renderMetricsGrid()}
                 <div className="mb-6">
                   <NodeLocationCard node={node} nodeId={nodeId} compact={false} mapTabLink />
@@ -640,6 +599,9 @@ export function NodeDetailContent({ nodeId, compact = false, activeTab, onTabCha
                     </div>
                   }
                 >
+                  {isManagedNode && managedForThisNode ? (
+                    <NodeOutgoingTraceroutesSection nodeId={nodeId} managed={managedForThisNode} />
+                  ) : null}
                   <NodeTracerouteHistorySection nodeId={nodeId} observedNode={node} />
                 </Suspense>
               </div>
@@ -660,7 +622,6 @@ export function NodeDetailContent({ nodeId, compact = false, activeTab, onTabCha
         </>
       ) : (
         <>
-          {renderFeederGeoCard()}
           {renderMetricsGrid()}
           {renderLegacyLocationBlock()}
 
@@ -675,6 +636,9 @@ export function NodeDetailContent({ nodeId, compact = false, activeTab, onTabCha
                   </div>
                 }
               >
+                {isManagedNode && managedForThisNode ? (
+                  <NodeOutgoingTraceroutesSection nodeId={nodeId} managed={managedForThisNode} />
+                ) : null}
                 <NodeTracerouteHistorySection nodeId={nodeId} observedNode={node} />
               </Suspense>
               <NodeStatsSection nodeId={nodeId} node={node} isManagedNode={isManagedNode} />

--- a/src/components/nodes/NodeOutgoingTraceroutesSection.test.tsx
+++ b/src/components/nodes/NodeOutgoingTraceroutesSection.test.tsx
@@ -1,0 +1,72 @@
+import { describe, it, expect, vi } from 'vitest';
+import { render, screen } from '@testing-library/react';
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import type { ManagedNode } from '@/lib/models';
+
+import { NodeOutgoingTraceroutesSection } from './NodeOutgoingTraceroutesSection';
+
+vi.mock('@/pages/traceroutes/TracerouteDetailModal', () => ({
+  TracerouteDetailModal: () => null,
+}));
+
+vi.mock('@/hooks/useTraceroutesWithWebSocket', () => ({
+  useTraceroutesWithWebSocket: () => ({
+    data: { results: [], count: 0, next: null, previous: null },
+    isLoading: false,
+    error: null,
+  }),
+}));
+
+vi.mock('@/hooks/api/useTraceroutes', () => ({
+  useTracerouteTriggerableNodesSuspense: () => ({ triggerableNodes: [] }),
+  useTriggerTraceroute: () => ({
+    mutate: vi.fn(),
+    mutateAsync: vi.fn(),
+    isPending: false,
+  }),
+}));
+
+function makeManaged(overrides: Partial<ManagedNode> = {}): ManagedNode {
+  return {
+    node_id: 42,
+    long_name: 'Feeder',
+    short_name: 'F1',
+    last_heard: null,
+    node_id_str: '!0000002a',
+    owner: { id: 1, username: 'u' },
+    constellation: { id: 1 },
+    position: { latitude: null, longitude: null },
+    geo_classification: {
+      tier: 'internal',
+      bearing_octant: null,
+      applicable_strategies: ['intra_zone'],
+    },
+    ...overrides,
+  } as ManagedNode;
+}
+
+function renderSection(managed: ManagedNode) {
+  const client = new QueryClient({ defaultOptions: { queries: { retry: false } } });
+  return render(
+    <QueryClientProvider client={client}>
+      <NodeOutgoingTraceroutesSection nodeId={managed.node_id} managed={managed} />
+    </QueryClientProvider>
+  );
+}
+
+describe('NodeOutgoingTraceroutesSection', () => {
+  it('renders outgoing heading and feeder classification when geo is present', () => {
+    renderSection(makeManaged());
+    expect(screen.getByTestId('node-detail-outgoing-traceroutes')).toBeInTheDocument();
+    expect(screen.getByTestId('node-detail-feeder-geo')).toBeInTheDocument();
+    expect(screen.getByText('Traceroute feeder classification')).toBeInTheDocument();
+    expect(screen.getByText('Internal')).toBeInTheDocument();
+    expect(screen.getByText(/No outgoing traceroutes/)).toBeInTheDocument();
+  });
+
+  it('omits classification block when geo_classification is missing', () => {
+    renderSection(makeManaged({ geo_classification: null }));
+    expect(screen.queryByTestId('node-detail-feeder-geo')).not.toBeInTheDocument();
+    expect(screen.getByText('Recent runs')).toBeInTheDocument();
+  });
+});

--- a/src/components/nodes/NodeOutgoingTraceroutesSection.tsx
+++ b/src/components/nodes/NodeOutgoingTraceroutesSection.tsx
@@ -1,0 +1,222 @@
+import { useState } from 'react';
+import { format } from 'date-fns';
+import { Link } from 'react-router-dom';
+import { toast } from 'sonner';
+import { RouteIcon, RotateCw } from 'lucide-react';
+
+import { Card, CardContent, CardDescription, CardHeader, CardTitle } from '@/components/ui/card';
+import { Badge } from '@/components/ui/badge';
+import { Button } from '@/components/ui/button';
+import { Table, TableBody, TableCell, TableHead, TableHeader, TableRow } from '@/components/ui/table';
+import { Tooltip, TooltipContent, TooltipProvider, TooltipTrigger } from '@/components/ui/tooltip';
+import { useTracerouteTriggerableNodesSuspense, useTriggerTraceroute } from '@/hooks/api/useTraceroutes';
+import { useTraceroutesWithWebSocket } from '@/hooks/useTraceroutesWithWebSocket';
+import { TracerouteDetailModal } from '@/pages/traceroutes/TracerouteDetailModal';
+import { getTracerouteErrorMessage } from '@/pages/traceroutes/tracerouteErrors';
+import type { AutoTraceRoute, ManagedNode } from '@/lib/models';
+import { STRATEGY_META, type TracerouteStrategyValue } from '@/lib/traceroute-strategy';
+
+const PAGE_SIZE = 10;
+
+function routeSummary(tr: AutoTraceRoute): string {
+  const outEmpty = !tr.route || tr.route.length === 0;
+  const backEmpty = !tr.route_back || tr.route_back.length === 0;
+  if (outEmpty && backEmpty) {
+    return tr.status === 'completed' ? 'Direct' : '—';
+  }
+  const outStr = outEmpty ? 'Direct' : `${tr.route?.length ?? 0} hops`;
+  const backStr = backEmpty ? 'Direct' : `${tr.route_back?.length ?? 0} hops`;
+  return `${outStr} out, ${backStr} back`;
+}
+
+function StatusBadge({ status }: { status: string }) {
+  const variant =
+    status === 'completed'
+      ? 'default'
+      : status === 'failed'
+        ? 'destructive'
+        : status === 'pending' || status === 'sent'
+          ? 'secondary'
+          : 'outline';
+  return <Badge variant={variant}>{status}</Badge>;
+}
+
+export interface NodeOutgoingTraceroutesSectionProps {
+  nodeId: number;
+  managed: ManagedNode;
+}
+
+export function NodeOutgoingTraceroutesSection({ nodeId, managed }: NodeOutgoingTraceroutesSectionProps) {
+  const [selectedTracerouteId, setSelectedTracerouteId] = useState<number | null>(null);
+
+  const { data, isLoading, error } = useTraceroutesWithWebSocket({
+    source_node: nodeId,
+    page_size: PAGE_SIZE,
+  });
+  const { triggerableNodes } = useTracerouteTriggerableNodesSuspense();
+  const triggerMutation = useTriggerTraceroute();
+
+  const traceroutes = data?.results ?? [];
+  const geo = managed.geo_classification;
+
+  const handleRepeat = (tr: AutoTraceRoute) => {
+    triggerMutation.mutate(
+      {
+        managedNodeId: tr.source_node.node_id,
+        targetNodeId: tr.target_node.node_id,
+        targetStrategy:
+          tr.target_strategy === 'intra_zone' ||
+          tr.target_strategy === 'dx_across' ||
+          tr.target_strategy === 'dx_same_side'
+            ? tr.target_strategy
+            : undefined,
+      },
+      {
+        onError: (err) => {
+          toast.error('Traceroute failed', {
+            description: getTracerouteErrorMessage(err),
+          });
+        },
+      }
+    );
+  };
+
+  const canTrigger = triggerableNodes.length > 0;
+
+  return (
+    <div className="mb-6">
+      <Card data-testid="node-detail-outgoing-traceroutes">
+        <CardHeader>
+          <CardTitle className="flex items-center gap-2">
+            <RouteIcon className="h-5 w-5" />
+            Outgoing traceroutes
+          </CardTitle>
+          <CardDescription>
+            Traceroutes initiated by this managed feeder toward other nodes. Click a row for the full path and map.
+          </CardDescription>
+        </CardHeader>
+        <CardContent className="space-y-8">
+          {geo ? (
+            <div className="space-y-3" data-testid="node-detail-feeder-geo">
+              <h3 className="text-sm font-semibold leading-none">Traceroute feeder classification</h3>
+              <p className="text-sm text-muted-foreground">
+                Geometry vs constellation envelope — drives which automated target strategies apply.
+              </p>
+              <div className="flex flex-wrap items-center gap-2">
+                <Badge variant="outline">
+                  {geo.tier === 'perimeter'
+                    ? `Perimeter${geo.bearing_octant ? ` (${geo.bearing_octant})` : ''}`
+                    : 'Internal'}
+                </Badge>
+                <TooltipProvider delayDuration={200}>
+                  {geo.applicable_strategies.map((s) => (
+                    <Tooltip key={s}>
+                      <TooltipTrigger asChild>
+                        <span className="inline-flex">
+                          <Badge variant="secondary" className="cursor-help">
+                            {STRATEGY_META[s as TracerouteStrategyValue]?.label ?? s}
+                          </Badge>
+                        </span>
+                      </TooltipTrigger>
+                      <TooltipContent side="top" className="max-w-xs text-sm">
+                        {STRATEGY_META[s as TracerouteStrategyValue]?.shortDescription ?? s}
+                      </TooltipContent>
+                    </Tooltip>
+                  ))}
+                </TooltipProvider>
+              </div>
+            </div>
+          ) : null}
+
+          <div className="space-y-3">
+            <h3 className="text-sm font-semibold leading-none">Recent runs</h3>
+            {isLoading && <div className="py-6 text-center text-muted-foreground">Loading…</div>}
+            {error && (
+              <div className="py-6 text-center text-destructive">
+                Failed to load traceroutes: {error instanceof Error ? error.message : 'Unknown error'}
+              </div>
+            )}
+            {!isLoading && !error && traceroutes.length === 0 && (
+              <div className="rounded-md border border-dashed py-8 text-center text-sm text-muted-foreground">
+                No outgoing traceroutes from this feeder yet.
+              </div>
+            )}
+            {!isLoading && !error && traceroutes.length > 0 && (
+              <>
+                <Table>
+                  <TableHeader>
+                    <TableRow>
+                      <TableHead>Target</TableHead>
+                      <TableHead>Type</TableHead>
+                      <TableHead>Triggered by</TableHead>
+                      <TableHead>Status</TableHead>
+                      <TableHead>Route</TableHead>
+                      <TableHead>Triggered</TableHead>
+                      <TableHead>Completed</TableHead>
+                      {canTrigger ? <TableHead className="w-12" /> : null}
+                    </TableRow>
+                  </TableHeader>
+                  <TableBody>
+                    {traceroutes.map((tr) => {
+                      const canRepeat = triggerableNodes.some((n) => n.node_id === tr.source_node.node_id);
+                      return (
+                        <TableRow
+                          key={tr.id}
+                          className="cursor-pointer hover:bg-muted/50"
+                          onClick={() => setSelectedTracerouteId(tr.id)}
+                        >
+                          <TableCell>{tr.target_node?.short_name ?? tr.target_node?.node_id_str ?? '—'}</TableCell>
+                          <TableCell>{tr.trigger_type}</TableCell>
+                          <TableCell>{tr.triggered_by_username ?? '—'}</TableCell>
+                          <TableCell>
+                            <StatusBadge status={tr.status} />
+                          </TableCell>
+                          <TableCell className="max-w-[200px]" title={routeSummary(tr)}>
+                            {routeSummary(tr)}
+                          </TableCell>
+                          <TableCell>{tr.triggered_at ? format(new Date(tr.triggered_at), 'PPp') : '—'}</TableCell>
+                          <TableCell>{tr.completed_at ? format(new Date(tr.completed_at), 'PPp') : '—'}</TableCell>
+                          {canTrigger ? (
+                            <TableCell onClick={(e) => e.stopPropagation()}>
+                              {canRepeat ? (
+                                <Button
+                                  variant="ghost"
+                                  size="icon"
+                                  className="h-8 w-8"
+                                  onClick={() => handleRepeat(tr)}
+                                  disabled={triggerMutation.isPending || tr.source_node.allow_auto_traceroute === false}
+                                  title="Repeat this traceroute"
+                                  aria-label="Repeat traceroute"
+                                >
+                                  <RotateCw className="h-4 w-4" />
+                                </Button>
+                              ) : null}
+                            </TableCell>
+                          ) : null}
+                        </TableRow>
+                      );
+                    })}
+                  </TableBody>
+                </Table>
+                <div className="text-right">
+                  <Link
+                    to={`/traceroutes?source_node=${nodeId}`}
+                    className="text-sm text-teal-600 hover:underline dark:text-teal-400"
+                  >
+                    View all traceroutes from this feeder →
+                  </Link>
+                </div>
+              </>
+            )}
+          </div>
+        </CardContent>
+      </Card>
+
+      <TracerouteDetailModal
+        tracerouteId={selectedTracerouteId}
+        open={selectedTracerouteId != null}
+        onOpenChange={(open) => !open && setSelectedTracerouteId(null)}
+      />
+    </div>
+  );
+}

--- a/src/lib/my-nodes-grouping.test.ts
+++ b/src/lib/my-nodes-grouping.test.ts
@@ -1,0 +1,283 @@
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
+import type { ManagedNode, ObservedNode } from '@/lib/models';
+
+import {
+  MY_NODES_CLAIMED_ONLINE_MS,
+  MY_NODES_CLAIMED_RECENT_MS,
+  MY_NODES_FEEDER_FRESH_MS,
+  bucketForLastHeard,
+  buildNodesForMap,
+  getManagedLiveness,
+  getPositionHint,
+  groupClaimedNodes,
+  managedRadioActivityAt,
+  mergeManagedPositionIntoObserved,
+  managedNodeToObservedNode,
+} from './my-nodes-grouping';
+
+const NOW = new Date('2026-04-21T12:00:00.000Z');
+
+function makeObserved(overrides: Partial<ObservedNode> = {}): ObservedNode {
+  return {
+    internal_id: 1,
+    node_id: 100,
+    node_id_str: '!00000064',
+    mac_addr: null,
+    long_name: 'LN',
+    short_name: 'SN',
+    hw_model: null,
+    public_key: null,
+    last_heard: NOW,
+    latest_position: null,
+    ...overrides,
+  } as ObservedNode;
+}
+
+function makeManaged(overrides: Partial<ManagedNode> = {}): ManagedNode {
+  return {
+    node_id: 200,
+    long_name: 'Managed LN',
+    short_name: 'M1',
+    last_heard: NOW,
+    node_id_str: '!000000c8',
+    owner: { id: 1, username: 'u' },
+    constellation: { id: 1 },
+    position: { latitude: 55.0, longitude: -4.0 },
+    ...overrides,
+  } as ManagedNode;
+}
+
+describe('bucketForLastHeard', () => {
+  beforeEach(() => {
+    vi.useFakeTimers();
+    vi.setSystemTime(NOW);
+  });
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  it('returns offline for null last_heard', () => {
+    expect(bucketForLastHeard(null, NOW)).toBe('offline');
+  });
+
+  it('treats future last_heard as online (clock skew)', () => {
+    const future = new Date(NOW.getTime() + 60_000);
+    expect(bucketForLastHeard(future, NOW)).toBe('online');
+  });
+
+  it('is online at exactly 2h boundary', () => {
+    const lh = new Date(NOW.getTime() - MY_NODES_CLAIMED_ONLINE_MS);
+    expect(bucketForLastHeard(lh, NOW)).toBe('online');
+  });
+
+  it('is recent just past 2h', () => {
+    const lh = new Date(NOW.getTime() - MY_NODES_CLAIMED_ONLINE_MS - 1);
+    expect(bucketForLastHeard(lh, NOW)).toBe('recent');
+  });
+
+  it('is recent at exactly 7d boundary', () => {
+    const lh = new Date(NOW.getTime() - MY_NODES_CLAIMED_RECENT_MS);
+    expect(bucketForLastHeard(lh, NOW)).toBe('recent');
+  });
+
+  it('is offline just past 7d', () => {
+    const lh = new Date(NOW.getTime() - MY_NODES_CLAIMED_RECENT_MS - 1);
+    expect(bucketForLastHeard(lh, NOW)).toBe('offline');
+  });
+});
+
+describe('groupClaimedNodes', () => {
+  beforeEach(() => {
+    vi.useFakeTimers();
+    vi.setSystemTime(NOW);
+  });
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  it('partitions nodes into buckets', () => {
+    const online = makeObserved({
+      node_id: 1,
+      last_heard: new Date(NOW.getTime() - 60_000),
+    });
+    const recent = makeObserved({
+      node_id: 2,
+      last_heard: new Date(NOW.getTime() - MY_NODES_CLAIMED_ONLINE_MS - 60_000),
+    });
+    const offline = makeObserved({ node_id: 3, last_heard: null });
+    const g = groupClaimedNodes([online, recent, offline], NOW);
+    expect(g.online).toEqual([online]);
+    expect(g.recent).toEqual([recent]);
+    expect(g.offline).toEqual([offline]);
+  });
+});
+
+describe('getManagedLiveness', () => {
+  beforeEach(() => {
+    vi.useFakeTimers();
+    vi.setSystemTime(NOW);
+  });
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  it('is ok when feeder and radio are fresh', () => {
+    const feeder = new Date(NOW.getTime() - MY_NODES_FEEDER_FRESH_MS / 2);
+    const radio = new Date(NOW.getTime() - MY_NODES_CLAIMED_ONLINE_MS / 2);
+    const r = getManagedLiveness(
+      {
+        last_packet_ingested_at: feeder,
+        radio_last_heard: radio,
+        last_heard: new Date(0),
+      },
+      NOW
+    );
+    expect(r.severity).toBe('ok');
+    expect(r.message).toBeNull();
+  });
+
+  it('warns when feeder stale and radio fresh', () => {
+    const feeder = new Date(NOW.getTime() - MY_NODES_FEEDER_FRESH_MS - 60_000);
+    const radio = new Date(NOW.getTime() - 60_000);
+    const r = getManagedLiveness(
+      {
+        last_packet_ingested_at: feeder,
+        radio_last_heard: radio,
+        last_heard: null,
+      },
+      NOW
+    );
+    expect(r.severity).toBe('warn');
+    expect(r.message).toMatch(/Feeder not reporting/);
+  });
+
+  it('warns when feeder fresh and radio stale', () => {
+    const feeder = new Date(NOW.getTime() - 60_000);
+    const radio = new Date(NOW.getTime() - MY_NODES_CLAIMED_ONLINE_MS - 60_000);
+    const r = getManagedLiveness(
+      {
+        last_packet_ingested_at: feeder,
+        radio_last_heard: radio,
+        last_heard: null,
+      },
+      NOW
+    );
+    expect(r.severity).toBe('warn');
+    expect(r.message).toMatch(/Radio hasn't heard/);
+  });
+
+  it('is destructive when both stale', () => {
+    const feeder = new Date(NOW.getTime() - MY_NODES_FEEDER_FRESH_MS - 60_000);
+    const radio = new Date(NOW.getTime() - MY_NODES_CLAIMED_ONLINE_MS - 60_000);
+    const r = getManagedLiveness(
+      {
+        last_packet_ingested_at: feeder,
+        radio_last_heard: radio,
+        last_heard: null,
+      },
+      NOW
+    );
+    expect(r.severity).toBe('destructive');
+    expect(r.message).toMatch(/Managed node offline/);
+  });
+});
+
+describe('managedRadioActivityAt', () => {
+  it('prefers radio_last_heard over last_heard', () => {
+    const r = new Date('2026-01-01T00:00:00Z');
+    const l = new Date('2026-06-01T00:00:00Z');
+    expect(managedRadioActivityAt({ radio_last_heard: r, last_heard: l })).toBe(r);
+  });
+
+  it('falls back to last_heard', () => {
+    const l = new Date('2026-06-01T00:00:00Z');
+    expect(managedRadioActivityAt({ radio_last_heard: null, last_heard: l })).toBe(l);
+  });
+});
+
+describe('getPositionHint', () => {
+  beforeEach(() => {
+    vi.useFakeTimers();
+    vi.setSystemTime(NOW);
+  });
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  it('returns No GPS position for missing coords', () => {
+    const n = makeObserved({ latest_position: { latitude: 0, longitude: 0 } as ObservedNode['latest_position'] });
+    expect(getPositionHint(n, NOW).label).toBe('No GPS position');
+  });
+
+  it('returns stale when reported_time older than 7d', () => {
+    const old = new Date(NOW.getTime() - MY_NODES_CLAIMED_RECENT_MS - 60_000);
+    const n = makeObserved({
+      latest_position: {
+        latitude: 1,
+        longitude: 2,
+        reported_time: old,
+        logged_time: null,
+        altitude: null,
+        location_source: 'gps',
+      },
+    });
+    expect(getPositionHint(n, NOW).label).toBe('GPS position stale (>7d)');
+  });
+});
+
+describe('buildNodesForMap and merge', () => {
+  it('dedupes by node_id and merges managed position when observed has none', () => {
+    const claimed = makeObserved({
+      node_id: 42,
+      latest_position: null,
+    });
+    const managed = makeManaged({
+      node_id: 42,
+      position: { latitude: 10, longitude: 20 },
+    });
+    const merged = buildNodesForMap([claimed], [managed]);
+    expect(merged).toHaveLength(1);
+    expect(merged[0].latest_position?.latitude).toBe(10);
+    expect(merged[0].short_name).toBe('SN');
+  });
+
+  it('keeps claimed position when already valid', () => {
+    const claimed = makeObserved({
+      node_id: 42,
+      latest_position: {
+        latitude: 1,
+        longitude: 2,
+        reported_time: null,
+        logged_time: null,
+        altitude: null,
+        location_source: 'gps',
+      },
+    });
+    const managed = makeManaged({
+      node_id: 42,
+      position: { latitude: 10, longitude: 20 },
+    });
+    const merged = buildNodesForMap([claimed], [managed]);
+    expect(merged[0].latest_position?.latitude).toBe(1);
+  });
+
+  it('adds managed-only nodes', () => {
+    const managed = makeManaged({ node_id: 99 });
+    const merged = buildNodesForMap([], [managed]);
+    expect(merged).toHaveLength(1);
+    expect(merged[0].node_id).toBe(99);
+  });
+
+  it('mergeManagedPositionIntoObserved fills from managed', () => {
+    const o = makeObserved({ node_id: 1, latest_position: null });
+    const m = makeManaged({ node_id: 1, position: { latitude: 3, longitude: 4 } });
+    const r = mergeManagedPositionIntoObserved(o, m);
+    expect(r.latest_position?.latitude).toBe(3);
+  });
+
+  it('managedNodeToObservedNode exposes coords for map', () => {
+    const m = makeManaged({ position: { latitude: 5, longitude: 6 } });
+    const o = managedNodeToObservedNode(m);
+    expect(o.latest_position?.latitude).toBe(5);
+  });
+});

--- a/src/lib/my-nodes-grouping.ts
+++ b/src/lib/my-nodes-grouping.ts
@@ -1,0 +1,274 @@
+import { formatDistanceToNow } from 'date-fns';
+
+import { MANAGED_NODE_ONLINE_MAX_AGE_SECONDS } from '@/lib/managed-node-status';
+import type { ManagedNode, ObservedNode, Position } from '@/lib/models';
+
+/** Claimed-node “online”: same window as dashboard “2h” and the Meshtastic bot’s online threshold. */
+export const MY_NODES_CLAIMED_ONLINE_MS = 2 * 60 * 60 * 1000;
+
+/** Upper bound for “last heard recently” (exclusive above this → offline). */
+export const MY_NODES_CLAIMED_RECENT_MS = 7 * 24 * 60 * 60 * 1000;
+
+const MS_PER_SECOND = 1000;
+
+export const MY_NODES_FEEDER_FRESH_MS = MANAGED_NODE_ONLINE_MAX_AGE_SECONDS * MS_PER_SECOND;
+
+export type ConnectivityBucket = 'online' | 'recent' | 'offline';
+
+export type ManagedLivenessSeverity = 'ok' | 'warn' | 'destructive';
+
+export interface ManagedLiveness {
+  feeder: 'fresh' | 'stale';
+  radio: 'fresh' | 'stale';
+  severity: ManagedLivenessSeverity;
+  /** User-facing summary; null when severity is `ok`. */
+  message: string | null;
+}
+
+export interface PositionHint {
+  label: string;
+  /** Shown in tooltip when useful (e.g. exact relative age). */
+  tooltip: string | null;
+}
+
+function parseDate(value: Date | string | null | undefined): Date | null {
+  if (value == null) return null;
+  const d = value instanceof Date ? value : new Date(value);
+  return Number.isNaN(d.getTime()) ? null : d;
+}
+
+/**
+ * Buckets for **claimed** nodes on My Nodes (by `last_heard` only).
+ * - Online: ≤ 2h
+ * - Recent: > 2h and ≤ 7d
+ * - Offline: null or > 7d
+ * Future clock skew: if last_heard is in the future, treat as online.
+ */
+export function bucketForLastHeard(
+  lastHeard: Date | string | null | undefined,
+  now: Date = new Date()
+): ConnectivityBucket {
+  const d = parseDate(lastHeard);
+  if (!d) return 'offline';
+  const ageMs = now.getTime() - d.getTime();
+  if (ageMs < 0) return 'online';
+  if (ageMs <= MY_NODES_CLAIMED_ONLINE_MS) return 'online';
+  if (ageMs <= MY_NODES_CLAIMED_RECENT_MS) return 'recent';
+  return 'offline';
+}
+
+export function groupClaimedNodes(
+  nodes: ObservedNode[],
+  now: Date = new Date()
+): Record<ConnectivityBucket, ObservedNode[]> {
+  const out: Record<ConnectivityBucket, ObservedNode[]> = {
+    online: [],
+    recent: [],
+    offline: [],
+  };
+  for (const n of nodes) {
+    out[bucketForLastHeard(n.last_heard, now)].push(n);
+  }
+  return out;
+}
+
+function isFresh(at: Date | string | null | undefined, maxAgeMs: number, now: Date): boolean {
+  const d = parseDate(at);
+  if (!d) return false;
+  const ageMs = now.getTime() - d.getTime();
+  if (ageMs < 0) return true;
+  return ageMs <= maxAgeMs;
+}
+
+function agePhrase(at: Date | string | null | undefined): string {
+  const d = parseDate(at);
+  if (!d) return 'never';
+  return formatDistanceToNow(d, { addSuffix: true });
+}
+
+/** Mesh-side activity: prefer `radio_last_heard`, else `last_heard`. */
+export function managedRadioActivityAt(
+  node: Pick<ManagedNode, 'radio_last_heard' | 'last_heard'>
+): Date | string | null {
+  if (node.radio_last_heard != null) return node.radio_last_heard;
+  return node.last_heard;
+}
+
+/**
+ * Dual-signal liveness for managed nodes on My Nodes.
+ * Feeder fresh = `last_packet_ingested_at` within 10m.
+ * Radio fresh = `radio_last_heard` (or `last_heard`) within 2h.
+ */
+export function getManagedLiveness(
+  node: Pick<ManagedNode, 'last_packet_ingested_at' | 'radio_last_heard' | 'last_heard'>,
+  now: Date = new Date()
+): ManagedLiveness {
+  const feederFresh = isFresh(node.last_packet_ingested_at, MY_NODES_FEEDER_FRESH_MS, now);
+  const radioAt = managedRadioActivityAt(node);
+  const radioFresh = isFresh(radioAt, MY_NODES_CLAIMED_ONLINE_MS, now);
+
+  const feeder: 'fresh' | 'stale' = feederFresh ? 'fresh' : 'stale';
+  const radio: 'fresh' | 'stale' = radioFresh ? 'fresh' : 'stale';
+
+  if (feederFresh && radioFresh) {
+    return { feeder, radio, severity: 'ok', message: null };
+  }
+
+  const feederAge = agePhrase(node.last_packet_ingested_at);
+  const radioAge = agePhrase(radioAt);
+
+  if (!feederFresh && radioFresh) {
+    return {
+      feeder,
+      radio,
+      severity: 'warn',
+      message: `Feeder not reporting to Meshflow — last packet ${feederAge}.`,
+    };
+  }
+  if (feederFresh && !radioFresh) {
+    return {
+      feeder,
+      radio,
+      severity: 'warn',
+      message: `Radio hasn't heard anything on the mesh — last activity ${radioAge}.`,
+    };
+  }
+  return {
+    feeder,
+    radio,
+    severity: 'destructive',
+    message: `Managed node offline — feeder last packet ${feederAge}; last mesh activity ${radioAge}.`,
+  };
+}
+
+const POSITION_STALE_MS = MY_NODES_CLAIMED_RECENT_MS;
+
+function hasValidCoords(lat: number | null | undefined, lon: number | null | undefined): boolean {
+  if (lat == null || lon == null) return false;
+  if (lat === 0 && lon === 0) return false;
+  return true;
+}
+
+/** User-facing GPS / last reported position hint for node cards. */
+export function getPositionHint(node: ObservedNode, now: Date = new Date()): PositionHint {
+  const pos = node.latest_position as
+    | {
+        latitude?: number;
+        longitude?: number;
+        reported_time?: Date | string | null;
+      }
+    | null
+    | undefined;
+
+  if (!pos) {
+    return { label: 'No GPS position', tooltip: null };
+  }
+  const lat = pos.latitude;
+  const lon = pos.longitude;
+  if (!hasValidCoords(lat, lon)) {
+    return { label: 'No GPS position', tooltip: null };
+  }
+
+  const reported = parseDate(pos.reported_time ?? null);
+  if (!reported) {
+    return {
+      label: 'GPS position recent',
+      tooltip: 'Position reported; no exact timestamp on record.',
+    };
+  }
+  const ageMs = now.getTime() - reported.getTime();
+  if (ageMs < 0) {
+    return {
+      label: 'GPS position recent',
+      tooltip: `Reported ${formatDistanceToNow(reported, { addSuffix: true })}`,
+    };
+  }
+  if (ageMs <= POSITION_STALE_MS) {
+    return {
+      label: 'GPS position recent',
+      tooltip: `Reported ${formatDistanceToNow(reported, { addSuffix: true })}`,
+    };
+  }
+  return {
+    label: 'GPS position stale (>7d)',
+    tooltip: `Reported ${formatDistanceToNow(reported, { addSuffix: true })}`,
+  };
+}
+
+function positionFromManaged(m: ManagedNode): Position | null {
+  const lat = m.position?.latitude;
+  const lon = m.position?.longitude;
+  if (!hasValidCoords(lat ?? null, lon ?? null)) return null;
+  return {
+    latitude: lat!,
+    longitude: lon!,
+    reported_time: null,
+    logged_time: null,
+    altitude: null,
+    location_source: 'managed',
+  };
+}
+
+function hasValidObservedPosition(p: Position | null | undefined): boolean {
+  if (!p) return false;
+  return hasValidCoords(p.latitude, p.longitude);
+}
+
+/**
+ * Synthetic `ObservedNode` for a managed-only row (map / fallbacks).
+ * Prefer merging a real claimed `ObservedNode` via `observedNodeForManagedRow` when available.
+ */
+export function managedNodeToObservedNode(m: ManagedNode): ObservedNode {
+  const latest_position = positionFromManaged(m);
+  return {
+    internal_id: 0,
+    node_id: m.node_id,
+    node_id_str: m.node_id_str,
+    mac_addr: null,
+    long_name: m.long_name,
+    short_name: m.short_name,
+    hw_model: null,
+    public_key: null,
+    role: null,
+    last_heard: m.last_heard ?? null,
+    latest_position,
+    latest_device_metrics: null,
+    owner: m.owner,
+  };
+}
+
+/** Prefer claimed telemetry/position; fill map position from managed default when missing. */
+export function mergeManagedPositionIntoObserved(node: ObservedNode, m: ManagedNode): ObservedNode {
+  if (hasValidObservedPosition(node.latest_position)) return node;
+  const pos = positionFromManaged(m);
+  if (!pos) return node;
+  return { ...node, latest_position: pos };
+}
+
+/**
+ * Union of claimed + managed for `NodesMap` / battery chart: one entry per `node_id`.
+ * When both exist, claimed data wins; managed fills in default position if needed.
+ */
+export function buildNodesForMap(claimed: ObservedNode[], managed: ManagedNode[]): ObservedNode[] {
+  const map = new Map<number, ObservedNode>();
+  for (const c of claimed) {
+    map.set(c.node_id, c);
+  }
+  for (const m of managed) {
+    const existing = map.get(m.node_id);
+    if (existing) {
+      map.set(m.node_id, mergeManagedPositionIntoObserved(existing, m));
+    } else {
+      map.set(m.node_id, managedNodeToObservedNode(m));
+    }
+  }
+  return [...map.values()];
+}
+
+/** Card row for a managed node: full observed payload when user also claimed it. */
+export function observedNodeForManagedRow(m: ManagedNode, claimed: ObservedNode | undefined): ObservedNode {
+  if (claimed) {
+    return mergeManagedPositionIntoObserved(claimed, m);
+  }
+  return managedNodeToObservedNode(m);
+}

--- a/src/pages/nodes/MyNodes.test.tsx
+++ b/src/pages/nodes/MyNodes.test.tsx
@@ -1,0 +1,192 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { render, screen } from '@testing-library/react';
+import { MemoryRouter } from 'react-router-dom';
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import type { ManagedNode, ObservedNode } from '@/lib/models';
+
+import { MyNodes } from './MyNodes';
+import { MY_NODES_CLAIMED_ONLINE_MS, MY_NODES_CLAIMED_RECENT_MS, MY_NODES_FEEDER_FRESH_MS } from '@/lib/my-nodes-grouping';
+
+vi.mock('@/providers/ConfigProvider', () => ({
+  useConfig: () => ({ apis: { meshBot: { baseUrl: 'https://bot.example' } } }),
+}));
+
+vi.mock('@tanstack/react-query', async () => {
+  const actual = await vi.importActual<typeof import('@tanstack/react-query')>('@tanstack/react-query');
+  return {
+    ...actual,
+    useQuery: vi.fn(() => ({ data: [] })),
+  };
+});
+
+const useMyClaimedNodesSuspense = vi.fn();
+const useMyManagedNodesSuspense = vi.fn();
+
+vi.mock('@/hooks/api/useNodes', () => ({
+  useMyClaimedNodesSuspense: () => useMyClaimedNodesSuspense(),
+  useMyManagedNodesSuspense: () => useMyManagedNodesSuspense(),
+}));
+
+vi.mock('@/hooks/api/useNodeWatches', () => ({
+  useNodeWatches: () => ({
+    data: { results: [] },
+    isLoading: false,
+    isError: false,
+  }),
+}));
+
+vi.mock('@/hooks/api/useApi', () => ({
+  useMeshtasticApi: () => ({
+    getApiKeys: vi.fn(),
+  }),
+}));
+
+vi.mock('@/components/nodes/NodesMap', () => ({
+  NodesMap: () => <div data-testid="nodes-map">map</div>,
+}));
+
+vi.mock('@/components/nodes/MonitoredNodesBatteryChart', () => ({
+  MonitoredNodesBatteryChart: () => <div data-testid="battery-chart">chart</div>,
+}));
+
+vi.mock('@/components/nodes/MeshWatchControls', () => ({
+  MeshWatchControls: () => <div data-testid="mesh-watch">watch</div>,
+}));
+
+const NOW = new Date('2026-04-21T12:00:00.000Z');
+
+function makeObserved(overrides: Partial<ObservedNode> = {}): ObservedNode {
+  return {
+    internal_id: 1,
+    node_id: 100,
+    node_id_str: '!00000064',
+    mac_addr: null,
+    long_name: 'LN',
+    short_name: 'SN',
+    hw_model: null,
+    public_key: null,
+    last_heard: NOW,
+    latest_position: null,
+    owner: { id: 1, username: 'me' },
+    ...overrides,
+  } as ObservedNode;
+}
+
+function makeManaged(overrides: Partial<ManagedNode> = {}): ManagedNode {
+  return {
+    node_id: 200,
+    long_name: 'MLN',
+    short_name: 'M1',
+    last_heard: NOW,
+    node_id_str: '!000000c8',
+    owner: { id: 1, username: 'me' },
+    constellation: { id: 1 },
+    position: { latitude: 55.0, longitude: -4.0 },
+    last_packet_ingested_at: new Date(NOW.getTime() - 60_000),
+    radio_last_heard: new Date(NOW.getTime() - 60_000),
+    ...overrides,
+  } as ManagedNode;
+}
+
+function renderMyNodes() {
+  const client = new QueryClient({
+    defaultOptions: { queries: { retry: false } },
+  });
+  return render(
+    <QueryClientProvider client={client}>
+      <MemoryRouter>
+        <MyNodes />
+      </MemoryRouter>
+    </QueryClientProvider>
+  );
+}
+
+describe('MyNodes', () => {
+  beforeEach(() => {
+    vi.useFakeTimers();
+    vi.setSystemTime(NOW);
+    useMyClaimedNodesSuspense.mockReturnValue({ myClaimedNodes: [] });
+    useMyManagedNodesSuspense.mockReturnValue({ myManagedNodes: [] });
+  });
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  it('does not show managed section when there are no managed nodes', () => {
+    renderMyNodes();
+    expect(screen.queryByText('Managed nodes')).not.toBeInTheDocument();
+  });
+
+  it('shows managed section when there are managed nodes', () => {
+    useMyManagedNodesSuspense.mockReturnValue({ myManagedNodes: [makeManaged()] });
+    renderMyNodes();
+    expect(screen.getByText('Managed nodes')).toBeInTheDocument();
+  });
+
+  it('dedupes claimed+managed so the node appears only under Managed', () => {
+    const nid = 42;
+    const claimed = makeObserved({
+      node_id: nid,
+      node_id_str: '!0000002a',
+      short_name: 'DEDUP',
+      last_heard: new Date(NOW.getTime() - 60_000),
+    });
+    const managed = makeManaged({
+      node_id: nid,
+      node_id_str: '!0000002a',
+      short_name: 'DEDUP',
+    });
+    useMyClaimedNodesSuspense.mockReturnValue({ myClaimedNodes: [claimed] });
+    useMyManagedNodesSuspense.mockReturnValue({ myManagedNodes: [managed] });
+    renderMyNodes();
+    expect(screen.getByText('Managed nodes')).toBeInTheDocument();
+    expect(screen.queryByText('Claimed nodes')).not.toBeInTheDocument();
+    const names = screen.getAllByText('DEDUP');
+    expect(names.length).toBe(1);
+  });
+
+  it('shows online empty state when every claimed-only node is offline', () => {
+    const offline = makeObserved({
+      node_id: 1,
+      last_heard: new Date(NOW.getTime() - MY_NODES_CLAIMED_RECENT_MS - 60_000),
+    });
+    useMyClaimedNodesSuspense.mockReturnValue({ myClaimedNodes: [offline] });
+    useMyManagedNodesSuspense.mockReturnValue({ myManagedNodes: [] });
+    renderMyNodes();
+    expect(screen.getByText('No nodes online right now.')).toBeInTheDocument();
+    expect(screen.queryByText('Last heard recently')).not.toBeInTheDocument();
+    expect(screen.getByText('Offline')).toBeInTheDocument();
+  });
+
+  it('hides Recent and Offline sections when those buckets are empty', () => {
+    const online = makeObserved({
+      node_id: 1,
+      last_heard: new Date(NOW.getTime() - 60_000),
+    });
+    useMyClaimedNodesSuspense.mockReturnValue({ myClaimedNodes: [online] });
+    useMyManagedNodesSuspense.mockReturnValue({ myManagedNodes: [] });
+    renderMyNodes();
+    expect(screen.queryByText('Last heard recently')).not.toBeInTheDocument();
+    expect(screen.queryByText('Offline')).not.toBeInTheDocument();
+  });
+
+  it('shows destructive managed liveness when feeder and radio are stale', () => {
+    const managed = makeManaged({
+      node_id: 7,
+      last_packet_ingested_at: new Date(NOW.getTime() - MY_NODES_FEEDER_FRESH_MS - 120_000),
+      radio_last_heard: new Date(NOW.getTime() - MY_NODES_CLAIMED_ONLINE_MS - 120_000),
+    });
+    useMyClaimedNodesSuspense.mockReturnValue({ myClaimedNodes: [] });
+    useMyManagedNodesSuspense.mockReturnValue({ myManagedNodes: [managed] });
+    renderMyNodes();
+    expect(screen.getByText('Connectivity issue')).toBeInTheDocument();
+    expect(screen.getByText(/Managed node offline/)).toBeInTheDocument();
+  });
+
+  it('renders map section title and map component', () => {
+    useMyClaimedNodesSuspense.mockReturnValue({ myClaimedNodes: [makeObserved()] });
+    useMyManagedNodesSuspense.mockReturnValue({ myManagedNodes: [] });
+    renderMyNodes();
+    expect(screen.getByText('Your nodes on the map')).toBeInTheDocument();
+  });
+});

--- a/src/pages/nodes/MyNodes.tsx
+++ b/src/pages/nodes/MyNodes.tsx
@@ -11,11 +11,17 @@ import { BotSetupInstructions, type BotDefaults } from '@/components/nodes/BotSe
 import { ObservedNode, type NodeWatch } from '@/lib/models';
 import type { NodeApiKeyConstellation } from '@/lib/models';
 import { SetupManagedNode } from '@/components/nodes/SetupManagedNode';
-import { NodesAndConstellationsMap } from '@/components/nodes/NodesAndConstellationsMap';
+import { NodesMap } from '@/components/nodes/NodesMap';
 import { MonitoredNodesBatteryChart } from '@/components/nodes/MonitoredNodesBatteryChart';
 import { MyNodeCard } from '@/components/nodes/MyNodeCard';
 import { useQuery } from '@tanstack/react-query';
 import { useMeshtasticApi } from '@/hooks/api/useApi';
+import {
+  buildNodesForMap,
+  getManagedLiveness,
+  groupClaimedNodes,
+  observedNodeForManagedRow,
+} from '@/lib/my-nodes-grouping';
 import {
   Dialog,
   DialogContent,
@@ -24,6 +30,12 @@ import {
   DialogHeader,
   DialogTitle,
 } from '@/components/ui/dialog';
+
+function hasMapPosition(node: ObservedNode): boolean {
+  const lat = node.latest_position?.latitude;
+  const lon = node.latest_position?.longitude;
+  return lat != null && lon != null && lat !== 0 && lon !== 0;
+}
 
 function MyNodesContent() {
   const navigate = useNavigate();
@@ -50,7 +62,28 @@ function MyNodesContent() {
     return m;
   }, [watchesQuery.data]);
 
-  const managedNodeIds = new Set(myManagedNodes.map((n) => n.node_id));
+  const managedNodeIds = useMemo(() => new Set(myManagedNodes.map((n) => n.node_id)), [myManagedNodes]);
+
+  const claimedByNodeId = useMemo(() => {
+    const m = new Map<number, ObservedNode>();
+    for (const c of myClaimedNodes) {
+      m.set(c.node_id, c);
+    }
+    return m;
+  }, [myClaimedNodes]);
+
+  const claimedOnlyNodes = useMemo(
+    () => myClaimedNodes.filter((n) => !managedNodeIds.has(n.node_id)),
+    [myClaimedNodes, managedNodeIds]
+  );
+
+  const connectivityBuckets = useMemo(() => groupClaimedNodes(claimedOnlyNodes), [claimedOnlyNodes]);
+
+  const mapNodes = useMemo(() => buildNodesForMap(myClaimedNodes, myManagedNodes), [myClaimedNodes, myManagedNodes]);
+
+  const mapNodesWithPosition = useMemo(() => mapNodes.filter(hasMapPosition), [mapNodes]);
+
+  const hasAnyNodes = myManagedNodes.length > 0 || myClaimedNodes.length > 0;
 
   const handleRunAsManagedNode = (node: ObservedNode) => {
     setSelectedNode(node);
@@ -61,14 +94,6 @@ function MyNodesContent() {
     setIsSetupDialogOpen(false);
     setSelectedNode(null);
   };
-
-  const allNodes = [...myClaimedNodes];
-
-  myManagedNodes.forEach((managedNode) => {
-    if (!allNodes.some((node) => node.node_id === managedNode.node_id)) {
-      allNodes.push(managedNode as unknown as ObservedNode);
-    }
-  });
 
   const renderInstructionsModal = () => {
     if (!showInstructionsNode) return null;
@@ -165,53 +190,165 @@ function MyNodesContent() {
 
       {renderInstructionsModal()}
 
-      {allNodes.length > 0 ? (
+      {hasAnyNodes ? (
         <>
-          <Card>
-            <CardHeader>
-              <CardTitle>Your nodes</CardTitle>
-              <CardDescription>
-                Claimed and managed radios in a compact layout. Open a node for full telemetry, position, and settings.
-              </CardDescription>
-            </CardHeader>
-            <CardContent>
-              <div className="grid grid-cols-1 sm:grid-cols-2 xl:grid-cols-3 gap-4">
-                {allNodes.map((node) => {
-                  const isManaged = managedNodeIds.has(node.node_id);
-                  const isClaimed = node.owner?.id !== undefined;
-                  const watch = watchesByNodeIdStr.get(node.node_id_str);
-                  return (
-                    <MyNodeCard
-                      key={node.node_id}
-                      node={node}
-                      isManaged={isManaged}
-                      isClaimed={isClaimed}
-                      watch={watch}
-                      watchesQuery={watchesQuery}
-                      onConvert={() => handleRunAsManagedNode(node)}
-                      onShowSetupInstructions={() => {
-                        setShowInstructionsNode(node);
-                        setInstructionsModalOpen(true);
-                      }}
-                    />
-                  );
-                })}
-              </div>
-            </CardContent>
-          </Card>
+          {myManagedNodes.length > 0 ? (
+            <Card>
+              <CardHeader>
+                <CardTitle>Managed nodes</CardTitle>
+                <CardDescription>
+                  Radios reporting into Meshflow as managed feeders. Open a node for full telemetry, position, and
+                  settings.
+                </CardDescription>
+              </CardHeader>
+              <CardContent>
+                <div className="grid grid-cols-1 sm:grid-cols-2 xl:grid-cols-3 gap-4">
+                  {myManagedNodes.map((managed) => {
+                    const node = observedNodeForManagedRow(managed, claimedByNodeId.get(managed.node_id));
+                    const watch = watchesByNodeIdStr.get(node.node_id_str);
+                    const liveness = getManagedLiveness(managed);
+                    return (
+                      <MyNodeCard
+                        key={`managed-${managed.node_id}`}
+                        node={node}
+                        isManaged
+                        isClaimed={node.owner?.id !== undefined}
+                        showClaimedBadge={false}
+                        managedLiveness={liveness}
+                        watch={watch}
+                        watchesQuery={watchesQuery}
+                        onConvert={() => handleRunAsManagedNode(node)}
+                        onShowSetupInstructions={() => {
+                          setShowInstructionsNode(node);
+                          setInstructionsModalOpen(true);
+                        }}
+                      />
+                    );
+                  })}
+                </div>
+              </CardContent>
+            </Card>
+          ) : null}
+
+          {claimedOnlyNodes.length > 0 ? (
+            <Card>
+              <CardHeader>
+                <CardTitle>Claimed nodes</CardTitle>
+                <CardDescription>
+                  Radios you own that are not in the managed list above. Grouped by how recently the mesh last heard
+                  them.
+                </CardDescription>
+              </CardHeader>
+              <CardContent className="space-y-8">
+                <section className="space-y-3" aria-labelledby="my-nodes-online-heading">
+                  <h2 id="my-nodes-online-heading" className="text-base font-semibold">
+                    Online
+                  </h2>
+                  {connectivityBuckets.online.length > 0 ? (
+                    <div className="grid grid-cols-1 sm:grid-cols-2 xl:grid-cols-3 gap-4">
+                      {connectivityBuckets.online.map((node) => {
+                        const watch = watchesByNodeIdStr.get(node.node_id_str);
+                        return (
+                          <MyNodeCard
+                            key={node.node_id}
+                            node={node}
+                            isManaged={false}
+                            isClaimed={node.owner?.id !== undefined}
+                            showClaimedBadge={false}
+                            watch={watch}
+                            watchesQuery={watchesQuery}
+                            onConvert={() => handleRunAsManagedNode(node)}
+                            onShowSetupInstructions={() => {
+                              setShowInstructionsNode(node);
+                              setInstructionsModalOpen(true);
+                            }}
+                          />
+                        );
+                      })}
+                    </div>
+                  ) : (
+                    <p className="text-sm text-muted-foreground rounded-md border border-dashed px-4 py-6 text-center">
+                      No nodes online right now.
+                    </p>
+                  )}
+                </section>
+
+                {connectivityBuckets.recent.length > 0 ? (
+                  <section className="space-y-3" aria-labelledby="my-nodes-recent-heading">
+                    <h2 id="my-nodes-recent-heading" className="text-base font-semibold">
+                      Last heard recently
+                    </h2>
+                    <div className="grid grid-cols-1 sm:grid-cols-2 xl:grid-cols-3 gap-4">
+                      {connectivityBuckets.recent.map((node) => {
+                        const watch = watchesByNodeIdStr.get(node.node_id_str);
+                        return (
+                          <MyNodeCard
+                            key={node.node_id}
+                            node={node}
+                            isManaged={false}
+                            isClaimed={node.owner?.id !== undefined}
+                            showClaimedBadge={false}
+                            watch={watch}
+                            watchesQuery={watchesQuery}
+                            onConvert={() => handleRunAsManagedNode(node)}
+                            onShowSetupInstructions={() => {
+                              setShowInstructionsNode(node);
+                              setInstructionsModalOpen(true);
+                            }}
+                          />
+                        );
+                      })}
+                    </div>
+                  </section>
+                ) : null}
+
+                {connectivityBuckets.offline.length > 0 ? (
+                  <section className="space-y-3" aria-labelledby="my-nodes-offline-heading">
+                    <h2 id="my-nodes-offline-heading" className="text-base font-semibold">
+                      Offline
+                    </h2>
+                    <div className="grid grid-cols-1 sm:grid-cols-2 xl:grid-cols-3 gap-4">
+                      {connectivityBuckets.offline.map((node) => {
+                        const watch = watchesByNodeIdStr.get(node.node_id_str);
+                        return (
+                          <MyNodeCard
+                            key={node.node_id}
+                            node={node}
+                            isManaged={false}
+                            isClaimed={node.owner?.id !== undefined}
+                            showClaimedBadge={false}
+                            watch={watch}
+                            watchesQuery={watchesQuery}
+                            onConvert={() => handleRunAsManagedNode(node)}
+                            onShowSetupInstructions={() => {
+                              setShowInstructionsNode(node);
+                              setInstructionsModalOpen(true);
+                            }}
+                          />
+                        );
+                      })}
+                    </div>
+                  </section>
+                ) : null}
+              </CardContent>
+            </Card>
+          ) : null}
 
           <section className="space-y-2" aria-labelledby="my-nodes-map-heading">
             <h2 id="my-nodes-map-heading" className="text-lg font-semibold">
-              Constellation map
+              Your nodes on the map
             </h2>
             <CollapsibleSection title="Map" defaultOpen={false}>
-              <div className="h-[min(600px,70vh)] min-h-[320px] bg-background rounded-lg border">
-                <NodesAndConstellationsMap
-                  managedNodes={myManagedNodes}
-                  observedNodes={myClaimedNodes}
-                  showConstellation={true}
-                  showUnmanagedNodes={true}
-                />
+              <div className="space-y-2">
+                {mapNodesWithPosition.length === 0 ? (
+                  <p className="text-sm text-muted-foreground px-1">
+                    None of your nodes have a valid GPS position yet. Open a node’s details after it reports position to
+                    see it here.
+                  </p>
+                ) : null}
+                <div className="h-[min(600px,70vh)] min-h-[320px] bg-background rounded-lg border">
+                  <NodesMap nodes={mapNodes} />
+                </div>
               </div>
             </CollapsibleSection>
           </section>
@@ -222,7 +359,7 @@ function MyNodesContent() {
             </h2>
             <CollapsibleSection title="Battery chart" defaultOpen={false}>
               <div className="bg-background rounded-lg border">
-                <MonitoredNodesBatteryChart nodes={allNodes} />
+                <MonitoredNodesBatteryChart nodes={mapNodes} />
               </div>
             </CollapsibleSection>
           </section>


### PR DESCRIPTION
## Summary

Implements [issue #192](https://github.com/pskillen/meshtastic-bot-ui/issues/192): refresh **My Nodes** with a managed-only section (dual-signal feeder + mesh liveness warnings), claimed-only connectivity buckets (Online always + empty state; Recent/Offline only when non-empty), `NodesMap` instead of the constellations map, clearer GPS labels with tooltips, no redundant Claimed badge on this page, and stronger dark-mode card borders. Grouping logic lives in `src/lib/my-nodes-grouping.ts` with unit tests.

Also on **Node Details → Traceroutes** (for managed nodes): new **Outgoing traceroutes** card with feeder classification moved here from Overview, plus a short outgoing traceroute list (same shape as incoming) and a link to the full history filtered by `source_node`.

**Recency documentation:** this branch does **not** add `RECENCY.md` in the UI repo. That content is being moved to **meshflow-api** as the authoritative doc (see the companion change there when it lands).

**Closes #192**

## Testing performed

- `npm test` (Vitest), including `my-nodes-grouping`, `MyNodeCard`, `MyNodes`, `NodeOutgoingTraceroutesSection`, and existing suites
- `npm run build`
- `npm run lint` (0 errors; existing repo warnings only)
