### PR TITLE
feat(traceroutes): coverage maps — strategy filter, towers, heard ghosts

### DIFF
--- a/src/components/map/FeederIconLayer.tsx
+++ b/src/components/map/FeederIconLayer.tsx
@@ -1,0 +1,46 @@
+import { IconLayer } from '@deck.gl/layers';
+
+import type { FeederReachFeeder } from '@/lib/api/meshtastic-api';
+
+/** Broadcast tower on slate disc — visually distinct from reliability dots. */
+const FEEDER_TOWER_ICON_SVG = `<svg xmlns="http://www.w3.org/2000/svg" width="72" height="72" viewBox="0 0 72 72">
+  <defs>
+    <filter id="fs" x="-20%" y="-20%" width="140%" height="140%">
+      <feDropShadow dx="0" dy="1" stdDeviation="2" flood-color="#000" flood-opacity="0.45"/>
+    </filter>
+  </defs>
+  <circle cx="36" cy="38" r="24" fill="#0f172a" stroke="#f8fafc" stroke-width="2.5" filter="url(#fs)"/>
+  <rect x="33" y="14" width="6" height="22" fill="#fb923c" stroke="#fff7ed" stroke-width="1"/>
+  <path d="M22 30 L50 30 L46 16 L26 16 Z" fill="#fb923c" stroke="#fff7ed" stroke-width="1"/>
+  <line x1="18" y1="16" x2="54" y2="16" stroke="#f8fafc" stroke-width="2" stroke-linecap="round"/>
+  <line x1="26" y1="10" x2="46" y2="10" stroke="#f8fafc" stroke-width="1.5" stroke-linecap="round"/>
+</svg>`;
+
+const FEEDER_TOWER_ICON_URL = `data:image/svg+xml;charset=utf-8,${encodeURIComponent(FEEDER_TOWER_ICON_SVG)}`;
+
+const FEEDER_ICON_DESCRIPTOR = {
+  url: FEEDER_TOWER_ICON_URL,
+  width: 72,
+  height: 72,
+  anchorY: 72,
+} as const;
+
+export type FeederIconDatum = Pick<
+  FeederReachFeeder,
+  'lat' | 'lng' | 'node_id' | 'node_id_str' | 'short_name' | 'long_name' | 'managed_node_id'
+> & { lat: number; lng: number };
+
+export function buildFeederIconLayer<T extends FeederIconDatum>(
+  data: T[],
+  options?: { id?: string; size?: number; pickable?: boolean }
+): IconLayer<T> {
+  return new IconLayer<T>({
+    id: options?.id ?? 'feeder-tower-icons',
+    data,
+    pickable: options?.pickable ?? true,
+    getPosition: (d) => [d.lng, d.lat],
+    getIcon: () => FEEDER_ICON_DESCRIPTOR,
+    getSize: options?.size ?? 36,
+    sizeUnits: 'pixels',
+  });
+}

--- a/src/components/map/coverageStyling.ts
+++ b/src/components/map/coverageStyling.ts
@@ -1,0 +1,32 @@
+/** Shared reliability ramp and dot sizing for traceroute coverage maps. */
+
+export const LOW_CONFIDENCE_COLOR: [number, number, number, number] = [148, 163, 184, 140];
+
+export function smoothedRate(successes: number, attempts: number): number {
+  return (successes + 1) / (attempts + 2);
+}
+
+/** Map a smoothed reliability (0..1) to red→amber→green. */
+export function reliabilityColor(rate: number, alpha = 220): [number, number, number, number] {
+  const t = Math.max(0, Math.min(1, rate));
+  let r: number;
+  let g: number;
+  let b: number;
+  if (t < 0.7) {
+    const k = t / 0.7;
+    r = Math.round(239 + (245 - 239) * k);
+    g = Math.round(68 + (158 - 68) * k);
+    b = Math.round(68 + (11 - 68) * k);
+  } else {
+    const k = Math.min(1, (t - 0.7) / 0.2);
+    r = Math.round(245 + (34 - 245) * k);
+    g = Math.round(158 + (197 - 158) * k);
+    b = Math.round(11 + (94 - 11) * k);
+  }
+  return [r, g, b, alpha];
+}
+
+/** Scale attempts to a pixel radius, clamped to [6, 30]. */
+export function attemptsToRadius(attempts: number): number {
+  return Math.max(6, Math.min(30, 6 + Math.sqrt(attempts) * 3));
+}

--- a/src/components/traceroutes/ConstellationCoverageMap.tsx
+++ b/src/components/traceroutes/ConstellationCoverageMap.tsx
@@ -15,10 +15,11 @@ import {
 } from '@/components/map/coverageStyling';
 import { DeckMapboxMap } from '@/components/map/DeckMapboxMap';
 import type { ConstellationCoverageHex, ConstellationCoverageTarget } from '@/lib/api/meshtastic-api';
+import type { CoverageHeardGhost } from '@/lib/coverageHeardGhosts';
 
 const DEFAULT_CENTER = { longitude: -4.2518, latitude: 55.8642, zoom: 7 };
 
-export type ConstellationMapLayerKey = 'hex' | 'dots' | 'feeders';
+export type ConstellationMapLayerKey = 'hex' | 'dots' | 'feeders' | 'heard';
 
 export interface SmoothedHex extends ConstellationCoverageHex {
   smoothed: number;
@@ -32,10 +33,15 @@ function feederLabel(f: FeederIconDatum): string {
   return f.short_name || f.long_name || f.node_id_str || `!${f.node_id.toString(16)}`;
 }
 
+function ghostLabel(g: CoverageHeardGhost): string {
+  return g.short_name || g.long_name || g.node_id_str || `!${g.node_id.toString(16)}`;
+}
+
 export interface ConstellationCoverageMapProps {
   hexes: ConstellationCoverageHex[];
   targets?: ConstellationCoverageTarget[];
   feeders?: FeederIconDatum[];
+  heardGhosts: CoverageHeardGhost[];
   enabledLayers: ConstellationMapLayerKey[];
   minAttempts: number;
 }
@@ -44,12 +50,14 @@ export function ConstellationCoverageMap({
   hexes,
   targets = [],
   feeders = [],
+  heardGhosts,
   enabledLayers,
   minAttempts,
 }: ConstellationCoverageMapProps) {
   const [selectedHex, setSelectedHex] = useState<SmoothedHex | null>(null);
   const [selectedTarget, setSelectedTarget] = useState<ConstellationCoverageTarget | null>(null);
   const [selectedFeeder, setSelectedFeeder] = useState<FeederIconDatum | null>(null);
+  const [selectedHeardGhost, setSelectedHeardGhost] = useState<CoverageHeardGhost | null>(null);
 
   const enabledSet = useMemo(() => new Set(enabledLayers), [enabledLayers]);
 
@@ -95,6 +103,22 @@ export function ConstellationCoverageMap({
     });
   }, [enabledSet, targets, minAttempts]);
 
+  const heardGhostsLayer = useMemo(() => {
+    if (!enabledSet.has('heard') || heardGhosts.length === 0) return null;
+    return new ScatterplotLayer<CoverageHeardGhost>({
+      id: 'constellation-coverage-heard-ghosts',
+      data: heardGhosts,
+      getPosition: (d) => [d.lng, d.lat],
+      getRadius: 4,
+      radiusUnits: 'pixels',
+      filled: false,
+      stroked: true,
+      lineWidthMinPixels: 1.5,
+      getLineColor: [100, 116, 139, 220],
+      pickable: true,
+    });
+  }, [enabledSet, heardGhosts]);
+
   const feederIconLayer = useMemo(() => {
     if (!enabledSet.has('feeders') || feeders.length === 0) return null;
     const positioned = feeders.filter((f) => f.lat != null && f.lng != null);
@@ -107,8 +131,8 @@ export function ConstellationCoverageMap({
   }, [enabledSet, feeders]);
 
   const layers = useMemo(
-    () => [hexLayer, dotsLayer, feederIconLayer].filter(Boolean) as Layer[],
-    [hexLayer, dotsLayer, feederIconLayer]
+    () => [hexLayer, heardGhostsLayer, dotsLayer, feederIconLayer].filter(Boolean) as Layer[],
+    [hexLayer, heardGhostsLayer, dotsLayer, feederIconLayer]
   );
 
   const handleClick = useCallback((info: PickingInfo) => {
@@ -117,11 +141,20 @@ export function ConstellationCoverageMap({
       setSelectedFeeder(info.object as FeederIconDatum);
       setSelectedHex(null);
       setSelectedTarget(null);
+      setSelectedHeardGhost(null);
       return;
     }
     if (lid === 'constellation-coverage-dots' && info.object) {
       setSelectedTarget(info.object as ConstellationCoverageTarget);
       setSelectedHex(null);
+      setSelectedFeeder(null);
+      setSelectedHeardGhost(null);
+      return;
+    }
+    if (lid === 'constellation-coverage-heard-ghosts' && info.object) {
+      setSelectedHeardGhost(info.object as CoverageHeardGhost);
+      setSelectedHex(null);
+      setSelectedTarget(null);
       setSelectedFeeder(null);
       return;
     }
@@ -129,11 +162,13 @@ export function ConstellationCoverageMap({
       setSelectedHex(info.object as SmoothedHex);
       setSelectedTarget(null);
       setSelectedFeeder(null);
+      setSelectedHeardGhost(null);
       return;
     }
     setSelectedHex(null);
     setSelectedTarget(null);
     setSelectedFeeder(null);
+    setSelectedHeardGhost(null);
   }, []);
 
   return (
@@ -143,6 +178,44 @@ export function ConstellationCoverageMap({
       onClick={handleClick}
       data-testid="constellation-coverage-map-container"
     >
+      {selectedHeardGhost && (
+        <Popup
+          longitude={selectedHeardGhost.lng}
+          latitude={selectedHeardGhost.lat}
+          anchor="bottom"
+          closeButton={false}
+          closeOnClick={false}
+          onClose={() => setSelectedHeardGhost(null)}
+          maxWidth="320px"
+          className="meshflow-map-popup"
+        >
+          <div className="relative min-w-[180px] rounded-md border border-slate-600 bg-slate-800 px-3 py-2 text-sm text-slate-100 shadow-lg">
+            <button
+              type="button"
+              onClick={() => setSelectedHeardGhost(null)}
+              className="absolute right-1 top-1 rounded p-0.5 text-slate-400 hover:bg-slate-700 hover:text-slate-200"
+              aria-label="Close"
+            >
+              <X className="h-3.5 w-3.5" aria-hidden />
+            </button>
+            <div className="pr-5">
+              <div className="text-xs font-medium uppercase tracking-wide text-slate-400">
+                Heard (no traceroute row)
+              </div>
+              <div className="mt-0.5 font-semibold">{ghostLabel(selectedHeardGhost)}</div>
+              <div className="mt-0.5 text-xs text-slate-400">
+                {selectedHeardGhost.node_id_str || `!${selectedHeardGhost.node_id.toString(16)}`}
+              </div>
+              <Link
+                to={`/nodes/${selectedHeardGhost.node_id}`}
+                className="mt-1 inline-block text-xs text-emerald-400 hover:text-emerald-300 hover:underline"
+              >
+                Open details
+              </Link>
+            </div>
+          </div>
+        </Popup>
+      )}
       {selectedHex && (
         <Popup
           longitude={selectedHex.centre_lng}

--- a/src/components/traceroutes/ConstellationCoverageMap.tsx
+++ b/src/components/traceroutes/ConstellationCoverageMap.tsx
@@ -1,49 +1,57 @@
 import { useCallback, useMemo, useState } from 'react';
+import { Link } from 'react-router-dom';
 import { Popup } from 'react-map-gl';
+import { ScatterplotLayer } from '@deck.gl/layers';
 import { H3HexagonLayer } from '@deck.gl/geo-layers';
 import type { Layer, PickingInfo } from '@deck.gl/core';
 import { X } from 'lucide-react';
 
+import { buildFeederIconLayer, type FeederIconDatum } from '@/components/map/FeederIconLayer';
+import {
+  attemptsToRadius,
+  LOW_CONFIDENCE_COLOR,
+  reliabilityColor,
+  smoothedRate,
+} from '@/components/map/coverageStyling';
 import { DeckMapboxMap } from '@/components/map/DeckMapboxMap';
-import type { ConstellationCoverageHex } from '@/lib/api/meshtastic-api';
+import type { ConstellationCoverageHex, ConstellationCoverageTarget } from '@/lib/api/meshtastic-api';
 
 const DEFAULT_CENTER = { longitude: -4.2518, latitude: 55.8642, zoom: 7 };
-const LOW_CONFIDENCE_COLOR: [number, number, number, number] = [148, 163, 184, 140];
+
+export type ConstellationMapLayerKey = 'hex' | 'dots' | 'feeders';
 
 export interface SmoothedHex extends ConstellationCoverageHex {
   smoothed: number;
 }
 
-function smoothedRate(successes: number, attempts: number): number {
-  return (successes + 1) / (attempts + 2);
+function getTargetLabel(t: ConstellationCoverageTarget): string {
+  return t.short_name || t.long_name || t.node_id_str || `!${t.node_id.toString(16)}`;
 }
 
-function reliabilityColor(rate: number, alpha = 160): [number, number, number, number] {
-  const t = Math.max(0, Math.min(1, rate));
-  let r: number;
-  let g: number;
-  let b: number;
-  if (t < 0.7) {
-    const k = t / 0.7;
-    r = Math.round(239 + (245 - 239) * k);
-    g = Math.round(68 + (158 - 68) * k);
-    b = Math.round(68 + (11 - 68) * k);
-  } else {
-    const k = Math.min(1, (t - 0.7) / 0.2);
-    r = Math.round(245 + (34 - 245) * k);
-    g = Math.round(158 + (197 - 158) * k);
-    b = Math.round(11 + (94 - 11) * k);
-  }
-  return [r, g, b, alpha];
+function feederLabel(f: FeederIconDatum): string {
+  return f.short_name || f.long_name || f.node_id_str || `!${f.node_id.toString(16)}`;
 }
 
 export interface ConstellationCoverageMapProps {
   hexes: ConstellationCoverageHex[];
+  targets?: ConstellationCoverageTarget[];
+  feeders?: FeederIconDatum[];
+  enabledLayers: ConstellationMapLayerKey[];
   minAttempts: number;
 }
 
-export function ConstellationCoverageMap({ hexes, minAttempts }: ConstellationCoverageMapProps) {
+export function ConstellationCoverageMap({
+  hexes,
+  targets = [],
+  feeders = [],
+  enabledLayers,
+  minAttempts,
+}: ConstellationCoverageMapProps) {
   const [selectedHex, setSelectedHex] = useState<SmoothedHex | null>(null);
+  const [selectedTarget, setSelectedTarget] = useState<ConstellationCoverageTarget | null>(null);
+  const [selectedFeeder, setSelectedFeeder] = useState<FeederIconDatum | null>(null);
+
+  const enabledSet = useMemo(() => new Set(enabledLayers), [enabledLayers]);
 
   const smoothedHexes: SmoothedHex[] = useMemo(
     () =>
@@ -54,8 +62,8 @@ export function ConstellationCoverageMap({ hexes, minAttempts }: ConstellationCo
     [hexes]
   );
 
-  const layer = useMemo(() => {
-    if (smoothedHexes.length === 0) return null;
+  const hexLayer = useMemo(() => {
+    if (!enabledSet.has('hex') || smoothedHexes.length === 0) return null;
     return new H3HexagonLayer<SmoothedHex>({
       id: 'constellation-coverage-hex',
       data: smoothedHexes,
@@ -63,21 +71,69 @@ export function ConstellationCoverageMap({ hexes, minAttempts }: ConstellationCo
       extruded: false,
       stroked: true,
       filled: true,
-      getFillColor: (d) => (d.attempts < minAttempts ? LOW_CONFIDENCE_COLOR : reliabilityColor(d.smoothed)),
+      getFillColor: (d) => (d.attempts < minAttempts ? LOW_CONFIDENCE_COLOR : reliabilityColor(d.smoothed, 160)),
       getLineColor: [15, 23, 42, 180],
       lineWidthMinPixels: 1,
       pickable: true,
     });
-  }, [smoothedHexes, minAttempts]);
+  }, [smoothedHexes, minAttempts, enabledSet]);
 
-  const layers = useMemo(() => [layer].filter(Boolean) as Layer[], [layer]);
+  const dotsLayer = useMemo(() => {
+    if (!enabledSet.has('dots') || targets.length === 0) return null;
+    return new ScatterplotLayer<ConstellationCoverageTarget>({
+      id: 'constellation-coverage-dots',
+      data: targets,
+      getPosition: (d) => [d.lng, d.lat],
+      getFillColor: (d) =>
+        d.attempts < minAttempts ? LOW_CONFIDENCE_COLOR : reliabilityColor(smoothedRate(d.successes, d.attempts)),
+      getRadius: (d) => attemptsToRadius(d.attempts),
+      radiusUnits: 'pixels',
+      stroked: true,
+      lineWidthMinPixels: 1,
+      getLineColor: [15, 23, 42, 200],
+      pickable: true,
+    });
+  }, [enabledSet, targets, minAttempts]);
+
+  const feederIconLayer = useMemo(() => {
+    if (!enabledSet.has('feeders') || feeders.length === 0) return null;
+    const positioned = feeders.filter((f) => f.lat != null && f.lng != null);
+    if (positioned.length === 0) return null;
+    return buildFeederIconLayer(positioned, {
+      id: 'constellation-feeder-tower-icons',
+      size: 38,
+      pickable: true,
+    });
+  }, [enabledSet, feeders]);
+
+  const layers = useMemo(
+    () => [hexLayer, dotsLayer, feederIconLayer].filter(Boolean) as Layer[],
+    [hexLayer, dotsLayer, feederIconLayer]
+  );
 
   const handleClick = useCallback((info: PickingInfo) => {
-    if (info.object && info.layer?.id === 'constellation-coverage-hex') {
-      setSelectedHex(info.object as SmoothedHex);
-    } else {
+    const lid = info.layer?.id;
+    if (lid === 'constellation-feeder-tower-icons' && info.object) {
+      setSelectedFeeder(info.object as FeederIconDatum);
       setSelectedHex(null);
+      setSelectedTarget(null);
+      return;
     }
+    if (lid === 'constellation-coverage-dots' && info.object) {
+      setSelectedTarget(info.object as ConstellationCoverageTarget);
+      setSelectedHex(null);
+      setSelectedFeeder(null);
+      return;
+    }
+    if (lid === 'constellation-coverage-hex' && info.object) {
+      setSelectedHex(info.object as SmoothedHex);
+      setSelectedTarget(null);
+      setSelectedFeeder(null);
+      return;
+    }
+    setSelectedHex(null);
+    setSelectedTarget(null);
+    setSelectedFeeder(null);
   }, []);
 
   return (
@@ -118,6 +174,95 @@ export function ConstellationCoverageMap({ hexes, minAttempts }: ConstellationCo
                 {selectedHex.contributing_feeders} feeder{selectedHex.contributing_feeders === 1 ? '' : 's'},{' '}
                 {selectedHex.contributing_targets} target{selectedHex.contributing_targets === 1 ? '' : 's'}
               </div>
+            </div>
+          </div>
+        </Popup>
+      )}
+      {selectedTarget && (
+        <Popup
+          longitude={selectedTarget.lng}
+          latitude={selectedTarget.lat}
+          anchor="bottom"
+          closeButton={false}
+          closeOnClick={false}
+          onClose={() => setSelectedTarget(null)}
+          maxWidth="320px"
+          className="meshflow-map-popup"
+        >
+          <div className="relative min-w-[180px] rounded-md border border-slate-600 bg-slate-800 px-3 py-2 text-sm text-slate-100 shadow-lg">
+            <button
+              type="button"
+              onClick={() => setSelectedTarget(null)}
+              className="absolute right-1 top-1 rounded p-0.5 text-slate-400 hover:bg-slate-700 hover:text-slate-200"
+              aria-label="Close"
+            >
+              <X className="h-3.5 w-3.5" aria-hidden />
+            </button>
+            <div className="pr-5">
+              <div className="font-semibold">
+                {selectedTarget.long_name && selectedTarget.short_name
+                  ? `${selectedTarget.long_name} (${selectedTarget.short_name})`
+                  : getTargetLabel(selectedTarget)}
+              </div>
+              <div className="mt-0.5 text-xs text-slate-400">
+                {selectedTarget.node_id_str || `!${selectedTarget.node_id.toString(16)}`}
+              </div>
+              <div className="mt-1 text-xs">
+                {selectedTarget.successes} / {selectedTarget.attempts} (
+                {selectedTarget.attempts > 0
+                  ? ((selectedTarget.successes / selectedTarget.attempts) * 100).toFixed(0)
+                  : '0'}
+                % raw)
+              </div>
+              <div className="text-xs">
+                Smoothed: {(smoothedRate(selectedTarget.successes, selectedTarget.attempts) * 100).toFixed(0)}%
+              </div>
+              <div className="text-xs text-slate-400">
+                {selectedTarget.contributing_feeders} contributing feeder
+                {selectedTarget.contributing_feeders === 1 ? '' : 's'}
+              </div>
+              <Link
+                to={`/nodes/${selectedTarget.node_id}`}
+                className="mt-1 inline-block text-xs text-emerald-400 hover:text-emerald-300 hover:underline"
+              >
+                Open details
+              </Link>
+            </div>
+          </div>
+        </Popup>
+      )}
+      {selectedFeeder && (
+        <Popup
+          longitude={selectedFeeder.lng}
+          latitude={selectedFeeder.lat}
+          anchor="bottom"
+          closeButton={false}
+          closeOnClick={false}
+          onClose={() => setSelectedFeeder(null)}
+          maxWidth="320px"
+          className="meshflow-map-popup"
+        >
+          <div className="relative min-w-[180px] rounded-md border border-slate-600 bg-slate-800 px-3 py-2 text-sm text-slate-100 shadow-lg">
+            <button
+              type="button"
+              onClick={() => setSelectedFeeder(null)}
+              className="absolute right-1 top-1 rounded p-0.5 text-slate-400 hover:bg-slate-700 hover:text-slate-200"
+              aria-label="Close"
+            >
+              <X className="h-3.5 w-3.5" aria-hidden />
+            </button>
+            <div className="pr-5">
+              <div className="text-xs font-medium uppercase tracking-wide text-amber-400">Managed node (feeder)</div>
+              <div className="mt-0.5 font-semibold">{feederLabel(selectedFeeder)}</div>
+              <div className="mt-0.5 text-xs text-slate-400">
+                {selectedFeeder.node_id_str || `!${selectedFeeder.node_id.toString(16)}`}
+              </div>
+              <Link
+                to={`/nodes/${selectedFeeder.node_id}`}
+                className="mt-1 inline-block text-xs text-emerald-400 hover:text-emerald-300 hover:underline"
+              >
+                Open details
+              </Link>
             </div>
           </div>
         </Popup>

--- a/src/components/traceroutes/FeederCoverageMap.tsx
+++ b/src/components/traceroutes/FeederCoverageMap.tsx
@@ -19,8 +19,9 @@ import {
 } from '@/components/map/coverageStyling';
 import { DeckMapboxMap } from '@/components/map/DeckMapboxMap';
 import type { FeederReachFeeder, FeederReachTarget } from '@/lib/api/meshtastic-api';
+import type { CoverageHeardGhost } from '@/lib/coverageHeardGhosts';
 
-export type CoverageLayerKey = 'dots' | 'hex' | 'polygon';
+export type CoverageLayerKey = 'dots' | 'hex' | 'polygon' | 'heard';
 
 const DEFAULT_CENTER = { longitude: -4.2518, latitude: 55.8642, zoom: 8 };
 const POLYGON_FILL: [number, number, number, number] = [99, 102, 241, 50];
@@ -45,13 +46,25 @@ interface HexBin {
 export interface FeederCoverageMapProps {
   feeder: FeederReachFeeder;
   targets: FeederReachTarget[];
+  heardGhosts: CoverageHeardGhost[];
   enabledLayers: CoverageLayerKey[];
   minAttempts: number;
 }
 
-export function FeederCoverageMap({ feeder, targets, enabledLayers, minAttempts }: FeederCoverageMapProps) {
+function ghostLabel(g: CoverageHeardGhost): string {
+  return g.short_name || g.long_name || g.node_id_str || `!${g.node_id.toString(16)}`;
+}
+
+export function FeederCoverageMap({
+  feeder,
+  targets,
+  heardGhosts,
+  enabledLayers,
+  minAttempts,
+}: FeederCoverageMapProps) {
   const [selectedTarget, setSelectedTarget] = useState<FeederReachTarget | null>(null);
   const [selectedFeederMarker, setSelectedFeederMarker] = useState<FeederReachFeeder | null>(null);
+  const [selectedHeardGhost, setSelectedHeardGhost] = useState<CoverageHeardGhost | null>(null);
 
   const enabledSet = useMemo(() => new Set(enabledLayers), [enabledLayers]);
 
@@ -144,6 +157,22 @@ export function FeederCoverageMap({ feeder, targets, enabledLayers, minAttempts 
     });
   }, [polygonFeature]);
 
+  const heardGhostsLayer = useMemo(() => {
+    if (!enabledSet.has('heard') || heardGhosts.length === 0) return null;
+    return new ScatterplotLayer<CoverageHeardGhost>({
+      id: 'feeder-coverage-heard-ghosts',
+      data: heardGhosts,
+      getPosition: (d) => [d.lng, d.lat],
+      getRadius: 4,
+      radiusUnits: 'pixels',
+      filled: false,
+      stroked: true,
+      lineWidthMinPixels: 1.5,
+      getLineColor: [100, 116, 139, 220],
+      pickable: true,
+    });
+  }, [enabledSet, heardGhosts]);
+
   const feederIconLayer = useMemo(() => {
     if (feeder.lat == null || feeder.lng == null) return null;
     return buildFeederIconLayer([{ ...feeder, lat: feeder.lat, lng: feeder.lng }], {
@@ -154,23 +183,33 @@ export function FeederCoverageMap({ feeder, targets, enabledLayers, minAttempts 
   }, [feeder]);
 
   const layers = useMemo(
-    () => [polygonLayer, hexLayer, dotsLayer, feederIconLayer].filter(Boolean) as Layer[],
-    [polygonLayer, hexLayer, dotsLayer, feederIconLayer]
+    () => [polygonLayer, hexLayer, heardGhostsLayer, dotsLayer, feederIconLayer].filter(Boolean) as Layer[],
+    [polygonLayer, hexLayer, heardGhostsLayer, dotsLayer, feederIconLayer]
   );
 
   const handleClick = useCallback((info: PickingInfo) => {
-    if (info.layer?.id === 'feeder-coverage-feeder-icons' && info.object) {
+    const lid = info.layer?.id;
+    if (lid === 'feeder-coverage-feeder-icons' && info.object) {
       setSelectedFeederMarker(info.object as FeederReachFeeder);
       setSelectedTarget(null);
+      setSelectedHeardGhost(null);
       return;
     }
-    if (info.object && info.layer?.id === 'feeder-coverage-dots') {
+    if (lid === 'feeder-coverage-dots' && info.object) {
       setSelectedTarget(info.object as FeederReachTarget);
       setSelectedFeederMarker(null);
-    } else {
+      setSelectedHeardGhost(null);
+      return;
+    }
+    if (lid === 'feeder-coverage-heard-ghosts' && info.object) {
+      setSelectedHeardGhost(info.object as CoverageHeardGhost);
       setSelectedTarget(null);
       setSelectedFeederMarker(null);
+      return;
     }
+    setSelectedTarget(null);
+    setSelectedFeederMarker(null);
+    setSelectedHeardGhost(null);
   }, []);
 
   const initialView = useMemo(() => {
@@ -228,6 +267,44 @@ export function FeederCoverageMap({ feeder, targets, enabledLayers, minAttempts 
               </div>
               <Link
                 to={`/nodes/${selectedTarget.node_id}`}
+                className="mt-1 inline-block text-xs text-emerald-400 hover:text-emerald-300 hover:underline"
+              >
+                Open details
+              </Link>
+            </div>
+          </div>
+        </Popup>
+      )}
+      {selectedHeardGhost && (
+        <Popup
+          longitude={selectedHeardGhost.lng}
+          latitude={selectedHeardGhost.lat}
+          anchor="bottom"
+          closeButton={false}
+          closeOnClick={false}
+          onClose={() => setSelectedHeardGhost(null)}
+          maxWidth="320px"
+          className="meshflow-map-popup"
+        >
+          <div className="relative min-w-[180px] rounded-md border border-slate-600 bg-slate-800 px-3 py-2 text-sm text-slate-100 shadow-lg">
+            <button
+              type="button"
+              onClick={() => setSelectedHeardGhost(null)}
+              className="absolute right-1 top-1 rounded p-0.5 text-slate-400 hover:bg-slate-700 hover:text-slate-200"
+              aria-label="Close"
+            >
+              <X className="h-3.5 w-3.5" aria-hidden />
+            </button>
+            <div className="pr-5">
+              <div className="text-xs font-medium uppercase tracking-wide text-slate-400">
+                Heard (no traceroute row)
+              </div>
+              <div className="mt-0.5 font-semibold">{ghostLabel(selectedHeardGhost)}</div>
+              <div className="mt-0.5 text-xs text-slate-400">
+                {selectedHeardGhost.node_id_str || `!${selectedHeardGhost.node_id.toString(16)}`}
+              </div>
+              <Link
+                to={`/nodes/${selectedHeardGhost.node_id}`}
                 className="mt-1 inline-block text-xs text-emerald-400 hover:text-emerald-300 hover:underline"
               >
                 Open details

--- a/src/components/traceroutes/FeederCoverageMap.tsx
+++ b/src/components/traceroutes/FeederCoverageMap.tsx
@@ -10,49 +10,29 @@ import type { Feature, MultiPolygon, Polygon } from 'geojson';
 import { Link } from 'react-router-dom';
 import { X } from 'lucide-react';
 
+import { buildFeederIconLayer } from '@/components/map/FeederIconLayer';
+import {
+  attemptsToRadius,
+  LOW_CONFIDENCE_COLOR,
+  reliabilityColor,
+  smoothedRate,
+} from '@/components/map/coverageStyling';
 import { DeckMapboxMap } from '@/components/map/DeckMapboxMap';
 import type { FeederReachFeeder, FeederReachTarget } from '@/lib/api/meshtastic-api';
 
 export type CoverageLayerKey = 'dots' | 'hex' | 'polygon';
 
 const DEFAULT_CENTER = { longitude: -4.2518, latitude: 55.8642, zoom: 8 };
-const FEEDER_COLOR: [number, number, number, number] = [99, 102, 241, 230]; // indigo
 const POLYGON_FILL: [number, number, number, number] = [99, 102, 241, 50];
 const POLYGON_STROKE: [number, number, number, number] = [99, 102, 241, 200];
-const LOW_CONFIDENCE_COLOR: [number, number, number, number] = [148, 163, 184, 140]; // slate
 const H3_RESOLUTION = 6;
-
-function smoothedRate(successes: number, attempts: number): number {
-  return (successes + 1) / (attempts + 2);
-}
-
-/** Map a smoothed reliability (0..1) to red→amber→green. */
-function reliabilityColor(rate: number, alpha = 220): [number, number, number, number] {
-  const t = Math.max(0, Math.min(1, rate));
-  let r: number;
-  let g: number;
-  let b: number;
-  if (t < 0.7) {
-    const k = t / 0.7;
-    r = Math.round(239 + (245 - 239) * k);
-    g = Math.round(68 + (158 - 68) * k);
-    b = Math.round(68 + (11 - 68) * k);
-  } else {
-    const k = Math.min(1, (t - 0.7) / 0.2);
-    r = Math.round(245 + (34 - 245) * k);
-    g = Math.round(158 + (197 - 158) * k);
-    b = Math.round(11 + (94 - 11) * k);
-  }
-  return [r, g, b, alpha];
-}
-
-/** Scale attempts to a pixel radius, clamped to [6, 30]. */
-function attemptsToRadius(attempts: number): number {
-  return Math.max(6, Math.min(30, 6 + Math.sqrt(attempts) * 3));
-}
 
 function getTargetLabel(t: FeederReachTarget): string {
   return t.short_name || t.long_name || t.node_id_str || `!${t.node_id.toString(16)}`;
+}
+
+function feederPopupTitle(f: FeederReachFeeder): string {
+  return f.short_name || f.long_name || f.node_id_str || `!${f.node_id.toString(16)}`;
 }
 
 interface HexBin {
@@ -71,10 +51,10 @@ export interface FeederCoverageMapProps {
 
 export function FeederCoverageMap({ feeder, targets, enabledLayers, minAttempts }: FeederCoverageMapProps) {
   const [selectedTarget, setSelectedTarget] = useState<FeederReachTarget | null>(null);
+  const [selectedFeederMarker, setSelectedFeederMarker] = useState<FeederReachFeeder | null>(null);
 
   const enabledSet = useMemo(() => new Set(enabledLayers), [enabledLayers]);
 
-  // Layer A: per-target dots with smoothed-rate fill, attempts-scaled radius.
   const dotsLayer = useMemo(() => {
     if (!enabledSet.has('dots') || targets.length === 0) return null;
     return new ScatterplotLayer({
@@ -92,7 +72,6 @@ export function FeederCoverageMap({ feeder, targets, enabledLayers, minAttempts 
     });
   }, [enabledSet, targets, minAttempts]);
 
-  // Layer B: client-side H3 binning at res 6, smoothed rate.
   const hexBins: HexBin[] = useMemo(() => {
     const acc = new Map<string, { attempts: number; successes: number }>();
     for (const t of targets) {
@@ -131,7 +110,6 @@ export function FeederCoverageMap({ feeder, targets, enabledLayers, minAttempts 
     });
   }, [enabledSet, hexBins, minAttempts]);
 
-  // Layer C: concave hull around successfully-reached targets.
   const polygonFeature = useMemo<Feature<Polygon | MultiPolygon> | null>(() => {
     if (!enabledSet.has('polygon')) return null;
     const successPoints = targets.filter((t) => t.successes > 0);
@@ -155,7 +133,6 @@ export function FeederCoverageMap({ feeder, targets, enabledLayers, minAttempts 
         if (f.geometry.type === 'Polygon') {
           return f.geometry.coordinates as number[][][];
         }
-        // MultiPolygon: deck.gl PolygonLayer expects one polygon per feature; flatten to outer rings.
         return (f.geometry.coordinates as number[][][][]).flat() as unknown as number[][][];
       },
       getFillColor: POLYGON_FILL,
@@ -167,33 +144,32 @@ export function FeederCoverageMap({ feeder, targets, enabledLayers, minAttempts 
     });
   }, [polygonFeature]);
 
-  // Feeder marker (always shown, on top so the user can locate the feeder).
-  const feederLayer = useMemo(() => {
+  const feederIconLayer = useMemo(() => {
     if (feeder.lat == null || feeder.lng == null) return null;
-    return new ScatterplotLayer({
-      id: 'feeder-coverage-feeder',
-      data: [feeder],
-      getPosition: (d) => [d.lng as number, d.lat as number],
-      getFillColor: () => FEEDER_COLOR,
-      getRadius: 10,
-      radiusUnits: 'pixels',
-      stroked: true,
-      lineWidthMinPixels: 2,
-      getLineColor: [255, 255, 255, 230],
-      pickable: false,
+    return buildFeederIconLayer([{ ...feeder, lat: feeder.lat, lng: feeder.lng }], {
+      id: 'feeder-coverage-feeder-icons',
+      size: 36,
+      pickable: true,
     });
   }, [feeder]);
 
   const layers = useMemo(
-    () => [polygonLayer, hexLayer, dotsLayer, feederLayer].filter(Boolean) as Layer[],
-    [polygonLayer, hexLayer, dotsLayer, feederLayer]
+    () => [polygonLayer, hexLayer, dotsLayer, feederIconLayer].filter(Boolean) as Layer[],
+    [polygonLayer, hexLayer, dotsLayer, feederIconLayer]
   );
 
   const handleClick = useCallback((info: PickingInfo) => {
+    if (info.layer?.id === 'feeder-coverage-feeder-icons' && info.object) {
+      setSelectedFeederMarker(info.object as FeederReachFeeder);
+      setSelectedTarget(null);
+      return;
+    }
     if (info.object && info.layer?.id === 'feeder-coverage-dots') {
       setSelectedTarget(info.object as FeederReachTarget);
+      setSelectedFeederMarker(null);
     } else {
       setSelectedTarget(null);
+      setSelectedFeederMarker(null);
     }
   }, []);
 
@@ -252,6 +228,42 @@ export function FeederCoverageMap({ feeder, targets, enabledLayers, minAttempts 
               </div>
               <Link
                 to={`/nodes/${selectedTarget.node_id}`}
+                className="mt-1 inline-block text-xs text-emerald-400 hover:text-emerald-300 hover:underline"
+              >
+                Open details
+              </Link>
+            </div>
+          </div>
+        </Popup>
+      )}
+      {selectedFeederMarker && selectedFeederMarker.lat != null && selectedFeederMarker.lng != null && (
+        <Popup
+          longitude={selectedFeederMarker.lng}
+          latitude={selectedFeederMarker.lat}
+          anchor="bottom"
+          closeButton={false}
+          closeOnClick={false}
+          onClose={() => setSelectedFeederMarker(null)}
+          maxWidth="320px"
+          className="meshflow-map-popup"
+        >
+          <div className="relative min-w-[180px] rounded-md border border-slate-600 bg-slate-800 px-3 py-2 text-sm text-slate-100 shadow-lg">
+            <button
+              type="button"
+              onClick={() => setSelectedFeederMarker(null)}
+              className="absolute right-1 top-1 rounded p-0.5 text-slate-400 hover:bg-slate-700 hover:text-slate-200"
+              aria-label="Close"
+            >
+              <X className="h-3.5 w-3.5" aria-hidden />
+            </button>
+            <div className="pr-5">
+              <div className="text-xs font-medium uppercase tracking-wide text-amber-400">Managed node (feeder)</div>
+              <div className="mt-0.5 font-semibold">{feederPopupTitle(selectedFeederMarker)}</div>
+              <div className="mt-0.5 text-xs text-slate-400">
+                {selectedFeederMarker.node_id_str || `!${selectedFeederMarker.node_id.toString(16)}`}
+              </div>
+              <Link
+                to={`/nodes/${selectedFeederMarker.node_id}`}
                 className="mt-1 inline-block text-xs text-emerald-400 hover:text-emerald-300 hover:underline"
               >
                 Open details

--- a/src/hooks/api/useConstellationCoverage.ts
+++ b/src/hooks/api/useConstellationCoverage.ts
@@ -9,6 +9,10 @@ export interface UseConstellationCoverageParams {
   triggeredAtAfter?: Date;
   triggeredAtBefore?: Date;
   h3Resolution?: number;
+  /** When true, request per-target rows and feeder markers from the API. */
+  includeTargets?: boolean;
+  /** Comma-separated target_strategy tokens (omit when all strategies). */
+  targetStrategy?: string;
 }
 
 const FIVE_MINUTES_MS = 5 * 60 * 1000;
@@ -33,6 +37,8 @@ export function useConstellationCoverage(params: UseConstellationCoverageParams)
         triggeredAtAfterKey,
         triggeredAtBeforeKey,
         h3Resolution: params.h3Resolution,
+        includeTargets: params.includeTargets,
+        targetStrategy: params.targetStrategy,
       },
     ],
     enabled: params.constellationId != null,
@@ -43,6 +49,8 @@ export function useConstellationCoverage(params: UseConstellationCoverageParams)
         triggered_at_after: triggeredAtAfter,
         triggered_at_before: triggeredAtBefore,
         h3_resolution: params.h3Resolution,
+        include_targets: params.includeTargets,
+        target_strategy: params.targetStrategy,
       }),
   });
 }

--- a/src/hooks/api/useFeederReach.ts
+++ b/src/hooks/api/useFeederReach.ts
@@ -8,6 +8,8 @@ export interface UseFeederReachParams {
   feederId?: number;
   triggeredAtAfter?: Date;
   triggeredAtBefore?: Date;
+  /** Comma-separated strategy tokens for `target_strategy` (omit when all strategies). */
+  targetStrategy?: string;
 }
 
 const FIVE_MINUTES_MS = 5 * 60 * 1000;
@@ -34,6 +36,7 @@ export function useFeederReach(params: UseFeederReachParams) {
         feederId: params.feederId,
         triggeredAtAfterKey,
         triggeredAtBeforeKey,
+        targetStrategy: params.targetStrategy,
       },
     ],
     enabled: params.feederId != null,
@@ -43,6 +46,7 @@ export function useFeederReach(params: UseFeederReachParams) {
         feeder_id: params.feederId as number,
         triggered_at_after: triggeredAtAfter,
         triggered_at_before: triggeredAtBefore,
+        target_strategy: params.targetStrategy,
       }),
   });
 }

--- a/src/hooks/api/useObservedNodesHeard.ts
+++ b/src/hooks/api/useObservedNodesHeard.ts
@@ -1,0 +1,60 @@
+import { useEffect, useMemo } from 'react';
+import { useInfiniteQuery, type InfiniteData } from '@tanstack/react-query';
+
+import { useMeshtasticApi } from './useApi';
+import type { ObservedNode, PaginatedResponse } from '@/lib/models';
+
+export interface UseObservedNodesHeardOptions {
+  lastHeardAfter: Date;
+  pageSize?: number;
+  /** When false, no fetch (e.g. layer toggled off). */
+  enabled?: boolean;
+}
+
+/**
+ * Paginated observed nodes with `last_heard` in range (same clock as coverage window).
+ * Fetches all pages like `useNodes` observed slice — use sparingly (e.g. map overlays).
+ */
+export function useObservedNodesHeard(options: UseObservedNodesHeardOptions) {
+  const api = useMeshtasticApi();
+  const pageSize = options.pageSize ?? 500;
+  const enabled = options.enabled !== false;
+  const lastHeardKey = Math.floor(options.lastHeardAfter.getTime() / (5 * 60 * 1000)).toString();
+
+  const query = useInfiniteQuery<
+    PaginatedResponse<ObservedNode>,
+    Error,
+    InfiniteData<PaginatedResponse<ObservedNode>>,
+    [string, number, string],
+    number
+  >({
+    queryKey: ['observed-nodes-heard', pageSize, lastHeardKey],
+    queryFn: async ({ pageParam = 1 }) =>
+      api.getNodes({
+        page: pageParam,
+        page_size: pageSize,
+        last_heard_after: options.lastHeardAfter,
+      }),
+    initialPageParam: 1,
+    getNextPageParam: (lastPage, allPages) => {
+      if (!lastPage.next) return undefined;
+      return allPages.length + 1;
+    },
+    enabled,
+  });
+
+  useEffect(() => {
+    if (!enabled) return;
+    if (query.hasNextPage && !query.isFetchingNextPage && !query.isError) {
+      void query.fetchNextPage();
+    }
+  }, [enabled, query.hasNextPage, query.isFetchingNextPage, query.isError, query.fetchNextPage]);
+
+  const nodes = useMemo(() => query.data?.pages.flatMap((p) => p.results) ?? [], [query.data?.pages]);
+
+  return {
+    nodes,
+    isLoading: query.isLoading,
+    isFetching: query.isFetching,
+  };
+}

--- a/src/lib/api/meshtastic-api.ts
+++ b/src/lib/api/meshtastic-api.ts
@@ -77,11 +77,28 @@ export interface ConstellationCoverageHex {
   contributing_targets: number;
 }
 
+/** Per-target aggregate across all feeders (when `include_targets=1`). */
+export interface ConstellationCoverageTarget {
+  node_id: number;
+  node_id_str: string;
+  short_name: string | null;
+  long_name: string | null;
+  lat: number;
+  lng: number;
+  attempts: number;
+  successes: number;
+  contributing_feeders: number;
+}
+
 export interface ConstellationCoverageData {
   constellation_id: number;
   h3_resolution: number;
   hexes: ConstellationCoverageHex[];
   meta: { window: CoverageWindow };
+  /** Present when the request used `include_targets=1`. */
+  targets?: ConstellationCoverageTarget[];
+  /** Managed nodes in the constellation with a map position (same shape as feeder-reach `feeder`). */
+  feeders?: FeederReachFeeder[];
 }
 
 export class MeshtasticApi extends BaseApi {
@@ -870,6 +887,8 @@ export class MeshtasticApi extends BaseApi {
     feeder_id: number;
     triggered_at_after?: string;
     triggered_at_before?: string;
+    /** Comma-separated strategy tokens (intra_zone, dx_across, dx_same_side, legacy). */
+    target_strategy?: string;
   }): Promise<FeederReachData> {
     const searchParams = new URLSearchParams();
     searchParams.append('feeder_id', params.feeder_id.toString());
@@ -878,6 +897,9 @@ export class MeshtasticApi extends BaseApi {
     }
     if (params.triggered_at_before) {
       searchParams.append('triggered_at_before', params.triggered_at_before);
+    }
+    if (params.target_strategy) {
+      searchParams.append('target_strategy', params.target_strategy);
     }
     return this.get('/traceroutes/feeder-reach/', searchParams);
   }
@@ -890,6 +912,10 @@ export class MeshtasticApi extends BaseApi {
     triggered_at_after?: string;
     triggered_at_before?: string;
     h3_resolution?: number;
+    /** When true, response includes `targets` and `feeders` for map layers. */
+    include_targets?: boolean;
+    /** Comma-separated strategy tokens (same as feeder-reach). */
+    target_strategy?: string;
   }): Promise<ConstellationCoverageData> {
     const searchParams = new URLSearchParams();
     searchParams.append('constellation_id', params.constellation_id.toString());
@@ -901,6 +927,12 @@ export class MeshtasticApi extends BaseApi {
     }
     if (params.h3_resolution != null) {
       searchParams.append('h3_resolution', params.h3_resolution.toString());
+    }
+    if (params.include_targets) {
+      searchParams.append('include_targets', '1');
+    }
+    if (params.target_strategy) {
+      searchParams.append('target_strategy', params.target_strategy);
     }
     return this.get('/traceroutes/constellation-coverage/', searchParams);
   }

--- a/src/lib/coverageHeardGhosts.test.ts
+++ b/src/lib/coverageHeardGhosts.test.ts
@@ -1,0 +1,56 @@
+import { describe, it, expect } from 'vitest';
+
+import { observedNodesToCoverageGhosts } from './coverageHeardGhosts';
+import type { ObservedNode } from './models';
+
+describe('observedNodesToCoverageGhosts', () => {
+  it('drops represented ids and nodes without position', () => {
+    const nodes: ObservedNode[] = [
+      {
+        internal_id: 1,
+        node_id: 10,
+        node_id_str: '!a',
+        mac_addr: null,
+        long_name: 'A',
+        short_name: 'A',
+        hw_model: null,
+        public_key: null,
+        latest_position: { latitude: 1, longitude: 2, reported_time: null, logged_time: null, altitude: null, location_source: 'gps' },
+      },
+      {
+        internal_id: 2,
+        node_id: 20,
+        node_id_str: '!b',
+        mac_addr: null,
+        long_name: null,
+        short_name: 'B',
+        hw_model: null,
+        public_key: null,
+        latest_position: null,
+      },
+    ];
+    const represented = new Set([10]);
+    expect(observedNodesToCoverageGhosts(nodes, represented)).toEqual([]);
+  });
+
+  it('keeps unrepresented nodes with coordinates', () => {
+    const nodes: ObservedNode[] = [
+      {
+        internal_id: 3,
+        node_id: 30,
+        node_id_str: '!c',
+        mac_addr: null,
+        long_name: 'Ghost',
+        short_name: 'G',
+        hw_model: null,
+        public_key: null,
+        latest_position: { latitude: 55.1, longitude: -4.1, reported_time: null, logged_time: null, altitude: null, location_source: 'gps' },
+      },
+    ];
+    const g = observedNodesToCoverageGhosts(nodes, new Set());
+    expect(g).toHaveLength(1);
+    expect(g[0].node_id).toBe(30);
+    expect(g[0].lat).toBe(55.1);
+    expect(g[0].lng).toBe(-4.1);
+  });
+});

--- a/src/lib/coverageHeardGhosts.ts
+++ b/src/lib/coverageHeardGhosts.ts
@@ -1,0 +1,33 @@
+import type { ObservedNode } from '@/lib/models';
+
+/** Observed node with position, not shown as a traceroute target or feeder marker. */
+export interface CoverageHeardGhost {
+  node_id: number;
+  node_id_str: string;
+  short_name: string | null;
+  long_name: string | null;
+  lat: number;
+  lng: number;
+}
+
+/** Nodes heard in the window with a map position, excluding traceroute coverage rows and feeders. */
+export function observedNodesToCoverageGhosts(
+  nodes: ObservedNode[],
+  representedNodeIds: ReadonlySet<number>
+): CoverageHeardGhost[] {
+  const out: CoverageHeardGhost[] = [];
+  for (const n of nodes) {
+    if (representedNodeIds.has(n.node_id)) continue;
+    const p = n.latest_position;
+    if (p == null || p.latitude == null || p.longitude == null) continue;
+    out.push({
+      node_id: n.node_id,
+      node_id_str: n.node_id_str,
+      short_name: n.short_name ?? null,
+      long_name: n.long_name ?? null,
+      lat: p.latitude,
+      lng: p.longitude,
+    });
+  }
+  return out;
+}

--- a/src/lib/traceroute-strategy.ts
+++ b/src/lib/traceroute-strategy.ts
@@ -52,3 +52,27 @@ export function applicableStrategiesFromGeo(
   const raw = geo?.applicable_strategies ?? [];
   return raw.filter((s): s is TracerouteStrategyValue => TRACEROUTE_STRATEGIES.includes(s as TracerouteStrategyValue));
 }
+
+/** Initial coverage UI state: every strategy checked (= no `target_strategy` filter on the API). */
+export function createCoverageStrategiesAllSelected(): Record<TracerouteStrategyValue, boolean> {
+  return Object.fromEntries(TRACEROUTE_STRATEGIES.map((k) => [k, true])) as Record<TracerouteStrategyValue, boolean>;
+}
+
+/**
+ * Comma-separated `target_strategy` query value, or `undefined` when all or none are selected
+ * (backend treats omitted param as all strategies).
+ */
+export function coverageTargetStrategyQueryParam(strategies: Record<string, boolean>): string | undefined {
+  const selected = TRACEROUTE_STRATEGIES.filter((k) => strategies[k]);
+  if (selected.length === 0 || selected.length === TRACEROUTE_STRATEGIES.length) {
+    return undefined;
+  }
+  return selected.join(',');
+}
+
+/** Human-readable line for coverage stats cards. */
+export function coverageTargetStrategySummary(strategies: Record<string, boolean>): string {
+  const selected = TRACEROUTE_STRATEGIES.filter((k) => strategies[k]);
+  if (selected.length === 0 || selected.length === TRACEROUTE_STRATEGIES.length) return 'All strategies';
+  return selected.map((k) => STRATEGY_META[k].label).join(', ');
+}

--- a/src/pages/traceroutes/ConstellationCoveragePage.test.tsx
+++ b/src/pages/traceroutes/ConstellationCoveragePage.test.tsx
@@ -10,17 +10,28 @@ vi.mock('@/hooks/api/useConstellationCoverage', () => ({
   useConstellationCoverage: vi.fn(),
 }));
 
+vi.mock('@/hooks/api/useNodes', () => ({
+  useNodes: vi.fn(() => ({ managedNodes: [], isLoadingManagedNodes: false })),
+}));
+
+vi.mock('@/hooks/api/useObservedNodesHeard', () => ({
+  useObservedNodesHeard: vi.fn(() => ({ nodes: [], isLoading: false, isFetching: false })),
+}));
+
 vi.mock('@/components/traceroutes/ConstellationCoverageMap', () => ({
   ConstellationCoverageMap: ({
     hexes,
+    heardGhosts,
     minAttempts,
   }: {
     hexes: { cell: string }[];
+    heardGhosts: unknown[];
     minAttempts: number;
   }) => (
     <div
       data-testid="constellation-coverage-map-mock"
       data-hex-count={hexes.length}
+      data-heard-ghost-count={heardGhosts.length}
       data-min-attempts={minAttempts}
     />
   ),

--- a/src/pages/traceroutes/ConstellationCoveragePage.tsx
+++ b/src/pages/traceroutes/ConstellationCoveragePage.tsx
@@ -4,18 +4,35 @@ import { subDays, subHours } from 'date-fns';
 import { CircleDashedIcon } from 'lucide-react';
 
 import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card';
+import { Checkbox } from '@/components/ui/checkbox';
 import { Input } from '@/components/ui/input';
 import { Label } from '@/components/ui/label';
 import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from '@/components/ui/select';
+import {
+  ConstellationCoverageMap,
+  type ConstellationMapLayerKey,
+} from '@/components/traceroutes/ConstellationCoverageMap';
+import { smoothedRate } from '@/components/map/coverageStyling';
+import type { FeederIconDatum } from '@/components/map/FeederIconLayer';
 import { useConstellations } from '@/hooks/api/useConstellations';
 import { useConstellationCoverage } from '@/hooks/api/useConstellationCoverage';
-import { ConstellationCoverageMap } from '@/components/traceroutes/ConstellationCoverageMap';
+import { cn } from '@/lib/utils';
+import {
+  TRACEROUTE_STRATEGIES,
+  STRATEGY_META,
+  createCoverageStrategiesAllSelected,
+  coverageTargetStrategyQueryParam,
+  coverageTargetStrategySummary,
+} from '@/lib/traceroute-strategy';
 
 type TimeRange = '24h' | '7d' | '30d';
 
-function smoothedRate(successes: number, attempts: number): number {
-  return (successes + 1) / (attempts + 2);
-}
+const CONSTELLATION_LAYERS: ConstellationMapLayerKey[] = ['hex', 'dots', 'feeders'];
+const CONSTELLATION_LAYER_LABEL: Record<ConstellationMapLayerKey, string> = {
+  hex: 'Hex',
+  dots: 'Dots',
+  feeders: 'Feeders',
+};
 
 function StatsCard({
   hexCount,
@@ -23,6 +40,9 @@ function StatsCard({
   totalSuccesses,
   meanSmoothed,
   minAttempts,
+  strategySummary,
+  dotCount,
+  feederMarkerCount,
   className,
 }: {
   hexCount: number;
@@ -30,6 +50,9 @@ function StatsCard({
   totalSuccesses: number;
   meanSmoothed: number | null;
   minAttempts: number;
+  strategySummary?: string;
+  dotCount?: number;
+  feederMarkerCount?: number;
   className?: string;
 }) {
   return (
@@ -38,14 +61,26 @@ function StatsCard({
         <CardTitle className="text-sm">Coverage stats</CardTitle>
       </CardHeader>
       <CardContent className="space-y-1.5 text-sm">
+        {strategySummary != null && (
+          <div className="text-xs text-muted-foreground">
+            Strategies: <span className="text-foreground">{strategySummary}</span>
+          </div>
+        )}
         <div>{hexCount.toLocaleString()} hexes</div>
+        {dotCount != null && (
+          <div>
+            {dotCount.toLocaleString()} target dots{' '}
+            <span className="text-xs text-muted-foreground">(min attempts)</span>
+          </div>
+        )}
+        {feederMarkerCount != null && <div>{feederMarkerCount.toLocaleString()} managed nodes (tower markers)</div>}
         <div>
           {totalSuccesses.toLocaleString()} / {totalAttempts.toLocaleString()} attempts succeeded
         </div>
         {meanSmoothed != null && <div>Mean smoothed reliability: {(meanSmoothed * 100).toFixed(1)}%</div>}
         <div className="pt-2 text-xs text-muted-foreground">Min attempts floor: {minAttempts}</div>
         <div className="pt-2">
-          <div className="mb-1 text-xs text-muted-foreground">Smoothed reliability</div>
+          <div className="mb-1 text-xs text-muted-foreground">Smoothed reliability (hex / dots)</div>
           <div
             className="h-2 w-full rounded"
             style={{
@@ -57,6 +92,11 @@ function StatsCard({
             <span>50%</span>
             <span>100%</span>
           </div>
+        </div>
+        <div className="border-t border-border pt-2 text-xs text-muted-foreground">
+          <strong className="text-foreground">Hex</strong>: H3 aggregate.{' '}
+          <strong className="text-foreground">Dots</strong>: each probed target (size = attempts, colour = reliability).{' '}
+          <strong className="text-foreground">Tower</strong>: managed feeder position.
         </div>
       </CardContent>
     </Card>
@@ -70,12 +110,17 @@ export function ConstellationCoveragePage() {
   const [timeRange, setTimeRange] = useState<TimeRange>('7d');
   const [minAttempts, setMinAttempts] = useState<number>(3);
   const [h3Resolution, setH3Resolution] = useState<number>(6);
+  const [mapLayers, setMapLayers] = useState<Record<ConstellationMapLayerKey, boolean>>({
+    hex: true,
+    dots: true,
+    feeders: true,
+  });
+  const [strategies, setStrategies] = useState(() => createCoverageStrategiesAllSelected());
 
   const { constellations, isLoading: constellationsLoading } = useConstellations(100, true);
 
   const constellationIdNum = constellationIdParam ? Number.parseInt(constellationIdParam, 10) : undefined;
 
-  // If no constellation in URL, redirect to the first one we can see (mirrors Dashboard behaviour).
   useEffect(() => {
     if (constellationIdParam) return;
     if (constellationsLoading) return;
@@ -90,14 +135,26 @@ export function ConstellationCoveragePage() {
     return subDays(new Date(), 30);
   }, [timeRange]);
 
+  const includeTargets = mapLayers.dots || mapLayers.feeders;
+
+  const targetStrategyParam = useMemo(() => coverageTargetStrategyQueryParam(strategies), [strategies]);
+  const strategySummary = useMemo(() => coverageTargetStrategySummary(strategies), [strategies]);
+
   const { data, isLoading, error } = useConstellationCoverage({
     constellationId: Number.isFinite(constellationIdNum) ? constellationIdNum : undefined,
     triggeredAtAfter,
     h3Resolution,
+    includeTargets,
+    targetStrategy: targetStrategyParam,
   });
 
   const filteredHexes = useMemo(
     () => (data?.hexes ?? []).filter((h) => h.attempts >= minAttempts),
+    [data, minAttempts]
+  );
+
+  const filteredTargets = useMemo(
+    () => (data?.targets ?? []).filter((t) => t.attempts >= minAttempts),
     [data, minAttempts]
   );
 
@@ -106,6 +163,18 @@ export function ConstellationCoveragePage() {
   const meanSmoothed = filteredHexes.length
     ? filteredHexes.reduce((acc, h) => acc + smoothedRate(h.successes, h.attempts), 0) / filteredHexes.length
     : null;
+
+  const positionedFeeders: FeederIconDatum[] = useMemo(() => {
+    const list = data?.feeders ?? [];
+    return list
+      .filter((f) => f.lat != null && f.lng != null)
+      .map((f) => ({ ...f, lat: f.lat as number, lng: f.lng as number }));
+  }, [data?.feeders]);
+
+  const feederMarkerCount = includeTargets ? positionedFeeders.length : undefined;
+  const dotCount = includeTargets ? filteredTargets.length : undefined;
+
+  const enabledMapLayers = CONSTELLATION_LAYERS.filter((k) => mapLayers[k]);
 
   return (
     <div className="flex min-h-[50vh] flex-col gap-4 px-4 py-4 md:px-6 md:py-6">
@@ -116,86 +185,130 @@ export function ConstellationCoveragePage() {
             <h1 className="text-xl font-semibold sm:text-2xl">Constellation coverage</h1>
           </div>
           <p className="max-w-2xl text-sm text-muted-foreground">
-            Combines traceroute attempts from every managed node in the selected constellation, grouped into map hex
-            cells. Each cell shows aggregate successes and failures toward targets in that area (smoothing and
-            minimum-attempt filters apply below).
+            Combines traceroute attempts from every managed node in the selected constellation. <strong>Hexes</strong>{' '}
+            group targets into H3 cells; <strong>dots</strong> show each probed target (size = attempts, colour =
+            smoothed reliability). <strong>Tower markers</strong> show managed feeder positions. Filter by
+            target-selection strategy to debug scheduler behaviour.
           </p>
         </div>
-        <div className="flex flex-wrap items-center gap-3" data-testid="constellation-coverage-filters">
-          <div className="flex items-center gap-2">
-            <Label className="text-xs text-muted-foreground" htmlFor="constellation-coverage-constellation">
-              Constellation
-            </Label>
-            <Select
-              value={constellationIdParam}
-              onValueChange={(v) => navigate(`/traceroutes/map/coverage/constellation/${v}`)}
-              disabled={constellationsLoading || constellations.length === 0}
+        <div className="flex flex-col gap-3" data-testid="constellation-coverage-filters">
+          <div className="flex flex-wrap items-center gap-3">
+            <div className="flex items-center gap-2">
+              <Label className="text-xs text-muted-foreground" htmlFor="constellation-coverage-constellation">
+                Constellation
+              </Label>
+              <Select
+                value={constellationIdParam}
+                onValueChange={(v) => navigate(`/traceroutes/map/coverage/constellation/${v}`)}
+                disabled={constellationsLoading || constellations.length === 0}
+              >
+                <SelectTrigger
+                  id="constellation-coverage-constellation"
+                  className="min-w-[200px]"
+                  aria-label="Select constellation"
+                >
+                  <SelectValue placeholder="Select constellation" />
+                </SelectTrigger>
+                <SelectContent>
+                  {constellations.map((c) => (
+                    <SelectItem key={c.id} value={String(c.id)}>
+                      {c.name}
+                    </SelectItem>
+                  ))}
+                </SelectContent>
+              </Select>
+            </div>
+            <div className="flex items-center gap-2">
+              <Label className="text-xs text-muted-foreground" htmlFor="constellation-coverage-window">
+                Window
+              </Label>
+              <Select value={timeRange} onValueChange={(v) => setTimeRange(v as TimeRange)}>
+                <SelectTrigger id="constellation-coverage-window" className="min-w-[140px]" aria-label="Time window">
+                  <SelectValue />
+                </SelectTrigger>
+                <SelectContent>
+                  <SelectItem value="24h">Last 24 hours</SelectItem>
+                  <SelectItem value="7d">Last 7 days</SelectItem>
+                  <SelectItem value="30d">Last 30 days</SelectItem>
+                </SelectContent>
+              </Select>
+            </div>
+            <div className="flex items-center gap-2">
+              <Label className="text-xs text-muted-foreground" htmlFor="constellation-coverage-resolution">
+                H3 resolution
+              </Label>
+              <Select value={String(h3Resolution)} onValueChange={(v) => setH3Resolution(Number.parseInt(v, 10))}>
+                <SelectTrigger
+                  id="constellation-coverage-resolution"
+                  className="min-w-[100px]"
+                  aria-label="H3 resolution"
+                >
+                  <SelectValue />
+                </SelectTrigger>
+                <SelectContent>
+                  <SelectItem value="5">5 (~9km)</SelectItem>
+                  <SelectItem value="6">6 (~3km)</SelectItem>
+                  <SelectItem value="7">7 (~1.2km)</SelectItem>
+                </SelectContent>
+              </Select>
+            </div>
+            <div className="flex items-center gap-2">
+              <Label className="text-xs text-muted-foreground" htmlFor="constellation-coverage-min-attempts">
+                Min attempts
+              </Label>
+              <Input
+                id="constellation-coverage-min-attempts"
+                type="number"
+                min={1}
+                value={minAttempts}
+                onChange={(e) => {
+                  const v = Number.parseInt(e.target.value, 10);
+                  setMinAttempts(Number.isFinite(v) && v >= 1 ? v : 1);
+                }}
+                className="w-20"
+              />
+            </div>
+            <div
+              className="flex rounded-md border border-input bg-muted/50 p-0.5"
+              data-testid="constellation-layer-pills"
             >
-              <SelectTrigger
-                id="constellation-coverage-constellation"
-                className="min-w-[200px]"
-                aria-label="Select constellation"
-              >
-                <SelectValue placeholder="Select constellation" />
-              </SelectTrigger>
-              <SelectContent>
-                {constellations.map((c) => (
-                  <SelectItem key={c.id} value={String(c.id)}>
-                    {c.name}
-                  </SelectItem>
-                ))}
-              </SelectContent>
-            </Select>
+              {CONSTELLATION_LAYERS.map((key) => (
+                <button
+                  key={key}
+                  type="button"
+                  aria-pressed={mapLayers[key]}
+                  aria-label={`Toggle ${CONSTELLATION_LAYER_LABEL[key]} layer`}
+                  onClick={() => setMapLayers((s) => ({ ...s, [key]: !s[key] }))}
+                  className={cn(
+                    'rounded px-3 py-1.5 text-sm font-medium transition-colors',
+                    mapLayers[key]
+                      ? 'bg-background text-foreground shadow-sm'
+                      : 'text-muted-foreground hover:text-foreground'
+                  )}
+                >
+                  {CONSTELLATION_LAYER_LABEL[key]}
+                </button>
+              ))}
+            </div>
           </div>
-          <div className="flex items-center gap-2">
-            <Label className="text-xs text-muted-foreground" htmlFor="constellation-coverage-window">
-              Window
-            </Label>
-            <Select value={timeRange} onValueChange={(v) => setTimeRange(v as TimeRange)}>
-              <SelectTrigger id="constellation-coverage-window" className="min-w-[140px]" aria-label="Time window">
-                <SelectValue />
-              </SelectTrigger>
-              <SelectContent>
-                <SelectItem value="24h">Last 24 hours</SelectItem>
-                <SelectItem value="7d">Last 7 days</SelectItem>
-                <SelectItem value="30d">Last 30 days</SelectItem>
-              </SelectContent>
-            </Select>
-          </div>
-          <div className="flex items-center gap-2">
-            <Label className="text-xs text-muted-foreground" htmlFor="constellation-coverage-resolution">
-              H3 resolution
-            </Label>
-            <Select value={String(h3Resolution)} onValueChange={(v) => setH3Resolution(Number.parseInt(v, 10))}>
-              <SelectTrigger
-                id="constellation-coverage-resolution"
-                className="min-w-[100px]"
-                aria-label="H3 resolution"
-              >
-                <SelectValue />
-              </SelectTrigger>
-              <SelectContent>
-                <SelectItem value="5">5 (~9km)</SelectItem>
-                <SelectItem value="6">6 (~3km)</SelectItem>
-                <SelectItem value="7">7 (~1.2km)</SelectItem>
-              </SelectContent>
-            </Select>
-          </div>
-          <div className="flex items-center gap-2">
-            <Label className="text-xs text-muted-foreground" htmlFor="constellation-coverage-min-attempts">
-              Min attempts
-            </Label>
-            <Input
-              id="constellation-coverage-min-attempts"
-              type="number"
-              min={1}
-              value={minAttempts}
-              onChange={(e) => {
-                const v = Number.parseInt(e.target.value, 10);
-                setMinAttempts(Number.isFinite(v) && v >= 1 ? v : 1);
-              }}
-              className="w-20"
-            />
+          <div className="flex flex-col gap-2 rounded-md border border-border bg-muted/30 px-3 py-2">
+            <span className="text-xs font-medium text-muted-foreground">Target selection strategies</span>
+            <div className="flex flex-wrap gap-x-4 gap-y-2">
+              {TRACEROUTE_STRATEGIES.map((opt) => (
+                <label
+                  key={opt}
+                  htmlFor={`constellation-strategy-${opt}`}
+                  className="flex cursor-pointer items-center gap-2 text-sm"
+                >
+                  <Checkbox
+                    id={`constellation-strategy-${opt}`}
+                    checked={strategies[opt] ?? false}
+                    onCheckedChange={(c) => setStrategies((s) => ({ ...s, [opt]: c === true }))}
+                  />
+                  <span className="leading-none">{STRATEGY_META[opt].label}</span>
+                </label>
+              ))}
+            </div>
           </div>
         </div>
       </div>
@@ -207,6 +320,9 @@ export function ConstellationCoveragePage() {
           totalSuccesses={totalSuccesses}
           meanSmoothed={meanSmoothed}
           minAttempts={minAttempts}
+          strategySummary={strategySummary}
+          dotCount={dotCount}
+          feederMarkerCount={feederMarkerCount}
         />
       </div>
 
@@ -227,19 +343,28 @@ export function ConstellationCoveragePage() {
               </div>
             )}
             {!error && !isLoading && data && (
-              <ConstellationCoverageMap hexes={filteredHexes} minAttempts={minAttempts} />
+              <ConstellationCoverageMap
+                hexes={filteredHexes}
+                targets={filteredTargets}
+                feeders={positionedFeeders}
+                enabledLayers={enabledMapLayers}
+                minAttempts={minAttempts}
+              />
             )}
           </CardContent>
         </Card>
 
         <div className="absolute right-4 top-4 z-10 hidden md:block">
           <StatsCard
-            className="w-64"
+            className="w-72"
             hexCount={filteredHexes.length}
             totalAttempts={totalAttempts}
             totalSuccesses={totalSuccesses}
             meanSmoothed={meanSmoothed}
             minAttempts={minAttempts}
+            strategySummary={strategySummary}
+            dotCount={dotCount}
+            feederMarkerCount={feederMarkerCount}
           />
         </div>
       </div>

--- a/src/pages/traceroutes/ConstellationCoveragePage.tsx
+++ b/src/pages/traceroutes/ConstellationCoveragePage.tsx
@@ -16,6 +16,9 @@ import { smoothedRate } from '@/components/map/coverageStyling';
 import type { FeederIconDatum } from '@/components/map/FeederIconLayer';
 import { useConstellations } from '@/hooks/api/useConstellations';
 import { useConstellationCoverage } from '@/hooks/api/useConstellationCoverage';
+import { useNodes } from '@/hooks/api/useNodes';
+import { useObservedNodesHeard } from '@/hooks/api/useObservedNodesHeard';
+import { observedNodesToCoverageGhosts } from '@/lib/coverageHeardGhosts';
 import { cn } from '@/lib/utils';
 import {
   TRACEROUTE_STRATEGIES,
@@ -27,11 +30,12 @@ import {
 
 type TimeRange = '24h' | '7d' | '30d';
 
-const CONSTELLATION_LAYERS: ConstellationMapLayerKey[] = ['hex', 'dots', 'feeders'];
+const CONSTELLATION_LAYERS: ConstellationMapLayerKey[] = ['hex', 'dots', 'feeders', 'heard'];
 const CONSTELLATION_LAYER_LABEL: Record<ConstellationMapLayerKey, string> = {
   hex: 'Hex',
   dots: 'Dots',
   feeders: 'Feeders',
+  heard: 'Heard',
 };
 
 function StatsCard({
@@ -43,6 +47,7 @@ function StatsCard({
   strategySummary,
   dotCount,
   feederMarkerCount,
+  heardGhostCount,
   className,
 }: {
   hexCount: number;
@@ -53,6 +58,7 @@ function StatsCard({
   strategySummary?: string;
   dotCount?: number;
   feederMarkerCount?: number;
+  heardGhostCount?: number;
   className?: string;
 }) {
   return (
@@ -74,6 +80,12 @@ function StatsCard({
           </div>
         )}
         {feederMarkerCount != null && <div>{feederMarkerCount.toLocaleString()} managed nodes (tower markers)</div>}
+        {heardGhostCount != null && (
+          <div>
+            {heardGhostCount.toLocaleString()} heard-only nodes{' '}
+            <span className="text-xs text-muted-foreground">(hollow markers)</span>
+          </div>
+        )}
         <div>
           {totalSuccesses.toLocaleString()} / {totalAttempts.toLocaleString()} attempts succeeded
         </div>
@@ -96,7 +108,9 @@ function StatsCard({
         <div className="border-t border-border pt-2 text-xs text-muted-foreground">
           <strong className="text-foreground">Hex</strong>: H3 aggregate.{' '}
           <strong className="text-foreground">Dots</strong>: each probed target (size = attempts, colour = reliability).{' '}
-          <strong className="text-foreground">Tower</strong>: managed feeder position.
+          <strong className="text-foreground">Tower</strong>: managed feeder position.{' '}
+          <strong className="text-foreground">Heard</strong>: nodes with last_heard in the window and a position, not in
+          the traceroute target list or constellation managed-node set for this view.
         </div>
       </CardContent>
     </Card>
@@ -114,10 +128,12 @@ export function ConstellationCoveragePage() {
     hex: true,
     dots: true,
     feeders: true,
+    heard: false,
   });
   const [strategies, setStrategies] = useState(() => createCoverageStrategiesAllSelected());
 
   const { constellations, isLoading: constellationsLoading } = useConstellations(100, true);
+  const { managedNodes } = useNodes({ pageSize: 500 });
 
   const constellationIdNum = constellationIdParam ? Number.parseInt(constellationIdParam, 10) : undefined;
 
@@ -148,6 +164,29 @@ export function ConstellationCoveragePage() {
     targetStrategy: targetStrategyParam,
   });
 
+  const { nodes: heardObservedNodes } = useObservedNodesHeard({
+    lastHeardAfter: triggeredAtAfter,
+    pageSize: 500,
+    enabled: mapLayers.heard && Number.isFinite(constellationIdNum),
+  });
+
+  const representedForHeard = useMemo(() => {
+    const s = new Set<number>();
+    for (const t of data?.targets ?? []) s.add(t.node_id);
+    for (const f of data?.feeders ?? []) s.add(f.node_id);
+    if (Number.isFinite(constellationIdNum)) {
+      for (const m of managedNodes ?? []) {
+        if (m.constellation?.id === constellationIdNum && m.node_id != null) s.add(m.node_id);
+      }
+    }
+    return s;
+  }, [data?.targets, data?.feeders, managedNodes, constellationIdNum]);
+
+  const heardGhosts = useMemo(() => {
+    if (!mapLayers.heard) return [];
+    return observedNodesToCoverageGhosts(heardObservedNodes, representedForHeard);
+  }, [mapLayers.heard, heardObservedNodes, representedForHeard]);
+
   const filteredHexes = useMemo(
     () => (data?.hexes ?? []).filter((h) => h.attempts >= minAttempts),
     [data, minAttempts]
@@ -173,6 +212,7 @@ export function ConstellationCoveragePage() {
 
   const feederMarkerCount = includeTargets ? positionedFeeders.length : undefined;
   const dotCount = includeTargets ? filteredTargets.length : undefined;
+  const heardGhostCount = mapLayers.heard ? heardGhosts.length : undefined;
 
   const enabledMapLayers = CONSTELLATION_LAYERS.filter((k) => mapLayers[k]);
 
@@ -323,6 +363,7 @@ export function ConstellationCoveragePage() {
           strategySummary={strategySummary}
           dotCount={dotCount}
           feederMarkerCount={feederMarkerCount}
+          heardGhostCount={heardGhostCount}
         />
       </div>
 
@@ -347,6 +388,7 @@ export function ConstellationCoveragePage() {
                 hexes={filteredHexes}
                 targets={filteredTargets}
                 feeders={positionedFeeders}
+                heardGhosts={heardGhosts}
                 enabledLayers={enabledMapLayers}
                 minAttempts={minAttempts}
               />
@@ -365,6 +407,7 @@ export function ConstellationCoveragePage() {
             strategySummary={strategySummary}
             dotCount={dotCount}
             feederMarkerCount={feederMarkerCount}
+            heardGhostCount={heardGhostCount}
           />
         </div>
       </div>

--- a/src/pages/traceroutes/FeederCoveragePage.test.tsx
+++ b/src/pages/traceroutes/FeederCoveragePage.test.tsx
@@ -11,15 +11,21 @@ vi.mock('@/hooks/api/useFeederReach', () => ({
   useFeederReach: vi.fn(),
 }));
 
+vi.mock('@/hooks/api/useObservedNodesHeard', () => ({
+  useObservedNodesHeard: vi.fn(() => ({ nodes: [], isLoading: false, isFetching: false })),
+}));
+
 vi.mock('@/components/traceroutes/FeederCoverageMap', () => ({
   FeederCoverageMap: ({
     feeder,
     targets,
+    heardGhosts,
     enabledLayers,
     minAttempts,
   }: {
     feeder: { node_id: number };
     targets: { node_id: number }[];
+    heardGhosts: unknown[];
     enabledLayers: string[];
     minAttempts: number;
   }) => (
@@ -27,6 +33,7 @@ vi.mock('@/components/traceroutes/FeederCoverageMap', () => ({
       data-testid="feeder-coverage-map-mock"
       data-feeder={feeder.node_id}
       data-target-count={targets.length}
+      data-heard-ghost-count={heardGhosts.length}
       data-enabled-layers={enabledLayers.join(',')}
       data-min-attempts={minAttempts}
     />

--- a/src/pages/traceroutes/FeederCoveragePage.tsx
+++ b/src/pages/traceroutes/FeederCoveragePage.tsx
@@ -4,6 +4,7 @@ import { subDays, subHours } from 'date-fns';
 import { CircleDashedIcon, RouteIcon } from 'lucide-react';
 
 import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card';
+import { Checkbox } from '@/components/ui/checkbox';
 import { Input } from '@/components/ui/input';
 import { Label } from '@/components/ui/label';
 import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from '@/components/ui/select';
@@ -12,6 +13,13 @@ import { cn } from '@/lib/utils';
 import { useNodes } from '@/hooks/api/useNodes';
 import { useFeederReach } from '@/hooks/api/useFeederReach';
 import { FeederCoverageMap, type CoverageLayerKey } from '@/components/traceroutes/FeederCoverageMap';
+import {
+  TRACEROUTE_STRATEGIES,
+  STRATEGY_META,
+  createCoverageStrategiesAllSelected,
+  coverageTargetStrategyQueryParam,
+  coverageTargetStrategySummary,
+} from '@/lib/traceroute-strategy';
 
 type TimeRange = '24h' | '7d' | '30d';
 
@@ -33,6 +41,7 @@ function StatsCard({
   totalSuccesses,
   meanSmoothed,
   minAttempts,
+  strategySummary,
   className,
 }: {
   feederLabel: string;
@@ -41,6 +50,7 @@ function StatsCard({
   totalSuccesses: number;
   meanSmoothed: number | null;
   minAttempts: number;
+  strategySummary?: string;
   className?: string;
 }) {
   return (
@@ -49,6 +59,11 @@ function StatsCard({
         <CardTitle className="text-sm">Coverage stats</CardTitle>
       </CardHeader>
       <CardContent className="space-y-1.5 text-sm">
+        {strategySummary != null && (
+          <div className="text-xs text-muted-foreground">
+            Strategies: <span className="text-foreground">{strategySummary}</span>
+          </div>
+        )}
         <div className="text-xs text-muted-foreground">{feederLabel}</div>
         <div>{targetCount.toLocaleString()} targets reached</div>
         <div>
@@ -70,6 +85,10 @@ function StatsCard({
             <span>100%</span>
           </div>
         </div>
+        <div className="border-t border-border pt-2 text-xs text-muted-foreground">
+          <strong className="text-foreground">Dots</strong>: probed targets (size = attempts).{' '}
+          <strong className="text-foreground">Tower</strong>: this managed feeder (source node).
+        </div>
       </CardContent>
     </Card>
   );
@@ -84,6 +103,7 @@ export function FeederCoveragePage() {
     hex: false,
     polygon: false,
   });
+  const [strategies, setStrategies] = useState(() => createCoverageStrategiesAllSelected());
 
   const { managedNodes, isLoadingManagedNodes: feedersLoading } = useNodes({ pageSize: 500 });
 
@@ -128,9 +148,13 @@ export function FeederCoveragePage() {
     return subDays(new Date(), 30);
   }, [timeRange]);
 
+  const targetStrategyParam = useMemo(() => coverageTargetStrategyQueryParam(strategies), [strategies]);
+  const strategySummary = useMemo(() => coverageTargetStrategySummary(strategies), [strategies]);
+
   const { data, isLoading, error } = useFeederReach({
     feederId: selectedFeederId,
     triggeredAtAfter,
+    targetStrategy: targetStrategyParam,
   });
 
   const filteredTargets = useMemo(
@@ -162,80 +186,103 @@ export function FeederCoveragePage() {
           <p className="max-w-2xl text-sm text-muted-foreground">
             Maps completed and failed auto-traceroutes from one managed node to each probed target over the time window.
             Dots show per-target reliability; hex bins summarise nearby targets; the polygon outlines where at least one
-            successful route was observed (not a guarantee of RF coverage).
+            successful route was observed (not a guarantee of RF coverage). The selected managed node appears as an
+            orange tower marker (distinct from the heatmap dots). Use the strategy checkboxes to include only
+            traceroutes recorded under specific target-selection hypotheses.
           </p>
         </div>
-        <div className="flex flex-wrap items-center gap-3" data-testid="coverage-filters">
-          <div className="flex w-full items-center gap-2 sm:w-auto">
-            <Label className="text-xs text-muted-foreground" htmlFor="feeder-coverage-feeder">
-              Feeder
-            </Label>
-            <Select
-              value={selectedFeederId != null ? String(selectedFeederId) : undefined}
-              onValueChange={(v) => setSelectedFeederId(Number.parseInt(v, 10))}
-              disabled={feedersLoading || feederOptions.length === 0}
-            >
-              <SelectTrigger id="feeder-coverage-feeder" className="min-w-[200px]" aria-label="Select feeder">
-                <SelectValue placeholder="Select feeder" />
-              </SelectTrigger>
-              <SelectContent>
-                {feederOptions.map((n) => (
-                  <SelectItem key={n.node_id} value={String(n.node_id)}>
-                    {n.short_name || n.long_name || n.node_id_str}
-                  </SelectItem>
-                ))}
-              </SelectContent>
-            </Select>
-          </div>
-          <div className="flex items-center gap-2">
-            <Label className="text-xs text-muted-foreground" htmlFor="feeder-coverage-window">
-              Window
-            </Label>
-            <Select value={timeRange} onValueChange={(v) => setTimeRange(v as TimeRange)}>
-              <SelectTrigger id="feeder-coverage-window" className="min-w-[140px]" aria-label="Time window">
-                <SelectValue />
-              </SelectTrigger>
-              <SelectContent>
-                <SelectItem value="24h">Last 24 hours</SelectItem>
-                <SelectItem value="7d">Last 7 days</SelectItem>
-                <SelectItem value="30d">Last 30 days</SelectItem>
-              </SelectContent>
-            </Select>
-          </div>
-          <div className="flex items-center gap-2">
-            <Label className="text-xs text-muted-foreground" htmlFor="feeder-coverage-min-attempts">
-              Min attempts
-            </Label>
-            <Input
-              id="feeder-coverage-min-attempts"
-              type="number"
-              min={1}
-              value={minAttempts}
-              onChange={(e) => {
-                const v = Number.parseInt(e.target.value, 10);
-                setMinAttempts(Number.isFinite(v) && v >= 1 ? v : 1);
-              }}
-              className="w-20"
-            />
-          </div>
-          <div className="flex rounded-md border border-input bg-muted/50 p-0.5" data-testid="layer-pills">
-            {ALL_LAYERS.map((key) => (
-              <button
-                key={key}
-                type="button"
-                aria-pressed={layers[key]}
-                aria-label={`Toggle ${LAYER_LABEL[key]} layer`}
-                onClick={() => setLayers((s) => ({ ...s, [key]: !s[key] }))}
-                className={cn(
-                  'rounded px-3 py-1.5 text-sm font-medium transition-colors',
-                  layers[key]
-                    ? 'bg-background text-foreground shadow-sm'
-                    : 'text-muted-foreground hover:text-foreground'
-                )}
+        <div className="flex flex-col gap-3" data-testid="coverage-filters">
+          <div className="flex flex-wrap items-center gap-3">
+            <div className="flex w-full items-center gap-2 sm:w-auto">
+              <Label className="text-xs text-muted-foreground" htmlFor="feeder-coverage-feeder">
+                Feeder
+              </Label>
+              <Select
+                value={selectedFeederId != null ? String(selectedFeederId) : undefined}
+                onValueChange={(v) => setSelectedFeederId(Number.parseInt(v, 10))}
+                disabled={feedersLoading || feederOptions.length === 0}
               >
-                {LAYER_LABEL[key]}
-              </button>
-            ))}
+                <SelectTrigger id="feeder-coverage-feeder" className="min-w-[200px]" aria-label="Select feeder">
+                  <SelectValue placeholder="Select feeder" />
+                </SelectTrigger>
+                <SelectContent>
+                  {feederOptions.map((n) => (
+                    <SelectItem key={n.node_id} value={String(n.node_id)}>
+                      {n.short_name || n.long_name || n.node_id_str}
+                    </SelectItem>
+                  ))}
+                </SelectContent>
+              </Select>
+            </div>
+            <div className="flex items-center gap-2">
+              <Label className="text-xs text-muted-foreground" htmlFor="feeder-coverage-window">
+                Window
+              </Label>
+              <Select value={timeRange} onValueChange={(v) => setTimeRange(v as TimeRange)}>
+                <SelectTrigger id="feeder-coverage-window" className="min-w-[140px]" aria-label="Time window">
+                  <SelectValue />
+                </SelectTrigger>
+                <SelectContent>
+                  <SelectItem value="24h">Last 24 hours</SelectItem>
+                  <SelectItem value="7d">Last 7 days</SelectItem>
+                  <SelectItem value="30d">Last 30 days</SelectItem>
+                </SelectContent>
+              </Select>
+            </div>
+            <div className="flex items-center gap-2">
+              <Label className="text-xs text-muted-foreground" htmlFor="feeder-coverage-min-attempts">
+                Min attempts
+              </Label>
+              <Input
+                id="feeder-coverage-min-attempts"
+                type="number"
+                min={1}
+                value={minAttempts}
+                onChange={(e) => {
+                  const v = Number.parseInt(e.target.value, 10);
+                  setMinAttempts(Number.isFinite(v) && v >= 1 ? v : 1);
+                }}
+                className="w-20"
+              />
+            </div>
+            <div className="flex rounded-md border border-input bg-muted/50 p-0.5" data-testid="layer-pills">
+              {ALL_LAYERS.map((key) => (
+                <button
+                  key={key}
+                  type="button"
+                  aria-pressed={layers[key]}
+                  aria-label={`Toggle ${LAYER_LABEL[key]} layer`}
+                  onClick={() => setLayers((s) => ({ ...s, [key]: !s[key] }))}
+                  className={cn(
+                    'rounded px-3 py-1.5 text-sm font-medium transition-colors',
+                    layers[key]
+                      ? 'bg-background text-foreground shadow-sm'
+                      : 'text-muted-foreground hover:text-foreground'
+                  )}
+                >
+                  {LAYER_LABEL[key]}
+                </button>
+              ))}
+            </div>
+          </div>
+          <div className="flex flex-col gap-2 rounded-md border border-border bg-muted/30 px-3 py-2">
+            <span className="text-xs font-medium text-muted-foreground">Target selection strategies</span>
+            <div className="flex flex-wrap gap-x-4 gap-y-2">
+              {TRACEROUTE_STRATEGIES.map((opt) => (
+                <label
+                  key={opt}
+                  htmlFor={`feeder-coverage-strategy-${opt}`}
+                  className="flex cursor-pointer items-center gap-2 text-sm"
+                >
+                  <Checkbox
+                    id={`feeder-coverage-strategy-${opt}`}
+                    checked={strategies[opt] ?? false}
+                    onCheckedChange={(c) => setStrategies((s) => ({ ...s, [opt]: c === true }))}
+                  />
+                  <span className="leading-none">{STRATEGY_META[opt].label}</span>
+                </label>
+              ))}
+            </div>
           </div>
         </div>
       </div>
@@ -248,6 +295,7 @@ export function FeederCoveragePage() {
           totalSuccesses={totalSuccesses}
           meanSmoothed={meanSmoothed}
           minAttempts={minAttempts}
+          strategySummary={strategySummary}
         />
       </div>
 
@@ -282,13 +330,14 @@ export function FeederCoveragePage() {
 
         <div className="absolute right-4 top-4 z-10 hidden md:block">
           <StatsCard
-            className="w-64"
+            className="w-72"
             feederLabel={feederLabel}
             targetCount={filteredTargets.length}
             totalAttempts={totalAttempts}
             totalSuccesses={totalSuccesses}
             meanSmoothed={meanSmoothed}
             minAttempts={minAttempts}
+            strategySummary={strategySummary}
           />
         </div>
       </div>

--- a/src/pages/traceroutes/FeederCoveragePage.tsx
+++ b/src/pages/traceroutes/FeederCoveragePage.tsx
@@ -12,6 +12,8 @@ import { Button } from '@/components/ui/button';
 import { cn } from '@/lib/utils';
 import { useNodes } from '@/hooks/api/useNodes';
 import { useFeederReach } from '@/hooks/api/useFeederReach';
+import { useObservedNodesHeard } from '@/hooks/api/useObservedNodesHeard';
+import { observedNodesToCoverageGhosts } from '@/lib/coverageHeardGhosts';
 import { FeederCoverageMap, type CoverageLayerKey } from '@/components/traceroutes/FeederCoverageMap';
 import {
   TRACEROUTE_STRATEGIES,
@@ -23,11 +25,12 @@ import {
 
 type TimeRange = '24h' | '7d' | '30d';
 
-const ALL_LAYERS: CoverageLayerKey[] = ['dots', 'hex', 'polygon'];
+const ALL_LAYERS: CoverageLayerKey[] = ['dots', 'hex', 'polygon', 'heard'];
 const LAYER_LABEL: Record<CoverageLayerKey, string> = {
   dots: 'Dots',
   hex: 'Hex',
   polygon: 'Polygon',
+  heard: 'Heard',
 };
 
 function smoothedRate(successes: number, attempts: number): number {
@@ -42,6 +45,7 @@ function StatsCard({
   meanSmoothed,
   minAttempts,
   strategySummary,
+  heardGhostCount,
   className,
 }: {
   feederLabel: string;
@@ -51,6 +55,7 @@ function StatsCard({
   meanSmoothed: number | null;
   minAttempts: number;
   strategySummary?: string;
+  heardGhostCount?: number;
   className?: string;
 }) {
   return (
@@ -66,6 +71,12 @@ function StatsCard({
         )}
         <div className="text-xs text-muted-foreground">{feederLabel}</div>
         <div>{targetCount.toLocaleString()} targets reached</div>
+        {heardGhostCount != null && (
+          <div>
+            {heardGhostCount.toLocaleString()} heard-only nodes{' '}
+            <span className="text-xs text-muted-foreground">(hollow markers)</span>
+          </div>
+        )}
         <div>
           {totalSuccesses.toLocaleString()} / {totalAttempts.toLocaleString()} attempts succeeded
         </div>
@@ -87,7 +98,9 @@ function StatsCard({
         </div>
         <div className="border-t border-border pt-2 text-xs text-muted-foreground">
           <strong className="text-foreground">Dots</strong>: probed targets (size = attempts).{' '}
-          <strong className="text-foreground">Tower</strong>: this managed feeder (source node).
+          <strong className="text-foreground">Tower</strong>: this managed feeder (source node).{' '}
+          <strong className="text-foreground">Heard</strong>: other nodes with a position and last_heard in the window,
+          not in this feeder&apos;s traceroute target list for the current strategy filter.
         </div>
       </CardContent>
     </Card>
@@ -102,6 +115,7 @@ export function FeederCoveragePage() {
     dots: true,
     hex: false,
     polygon: false,
+    heard: false,
   });
   const [strategies, setStrategies] = useState(() => createCoverageStrategiesAllSelected());
 
@@ -156,6 +170,24 @@ export function FeederCoveragePage() {
     triggeredAtAfter,
     targetStrategy: targetStrategyParam,
   });
+
+  const { nodes: heardObservedNodes } = useObservedNodesHeard({
+    lastHeardAfter: triggeredAtAfter,
+    pageSize: 500,
+    enabled: layers.heard && selectedFeederId != null,
+  });
+
+  const representedForHeard = useMemo(() => {
+    const s = new Set<number>();
+    if (data?.feeder?.node_id != null) s.add(data.feeder.node_id);
+    for (const t of data?.targets ?? []) s.add(t.node_id);
+    return s;
+  }, [data]);
+
+  const heardGhosts = useMemo(() => {
+    if (!layers.heard) return [];
+    return observedNodesToCoverageGhosts(heardObservedNodes, representedForHeard);
+  }, [layers.heard, heardObservedNodes, representedForHeard]);
 
   const filteredTargets = useMemo(
     () => (data?.targets ?? []).filter((t) => t.attempts >= minAttempts),
@@ -296,6 +328,7 @@ export function FeederCoveragePage() {
           meanSmoothed={meanSmoothed}
           minAttempts={minAttempts}
           strategySummary={strategySummary}
+          heardGhostCount={layers.heard ? heardGhosts.length : undefined}
         />
       </div>
 
@@ -321,6 +354,7 @@ export function FeederCoveragePage() {
               <FeederCoverageMap
                 feeder={data.feeder}
                 targets={filteredTargets}
+                heardGhosts={heardGhosts}
                 enabledLayers={enabledLayers}
                 minAttempts={minAttempts}
               />
@@ -338,6 +372,7 @@ export function FeederCoveragePage() {
             meanSmoothed={meanSmoothed}
             minAttempts={minAttempts}
             strategySummary={strategySummary}
+            heardGhostCount={layers.heard ? heardGhosts.length : undefined}
           />
         </div>
       </div>


### PR DESCRIPTION
## Summary

- **Constellation** and **feeder** coverage maps: target dots, shared **feeder tower** `IconLayer`, and **target strategy** picker aligned with API `target_strategy`.
- Optional **Heard** layer (default off): hollow dots for observed nodes with positions in the same `last_heard` window as coverage that are **not** already shown as targets, feeders, or (constellation) managed nodes in-scope — useful for comparing auto-targeting to recent mesh activity.
- New `useObservedNodesHeard` hook, `coverageHeardGhosts` helper, and tests.

Pairs with API PR: https://github.com/pskillen/meshflow-api/pull/205

Refs pskillen/meshflow-api#204

## Testing performed

- `npm run build`
- Full `vitest run` via pre-commit hook (includes new `coverageHeardGhosts` tests and updated coverage page tests).