### PR TITLE
feat(traceroutes): auto-target preview map in Trigger Traceroute modal

### DIFF
--- a/src/components/traceroutes/AutoTargetPreviewMap.test.tsx
+++ b/src/components/traceroutes/AutoTargetPreviewMap.test.tsx
@@ -1,0 +1,118 @@
+import { describe, it, expect, vi } from 'vitest';
+import { render, screen } from '@testing-library/react';
+import type { GeoClassification, ManagedNode, ObservedNode } from '@/lib/models';
+import { AutoTargetPreviewMap } from './AutoTargetPreviewMap';
+
+vi.mock('@/components/map/DeckMapboxMap', () => ({
+  DeckMapboxMap: ({ 'data-testid': tid }: { 'data-testid'?: string }) => (
+    <div data-testid={tid ?? 'mock-deck'}>deck</div>
+  ),
+}));
+
+function sampleGeo(overrides: Partial<GeoClassification> = {}): GeoClassification {
+  return {
+    tier: 'perimeter',
+    bearing_octant: 'N',
+    applicable_strategies: ['intra_zone', 'dx_across', 'dx_same_side'],
+    envelope: { centroid_lat: 55.0, centroid_lon: -4.25, radius_km: 12 },
+    selection_centroid: { lat: 55.0, lon: -4.25 },
+    source_bearing_deg: 90,
+    selector_params: {
+      last_heard_within_hours: 3,
+      dx_half_window_sweep_deg: [45, 60, 75, 90],
+      perimeter_distance_fraction: 0.6,
+    },
+    ...overrides,
+  };
+}
+
+function makeFeeder(overrides: Partial<ManagedNode> = {}): ManagedNode {
+  return {
+    node_id: 7,
+    long_name: 'Source',
+    short_name: 'SRC',
+    last_heard: null,
+    node_id_str: '!00000007',
+    owner: { id: 1, username: 'me' },
+    constellation: { id: 1, name: 'C1' },
+    allow_auto_traceroute: true,
+    position: { latitude: 55.2, longitude: -4.25 },
+    geo_classification: sampleGeo(),
+    ...overrides,
+  } as ManagedNode;
+}
+
+const now = new Date();
+const candidate: ObservedNode = {
+  internal_id: 1,
+  node_id: 99,
+  node_id_str: '!00000063',
+  mac_addr: null,
+  long_name: 'Obs',
+  short_name: 'O',
+  hw_model: null,
+  public_key: null,
+  last_heard: now,
+  latest_position: {
+    latitude: 55.05,
+    longitude: -4.25,
+    reported_time: now,
+    logged_time: now,
+    altitude: null,
+    location_source: 'gps',
+  },
+} as ObservedNode;
+
+describe('AutoTargetPreviewMap', () => {
+  it('shows unavailable when selector_params is missing', () => {
+    const feeder = makeFeeder({
+      geo_classification: {
+        tier: 'perimeter',
+        bearing_octant: null,
+        applicable_strategies: ['dx_across'],
+      } as GeoClassification,
+    });
+    render(
+      <AutoTargetPreviewMap
+        feeder={feeder}
+        candidates={[candidate]}
+        managedNodeIds={new Set()}
+        strategy="auto"
+        halfWindowDeg={45}
+      />
+    );
+    expect(screen.getByTestId('auto-target-preview-unavailable')).toBeInTheDocument();
+  });
+
+  it('shows unavailable when feeder has no position', () => {
+    const feeder = makeFeeder({
+      position: { latitude: null, longitude: null },
+    });
+    render(
+      <AutoTargetPreviewMap
+        feeder={feeder}
+        candidates={[candidate]}
+        managedNodeIds={new Set()}
+        strategy="auto"
+        halfWindowDeg={45}
+      />
+    );
+    expect(screen.getByTestId('auto-target-preview-unavailable')).toBeInTheDocument();
+  });
+
+  it('renders map shell and legend when geo data is complete', () => {
+    render(
+      <AutoTargetPreviewMap
+        feeder={makeFeeder()}
+        candidates={[candidate]}
+        managedNodeIds={new Set()}
+        strategy="auto"
+        halfWindowDeg={45}
+      />
+    );
+    expect(screen.getByTestId('auto-target-preview-map')).toBeInTheDocument();
+    expect(screen.getByTestId('auto-target-preview-deck')).toBeInTheDocument();
+    expect(screen.getByText('Intra-zone')).toBeInTheDocument();
+    expect(screen.getByText('DX across')).toBeInTheDocument();
+  });
+});

--- a/src/components/traceroutes/AutoTargetPreviewMap.tsx
+++ b/src/components/traceroutes/AutoTargetPreviewMap.tsx
@@ -1,0 +1,374 @@
+import { useCallback, useMemo, useState } from 'react';
+import { Popup } from 'react-map-gl';
+import { PolygonLayer, ScatterplotLayer } from '@deck.gl/layers';
+import type { Layer, PickingInfo } from '@deck.gl/core';
+import { X } from 'lucide-react';
+
+import { buildFeederIconLayer } from '@/components/map/FeederIconLayer';
+import { DeckMapboxMap } from '@/components/map/DeckMapboxMap';
+import type { GeoClassification, ManagedNode, ObservedNode } from '@/lib/models';
+import {
+  buildCirclePolygon,
+  buildWedgePolygon,
+  classifyCandidate,
+  classifyForAuto,
+  type ClassifyContext,
+  type ExclusionReason,
+  suggestedWedgeRadiusKm,
+  type TargetPreviewStrategy,
+} from '@/lib/tracerouteTargetGeometry';
+
+type PlotRow = { node: ObservedNode; lng: number; lat: number };
+
+const INTRA_FILL: [number, number, number, number] = [34, 197, 94, 55];
+const INTRA_LINE: [number, number, number, number] = [22, 163, 74, 220];
+const DX_ACROSS_FILL: [number, number, number, number] = [59, 130, 246, 60];
+const DX_ACROSS_LINE: [number, number, number, number] = [37, 99, 235, 220];
+const DX_SAME_FILL: [number, number, number, number] = [245, 158, 11, 55];
+const DX_SAME_LINE: [number, number, number, number] = [217, 119, 6, 220];
+
+function nodeLabel(n: ObservedNode): string {
+  return n.short_name ?? n.long_name ?? n.node_id_str ?? String(n.node_id);
+}
+
+function reasonLabel(r: ExclusionReason): string {
+  switch (r) {
+    case 'included':
+      return 'Included in pool for the active strategy';
+    case 'no_position':
+      return 'No latest position';
+    case 'stale_last_heard':
+      return 'Outside last-heard window';
+    case 'is_managed':
+      return 'Managed node (excluded from auto targets)';
+    case 'is_source':
+      return 'Source node';
+    case 'outside_envelope':
+      return 'Outside intra-zone envelope';
+    case 'inside_envelope':
+      return 'Inside envelope (excluded for DX strategies)';
+    case 'outside_wedge':
+      return 'Outside DX wedge for this half-window';
+    default:
+      return r;
+  }
+}
+
+export interface AutoTargetPreviewMapProps {
+  feeder: ManagedNode;
+  candidates: ObservedNode[];
+  managedNodeIds: Set<number>;
+  strategy: TargetPreviewStrategy;
+  halfWindowDeg: number;
+}
+
+export function AutoTargetPreviewMap({
+  feeder,
+  candidates,
+  managedNodeIds,
+  strategy,
+  halfWindowDeg,
+}: AutoTargetPreviewMapProps) {
+  const [picked, setPicked] = useState<ObservedNode | null>(null);
+
+  const geo = feeder.geo_classification;
+  const feederLat = feeder.position?.latitude;
+  const feederLng = feeder.position?.longitude;
+
+  const classifyCtx = useMemo((): ClassifyContext | null => {
+    if (!geo?.selector_params || feederLat == null || feederLng == null) return null;
+    const mergedGeo: GeoClassification = {
+      tier: geo.tier,
+      bearing_octant: geo.bearing_octant ?? null,
+      applicable_strategies: geo.applicable_strategies ?? [],
+      envelope: geo.envelope ?? null,
+      selection_centroid: geo.selection_centroid ?? null,
+      source_bearing_deg: geo.source_bearing_deg ?? null,
+      selector_params: geo.selector_params,
+    };
+    const hours = mergedGeo.selector_params!.last_heard_within_hours;
+    const cutoff = new Date(Date.now() - hours * 60 * 60 * 1000);
+    return {
+      feederNodeId: feeder.node_id,
+      managedNodeIds,
+      lastHeardCutoff: cutoff,
+      geo: mergedGeo,
+      feederLat,
+      feederLon: feederLng,
+    };
+  }, [feeder.node_id, feederLat, feederLng, geo, managedNodeIds]);
+
+  const { envelope, centroid } = useMemo(() => {
+    const env = geo?.envelope ?? null;
+    const cen =
+      geo?.selection_centroid ??
+      (env ? { lat: env.centroid_lat, lon: env.centroid_lon } : null);
+    return { envelope: env, centroid: cen };
+  }, [geo?.envelope, geo?.selection_centroid]);
+
+  const wedgeRadiusKm = useMemo(() => {
+    if (!centroid || feederLat == null || feederLng == null) return 200;
+    return suggestedWedgeRadiusKm(feederLat, feederLng, centroid, envelope ?? null, candidates);
+  }, [candidates, centroid, envelope, feederLat, feederLng]);
+
+  const regionData = useMemo(() => {
+    if (!geo || !centroid || feederLat == null || feederLng == null) return [];
+    const rows: {
+      id: string;
+      polygon: [number, number][];
+      fill: [number, number, number, number];
+      line: [number, number, number, number];
+    }[] = [];
+    const applicable = geo.applicable_strategies ?? [];
+    const showIntra = envelope && (strategy === 'auto' ? applicable.includes('intra_zone') : strategy === 'intra_zone');
+    const showDxAcross = strategy === 'auto' ? applicable.includes('dx_across') : strategy === 'dx_across';
+    const showDxSame = strategy === 'auto' ? applicable.includes('dx_same_side') : strategy === 'dx_same_side';
+
+    if (showIntra && envelope) {
+      rows.push({
+        id: 'intra',
+        polygon: buildCirclePolygon(envelope.centroid_lat, envelope.centroid_lon, envelope.radius_km),
+        fill: INTRA_FILL,
+        line: INTRA_LINE,
+      });
+    }
+    const brSrc = geo.source_bearing_deg;
+    if (brSrc != null) {
+      if (showDxAcross) {
+        const center = (brSrc + 180) % 360;
+        rows.push({
+          id: 'dx_across',
+          polygon: buildWedgePolygon(centroid.lat, centroid.lon, center, halfWindowDeg, wedgeRadiusKm),
+          fill: DX_ACROSS_FILL,
+          line: DX_ACROSS_LINE,
+        });
+      }
+      if (showDxSame) {
+        rows.push({
+          id: 'dx_same',
+          polygon: buildWedgePolygon(centroid.lat, centroid.lon, brSrc, halfWindowDeg, wedgeRadiusKm),
+          fill: DX_SAME_FILL,
+          line: DX_SAME_LINE,
+        });
+      }
+    }
+    return rows;
+  }, [centroid, envelope, feederLat, feederLng, geo, halfWindowDeg, strategy, wedgeRadiusKm]);
+
+  const { includedData, excludedData } = useMemo(() => {
+    if (!classifyCtx || !geo) {
+      return { includedData: [] as ObservedNode[], excludedData: [] as ObservedNode[] };
+    }
+    const applicable = geo.applicable_strategies ?? ['dx_across', 'dx_same_side'];
+    const classifyOne = (n: ObservedNode) =>
+      strategy === 'auto'
+        ? classifyForAuto(n, classifyCtx, applicable, halfWindowDeg)
+        : classifyCandidate(n, classifyCtx, strategy, halfWindowDeg);
+
+    const included: ObservedNode[] = [];
+    const excluded: ObservedNode[] = [];
+    for (const n of candidates) {
+      const r = classifyOne(n);
+      if (r.included) included.push(n);
+      else excluded.push(n);
+    }
+    return { includedData: included, excludedData: excluded };
+  }, [candidates, classifyCtx, geo, halfWindowDeg, strategy]);
+
+  const positions = useMemo((): PlotRow[] => {
+    return [...includedData, ...excludedData]
+      .map((n) => {
+        const lat = n.latest_position?.latitude;
+        const lng = n.latest_position?.longitude;
+        if (lat == null || lng == null) return null;
+        return { node: n, lng, lat };
+      })
+      .filter((x): x is PlotRow => x != null);
+  }, [excludedData, includedData]);
+
+  const includedSet = useMemo(() => new Set(includedData.map((n) => n.node_id)), [includedData]);
+
+  const excludedLayer = useMemo(() => {
+    const data = positions.filter((p) => !includedSet.has(p.node.node_id));
+    if (data.length === 0) return null;
+    return new ScatterplotLayer<PlotRow>({
+      id: 'auto-target-excluded',
+      data,
+      getPosition: (d) => [d.lng, d.lat],
+      getRadius: 3,
+      radiusUnits: 'pixels',
+      filled: false,
+      stroked: true,
+      lineWidthMinPixels: 1.2,
+      getLineColor: [100, 116, 139, 220],
+      pickable: true,
+    });
+  }, [includedSet, positions]);
+
+  const includedLayer = useMemo(() => {
+    const data = positions.filter((p) => includedSet.has(p.node.node_id));
+    if (data.length === 0) return null;
+    return new ScatterplotLayer<PlotRow>({
+      id: 'auto-target-included',
+      data,
+      getPosition: (d) => [d.lng, d.lat],
+      getRadius: 7,
+      radiusUnits: 'pixels',
+      filled: true,
+      stroked: true,
+      lineWidthMinPixels: 1,
+      getFillColor: [15, 118, 110, 230],
+      getLineColor: [6, 78, 59, 240],
+      pickable: true,
+    });
+  }, [includedSet, positions]);
+
+  const polygonLayer = useMemo(() => {
+    if (regionData.length === 0) return null;
+    return new PolygonLayer<(typeof regionData)[0]>({
+      id: 'auto-target-regions',
+      data: regionData,
+      getPolygon: (d) => d.polygon,
+      getFillColor: (d) => d.fill,
+      getLineColor: (d) => d.line,
+      lineWidthMinPixels: 1.5,
+      stroked: true,
+      filled: true,
+      pickable: false,
+    });
+  }, [regionData]);
+
+  const feederLayer = useMemo(() => {
+    if (feederLat == null || feederLng == null) return null;
+    return buildFeederIconLayer(
+      [
+        {
+          lat: feederLat,
+          lng: feederLng,
+          node_id: feeder.node_id,
+          node_id_str: feeder.node_id_str,
+          short_name: feeder.short_name,
+          long_name: feeder.long_name,
+          managed_node_id: String(feeder.node_id),
+        },
+      ],
+      { id: 'auto-target-feeder-icons', size: 36, pickable: true }
+    );
+  }, [feeder, feederLat, feederLng]);
+
+  const layers = useMemo(
+    () => [polygonLayer, excludedLayer, includedLayer, feederLayer].filter(Boolean) as Layer[],
+    [polygonLayer, excludedLayer, includedLayer, feederLayer]
+  );
+
+  const initialViewState = useMemo(() => {
+    if (feederLat != null && feederLng != null) {
+      return { longitude: feederLng, latitude: feederLat, zoom: 9 };
+    }
+    if (centroid) {
+      return { longitude: centroid.lon, latitude: centroid.lat, zoom: 8 };
+    }
+    return { longitude: -4.25, latitude: 55.0, zoom: 8 };
+  }, [centroid, feederLat, feederLng]);
+
+  const handleClick = useCallback((info: PickingInfo) => {
+    const lid = info.layer?.id;
+    if ((lid === 'auto-target-included' || lid === 'auto-target-excluded') && info.object) {
+      setPicked((info.object as { node: ObservedNode }).node);
+      return;
+    }
+    setPicked(null);
+  }, []);
+
+  if (!geo?.selector_params) {
+    return (
+      <div
+        className="flex min-h-[220px] items-center justify-center rounded-md border bg-muted/30 px-4 text-center text-sm text-muted-foreground"
+        data-testid="auto-target-preview-unavailable"
+      >
+        Geo preview needs meshflow-api geo_classification fields (envelope, selection_centroid, selector_params). Update
+        the API and refetch managed nodes.
+      </div>
+    );
+  }
+
+  if (feederLat == null || feederLng == null) {
+    return (
+      <div
+        className="flex min-h-[220px] items-center justify-center rounded-md border bg-muted/30 px-4 text-center text-sm text-muted-foreground"
+        data-testid="auto-target-preview-unavailable"
+      >
+        Source node has no map position. Set a default location or wait for an observed position.
+      </div>
+    );
+  }
+
+  const pickedClassification =
+    picked && classifyCtx && geo
+      ? strategy === 'auto'
+        ? classifyForAuto(picked, classifyCtx, geo.applicable_strategies ?? [], halfWindowDeg)
+        : classifyCandidate(picked, classifyCtx, strategy, halfWindowDeg)
+      : null;
+
+  return (
+    <div className="space-y-2" data-testid="auto-target-preview-map">
+      <div className="h-[280px] overflow-hidden rounded-md border">
+        <DeckMapboxMap
+          layers={layers}
+          initialViewState={initialViewState}
+          onClick={handleClick}
+          data-testid="auto-target-preview-deck"
+        >
+          {picked && pickedClassification && (
+            <Popup
+              longitude={picked.latest_position!.longitude!}
+              latitude={picked.latest_position!.latitude!}
+              anchor="bottom"
+              closeButton={false}
+              closeOnClick={false}
+              onClose={() => setPicked(null)}
+              maxWidth="280px"
+              className="meshflow-map-popup"
+            >
+              <div className="relative min-w-[160px] rounded-md border border-slate-600 bg-slate-800 px-3 py-2 text-sm text-slate-100 shadow-lg">
+                <button
+                  type="button"
+                  onClick={() => setPicked(null)}
+                  className="absolute right-1 top-1 rounded p-0.5 text-slate-400 hover:bg-slate-700 hover:text-slate-200"
+                  aria-label="Close"
+                >
+                  <X className="h-3.5 w-3.5" aria-hidden />
+                </button>
+                <div className="pr-5 font-semibold">{nodeLabel(picked)}</div>
+                <div className="mt-1 text-xs text-slate-400">{pickedClassification.reason}</div>
+                <div className="mt-1 text-xs text-slate-300">{reasonLabel(pickedClassification.reason)}</div>
+              </div>
+            </Popup>
+          )}
+        </DeckMapboxMap>
+      </div>
+      <div className="flex flex-wrap gap-x-4 gap-y-1 text-xs text-muted-foreground">
+        <span className="flex items-center gap-1.5">
+          <span className="inline-block h-2.5 w-2.5 rounded-full bg-emerald-500/80" />
+          Intra-zone
+        </span>
+        <span className="flex items-center gap-1.5">
+          <span className="inline-block h-2.5 w-2.5 rounded-full bg-blue-500/80" />
+          DX across
+        </span>
+        <span className="flex items-center gap-1.5">
+          <span className="inline-block h-2.5 w-2.5 rounded-full bg-amber-500/80" />
+          DX same side
+        </span>
+        <span className="flex items-center gap-1.5">
+          <span className="inline-block h-3 w-3 rounded-full bg-teal-600" title="Candidate" />
+          Candidate
+        </span>
+        <span className="flex items-center gap-1.5">
+          <span className="inline-block h-2.5 w-2.5 rounded-full border border-slate-400 bg-transparent" />
+          Excluded
+        </span>
+      </div>
+    </div>
+  );
+}

--- a/src/lib/models.ts
+++ b/src/lib/models.ts
@@ -113,6 +113,17 @@ export interface GeoClassification {
   tier: 'perimeter' | 'internal';
   bearing_octant: 'N' | 'NE' | 'E' | 'SE' | 'S' | 'SW' | 'W' | 'NW' | null;
   applicable_strategies: ('intra_zone' | 'dx_across' | 'dx_same_side')[];
+  /** Circular envelope (centroid + p90 radius); null when fewer than three positioned managed nodes. */
+  envelope?: { centroid_lat: number; centroid_lon: number; radius_km: number } | null;
+  /** Centroid used for bearings and wedges (matches envelope centroid when defined, else constellation mean). */
+  selection_centroid?: { lat: number; lon: number } | null;
+  /** Bearing from selection centroid toward the feeder, degrees 0–360; null when feeder position unknown. */
+  source_bearing_deg?: number | null;
+  selector_params?: {
+    last_heard_within_hours: number;
+    dx_half_window_sweep_deg: number[];
+    perimeter_distance_fraction: number;
+  };
 }
 
 // ManagedNode from Meshflow API v2

--- a/src/lib/tracerouteTargetGeometry.test.ts
+++ b/src/lib/tracerouteTargetGeometry.test.ts
@@ -1,0 +1,207 @@
+import { describe, it, expect } from 'vitest';
+import type { GeoClassification, ObservedNode } from '@/lib/models';
+import {
+  bearingDifferenceDeg,
+  buildCirclePolygon,
+  classifyCandidate,
+  classifyForAuto,
+  destinationPoint,
+  haversineKm,
+  initialBearingDeg,
+} from './tracerouteTargetGeometry';
+
+function makeGeo(overrides: Partial<GeoClassification> = {}): GeoClassification {
+  return {
+    tier: 'perimeter',
+    bearing_octant: 'N',
+    applicable_strategies: ['intra_zone', 'dx_across', 'dx_same_side'],
+    envelope: {
+      centroid_lat: 55.0,
+      centroid_lon: -4.25,
+      radius_km: 10,
+    },
+    selection_centroid: { lat: 55.0, lon: -4.25 },
+    source_bearing_deg: 90,
+    selector_params: {
+      last_heard_within_hours: 3,
+      dx_half_window_sweep_deg: [45, 60, 75, 90],
+      perimeter_distance_fraction: 0.6,
+    },
+    ...overrides,
+  };
+}
+
+function makeObserved(overrides: Partial<ObservedNode> = {}): ObservedNode {
+  const now = new Date();
+  return {
+    internal_id: 1,
+    node_id: 99,
+    node_id_str: '!00000063',
+    mac_addr: null,
+    long_name: 'T',
+    short_name: 'T',
+    hw_model: null,
+    public_key: null,
+    last_heard: now,
+    latest_position: { latitude: 55.05, longitude: -4.25, reported_time: now, logged_time: now, altitude: null, location_source: 'gps' },
+    ...overrides,
+  } as ObservedNode;
+}
+
+describe('tracerouteTargetGeometry', () => {
+  it('haversineKm is zero for identical points', () => {
+    expect(haversineKm(1, 2, 1, 2)).toBe(0);
+  });
+
+  it('initialBearingDeg north is ~0 for lat move only', () => {
+    const b = initialBearingDeg(0, 0, 1, 0);
+    expect(b).toBeGreaterThanOrEqual(0);
+    expect(b).toBeLessThan(1);
+  });
+
+  it('bearingDifferenceDeg handles wrap', () => {
+    expect(bearingDifferenceDeg(350, 10)).toBe(20);
+  });
+
+  it('buildCirclePolygon closes the ring', () => {
+    const ring = buildCirclePolygon(55, -4.25, 5, 8);
+    expect(ring.length).toBe(9);
+    expect(ring[0]![0]).toBeCloseTo(ring[8]![0], 5);
+    expect(ring[0]![1]).toBeCloseTo(ring[8]![1], 5);
+  });
+
+  it('classifyCandidate intra includes point on envelope boundary', () => {
+    const geo = makeGeo();
+    const onRing = makeObserved({
+      node_id: 501,
+      latest_position: {
+        latitude: destinationPoint(geo.envelope!.centroid_lat, geo.envelope!.centroid_lon, 0, geo.envelope!.radius_km)[0],
+        longitude: destinationPoint(geo.envelope!.centroid_lat, geo.envelope!.centroid_lon, 0, geo.envelope!.radius_km)[1],
+        reported_time: new Date(),
+        logged_time: new Date(),
+        altitude: null,
+        location_source: 'gps',
+      },
+    });
+    const ctx = {
+      feederNodeId: 1,
+      managedNodeIds: new Set<number>(),
+      lastHeardCutoff: new Date(Date.now() - 4 * 60 * 60 * 1000),
+      geo,
+      feederLat: 55.2,
+      feederLon: -4.25,
+    };
+    const r = classifyCandidate(onRing, ctx, 'intra_zone', 45);
+    expect(r.included).toBe(true);
+  });
+
+  it('classifyCandidate dx excludes inside envelope', () => {
+    const geo = makeGeo();
+    const inside = makeObserved({
+      node_id: 502,
+      latest_position: {
+        latitude: 55.01,
+        longitude: -4.25,
+        reported_time: new Date(),
+        logged_time: new Date(),
+        altitude: null,
+        location_source: 'gps',
+      },
+    });
+    const ctx = {
+      feederNodeId: 1,
+      managedNodeIds: new Set<number>(),
+      lastHeardCutoff: new Date(Date.now() - 4 * 60 * 60 * 1000),
+      geo,
+      feederLat: 55.2,
+      feederLon: -4.25,
+    };
+    expect(classifyCandidate(inside, ctx, 'dx_across', 45).included).toBe(false);
+    expect(classifyCandidate(inside, ctx, 'dx_across', 45).reason).toBe('inside_envelope');
+  });
+
+  it('classifyCandidate excludes stale last_heard', () => {
+    const geo = makeGeo();
+    const stale = makeObserved({
+      node_id: 503,
+      last_heard: new Date(Date.now() - 5 * 60 * 60 * 1000),
+    });
+    const ctx = {
+      feederNodeId: 1,
+      managedNodeIds: new Set<number>(),
+      lastHeardCutoff: new Date(Date.now() - 3 * 60 * 60 * 1000),
+      geo,
+      feederLat: 55.2,
+      feederLon: -4.25,
+    };
+    expect(classifyCandidate(stale, ctx, 'intra_zone', 45).reason).toBe('stale_last_heard');
+  });
+
+  it('classifyCandidate dx_across vs dx_same_side differ at bearing 180', () => {
+    const geo = makeGeo({
+      source_bearing_deg: 180,
+      envelope: null,
+      selection_centroid: { lat: 55.0, lon: -4.25 },
+    });
+    const north = makeObserved({
+      node_id: 504,
+      latest_position: {
+        latitude: 56.0,
+        longitude: -4.25,
+        reported_time: new Date(),
+        logged_time: new Date(),
+        altitude: null,
+        location_source: 'gps',
+      },
+    });
+    const south = makeObserved({
+      node_id: 505,
+      latest_position: {
+        latitude: 53.5,
+        longitude: -4.25,
+        reported_time: new Date(),
+        logged_time: new Date(),
+        altitude: null,
+        location_source: 'gps',
+      },
+    });
+    const ctx = {
+      feederNodeId: 1,
+      managedNodeIds: new Set<number>(),
+      lastHeardCutoff: new Date(Date.now() - 4 * 60 * 60 * 1000),
+      geo,
+      feederLat: 54.0,
+      feederLon: -4.25,
+    };
+    expect(classifyCandidate(north, ctx, 'dx_across', 45).included).toBe(true);
+    expect(classifyCandidate(north, ctx, 'dx_same_side', 45).included).toBe(false);
+    expect(classifyCandidate(south, ctx, 'dx_across', 45).included).toBe(false);
+    expect(classifyCandidate(south, ctx, 'dx_same_side', 45).included).toBe(true);
+  });
+
+  it('classifyForAuto includes if any applicable strategy matches', () => {
+    const geo = makeGeo({
+      applicable_strategies: ['intra_zone', 'dx_across'],
+    });
+    const insideIntra = makeObserved({
+      node_id: 505,
+      latest_position: {
+        latitude: 55.05,
+        longitude: -4.25,
+        reported_time: new Date(),
+        logged_time: new Date(),
+        altitude: null,
+        location_source: 'gps',
+      },
+    });
+    const ctx = {
+      feederNodeId: 1,
+      managedNodeIds: new Set<number>(),
+      lastHeardCutoff: new Date(Date.now() - 4 * 60 * 60 * 1000),
+      geo,
+      feederLat: 55.2,
+      feederLon: -4.25,
+    };
+    expect(classifyForAuto(insideIntra, ctx, geo.applicable_strategies, 45).included).toBe(true);
+  });
+});

--- a/src/lib/tracerouteTargetGeometry.ts
+++ b/src/lib/tracerouteTargetGeometry.ts
@@ -1,0 +1,189 @@
+import type { GeoClassification, ObservedNode } from '@/lib/models';
+
+const EARTH_R_KM = 6371;
+
+export type ExclusionReason =
+  | 'no_position'
+  | 'stale_last_heard'
+  | 'is_managed'
+  | 'is_source'
+  | 'outside_envelope'
+  | 'inside_envelope'
+  | 'outside_wedge'
+  | 'included';
+
+export type TargetPreviewStrategy = 'auto' | 'intra_zone' | 'dx_across' | 'dx_same_side';
+
+export function haversineKm(lat1: number, lon1: number, lat2: number, lon2: number): number {
+  const toRad = (d: number) => (d * Math.PI) / 180;
+  const dLat = toRad(lat2 - lat1);
+  const dLon = toRad(lon2 - lon1);
+  const a =
+    Math.sin(dLat / 2) * Math.sin(dLat / 2) +
+    Math.cos(toRad(lat1)) * Math.cos(toRad(lat2)) * Math.sin(dLon / 2) * Math.sin(dLon / 2);
+  const c = 2 * Math.atan2(Math.sqrt(a), Math.sqrt(1 - a));
+  return EARTH_R_KM * c;
+}
+
+export function initialBearingDeg(lat1: number, lon1: number, lat2: number, lon2: number): number {
+  const φ1 = (lat1 * Math.PI) / 180;
+  const φ2 = (lat2 * Math.PI) / 180;
+  const dλ = ((lon2 - lon1) * Math.PI) / 180;
+  const y = Math.sin(dλ) * Math.cos(φ2);
+  const x = Math.cos(φ1) * Math.sin(φ2) - Math.sin(φ1) * Math.cos(φ2) * Math.cos(dλ);
+  const θ = (Math.atan2(y, x) * 180) / Math.PI;
+  return (θ + 360) % 360;
+}
+
+export function bearingDifferenceDeg(a: number, b: number): number {
+  return Math.abs(((a - b + 540) % 360) - 180);
+}
+
+/** Great-circle destination from (lat, lon) moving ``bearingDeg`` clockwise from north. */
+export function destinationPoint(lat: number, lon: number, bearingDeg: number, distanceKm: number): [number, number] {
+  const δ = distanceKm / EARTH_R_KM;
+  const θ = (bearingDeg * Math.PI) / 180;
+  const φ1 = (lat * Math.PI) / 180;
+  const λ1 = (lon * Math.PI) / 180;
+  const sinφ1 = Math.sin(φ1);
+  const cosφ1 = Math.cos(φ1);
+  const sinδ = Math.sin(δ);
+  const cosδ = Math.cos(δ);
+  const sinφ2 = sinφ1 * cosδ + cosφ1 * sinδ * Math.cos(θ);
+  const φ2 = Math.asin(sinφ2);
+  const y = Math.sin(θ) * sinδ * cosφ1;
+  const x = cosδ - sinφ1 * sinφ2;
+  const λ2 = λ1 + Math.atan2(y, x);
+  const lat2 = (φ2 * 180) / Math.PI;
+  const lon2 = (((λ2 * 180) / Math.PI + 540) % 360) - 180;
+  return [lat2, lon2];
+}
+
+/** Closed ring [lng, lat][] for deck.gl PolygonLayer. */
+export function buildCirclePolygon(
+  centerLat: number,
+  centerLon: number,
+  radiusKm: number,
+  steps = 64
+): [number, number][] {
+  const ring: [number, number][] = [];
+  for (let i = 0; i <= steps; i++) {
+    const bearing = (360 * i) / steps;
+    const [la, lo] = destinationPoint(centerLat, centerLon, bearing, radiusKm);
+    ring.push([lo, la]);
+  }
+  return ring;
+}
+
+/** Wedge from centroid, bearings in [centerBearing - half, centerBearing + half], outer arc at ``radiusKm``. */
+export function buildWedgePolygon(
+  centerLat: number,
+  centerLon: number,
+  centerBearingDeg: number,
+  halfWindowDeg: number,
+  radiusKm: number,
+  steps = 40
+): [number, number][] {
+  const ring: [number, number][] = [[centerLon, centerLat]];
+  const from = centerBearingDeg - halfWindowDeg;
+  const to = centerBearingDeg + halfWindowDeg;
+  for (let i = 0; i <= steps; i++) {
+    const t = i / steps;
+    const bearing = from + (to - from) * t;
+    const [la, lo] = destinationPoint(centerLat, centerLon, bearing, radiusKm);
+    ring.push([lo, la]);
+  }
+  ring.push([centerLon, centerLat]);
+  return ring;
+}
+
+export interface ClassifyContext {
+  feederNodeId: number;
+  managedNodeIds: Set<number>;
+  lastHeardCutoff: Date;
+  geo: GeoClassification;
+  feederLat: number;
+  feederLon: number;
+}
+
+function observedLatLon(node: ObservedNode): { lat: number; lon: number } | null {
+  const lat = node.latest_position?.latitude;
+  const lon = node.latest_position?.longitude;
+  if (lat == null || lon == null) return null;
+  return { lat, lon };
+}
+
+export function classifyCandidate(
+  node: ObservedNode,
+  ctx: ClassifyContext,
+  strategy: 'intra_zone' | 'dx_across' | 'dx_same_side',
+  halfWindowDeg: number
+): { included: boolean; reason: ExclusionReason } {
+  if (node.node_id === ctx.feederNodeId) return { included: false, reason: 'is_source' };
+  if (ctx.managedNodeIds.has(node.node_id)) return { included: false, reason: 'is_managed' };
+  const lh = node.last_heard;
+  if (!lh || lh < ctx.lastHeardCutoff) return { included: false, reason: 'stale_last_heard' };
+  const pos = observedLatLon(node);
+  if (!pos) return { included: false, reason: 'no_position' };
+
+  const c = ctx.geo.selection_centroid;
+  if (!c) {
+    if (strategy === 'intra_zone') return { included: false, reason: 'outside_envelope' };
+    return { included: true, reason: 'included' };
+  }
+
+  if (strategy === 'intra_zone') {
+    const env = ctx.geo.envelope;
+    if (!env) return { included: false, reason: 'outside_envelope' };
+    const d = haversineKm(env.centroid_lat, env.centroid_lon, pos.lat, pos.lon);
+    if (d <= env.radius_km) return { included: true, reason: 'included' };
+    return { included: false, reason: 'outside_envelope' };
+  }
+
+  const env = ctx.geo.envelope;
+  if (env) {
+    const dCent = haversineKm(env.centroid_lat, env.centroid_lon, pos.lat, pos.lon);
+    if (dCent <= env.radius_km) return { included: false, reason: 'inside_envelope' };
+  }
+
+  const brSrc = ctx.geo.source_bearing_deg;
+  if (brSrc == null) return { included: true, reason: 'included' };
+
+  const across = strategy === 'dx_across';
+  const centerBearing = across ? (brSrc + 180) % 360 : brSrc;
+  const brT = initialBearingDeg(c.lat, c.lon, pos.lat, pos.lon);
+  if (bearingDifferenceDeg(brT, centerBearing) > halfWindowDeg) {
+    return { included: false, reason: 'outside_wedge' };
+  }
+  return { included: true, reason: 'included' };
+}
+
+export function classifyForAuto(
+  node: ObservedNode,
+  ctx: ClassifyContext,
+  applicable: ('intra_zone' | 'dx_across' | 'dx_same_side')[],
+  halfWindowDeg: number
+): { included: boolean; reason: ExclusionReason } {
+  if (applicable.length === 0) return { included: false, reason: 'outside_wedge' };
+  const results = applicable.map((s) => classifyCandidate(node, ctx, s, halfWindowDeg));
+  const ok = results.find((r) => r.included);
+  if (ok) return ok;
+  return results[0]!;
+}
+
+export function suggestedWedgeRadiusKm(
+  feederLat: number,
+  feederLon: number,
+  centroid: { lat: number; lon: number },
+  envelope: GeoClassification['envelope'],
+  candidates: ObservedNode[]
+): number {
+  let maxD = haversineKm(centroid.lat, centroid.lon, feederLat, feederLon);
+  if (envelope) maxD = Math.max(maxD, envelope.radius_km * 2.5);
+  for (const n of candidates) {
+    const pos = observedLatLon(n);
+    if (!pos) continue;
+    maxD = Math.max(maxD, haversineKm(centroid.lat, centroid.lon, pos.lat, pos.lon));
+  }
+  return Math.min(900, Math.max(100, maxD * 1.2));
+}

--- a/src/pages/traceroutes/TriggerTracerouteModal.test.tsx
+++ b/src/pages/traceroutes/TriggerTracerouteModal.test.tsx
@@ -1,7 +1,12 @@
 import { describe, it, expect, vi } from 'vitest';
+import userEvent from '@testing-library/user-event';
 import { render, screen } from '@testing-library/react';
 import { TriggerTracerouteModal } from './TriggerTracerouteModal';
-import type { ManagedNode, ObservedNode } from '@/lib/models';
+import type { GeoClassification, ManagedNode, ObservedNode } from '@/lib/models';
+
+vi.mock('@/components/traceroutes/AutoTargetPreviewMap', () => ({
+  AutoTargetPreviewMap: () => <div data-testid="auto-target-preview-stub" />,
+}));
 
 function makeObservedNode(overrides: Partial<ObservedNode> = {}): ObservedNode {
   return {
@@ -14,6 +19,22 @@ function makeObservedNode(overrides: Partial<ObservedNode> = {}): ObservedNode {
     hw_model: null,
     public_key: null,
     ...overrides,
+  };
+}
+
+function sampleGeo(): GeoClassification {
+  return {
+    tier: 'perimeter',
+    bearing_octant: 'N',
+    applicable_strategies: ['intra_zone', 'dx_across', 'dx_same_side'],
+    envelope: { centroid_lat: 55.0, centroid_lon: -4.25, radius_km: 10 },
+    selection_centroid: { lat: 55.0, lon: -4.25 },
+    source_bearing_deg: 90,
+    selector_params: {
+      last_heard_within_hours: 3,
+      dx_half_window_sweep_deg: [45, 60, 75, 90],
+      perimeter_distance_fraction: 0.6,
+    },
   };
 }
 
@@ -91,6 +112,30 @@ describe('TriggerTracerouteModal with fixedTargetNode', () => {
       />
     );
     expect(screen.getByTestId('trigger-traceroute-strategy')).toBeInTheDocument();
+  });
+
+  it('shows auto-target preview after selecting a source in auto mode', async () => {
+    const user = userEvent.setup();
+    const managed = makeManagedNode({
+      position: { latitude: 55.2, longitude: -4.25 },
+      geo_classification: sampleGeo(),
+    });
+    render(
+      <TriggerTracerouteModal
+        open={true}
+        onOpenChange={vi.fn()}
+        mode="auto"
+        managedNodes={[managed]}
+        observedNodes={[]}
+        onTrigger={vi.fn()}
+        isSubmitting={false}
+      />
+    );
+    await user.click(screen.getByLabelText('Source node'));
+    const opt = await screen.findByRole('option', { name: /SRC/, hidden: true });
+    await user.click(opt);
+    expect(screen.getByTestId('auto-target-preview-stub')).toBeInTheDocument();
+    expect(screen.getByText(/DX half-window/i)).toBeInTheDocument();
   });
 
   it('does not render the fixed-target row when fixedTargetNode is omitted', () => {

--- a/src/pages/traceroutes/TriggerTracerouteModal.tsx
+++ b/src/pages/traceroutes/TriggerTracerouteModal.tsx
@@ -209,7 +209,8 @@ export function TriggerTracerouteModal({
                   </TooltipTrigger>
                   <TooltipContent side="right" className="max-w-xs text-xs">
                     In auto mode, chooses how the API picks a target. In pick-target mode, records the hypothesis with
-                    an explicit target. Intra-zone only applies to perimeter feeders.
+                    an explicit target. Intra-zone needs a constellation envelope (enough positioned managed nodes);
+                    the perimeter/internal badge is geometry only.
                   </TooltipContent>
                 </Tooltip>
               </TooltipProvider>

--- a/src/pages/traceroutes/TriggerTracerouteModal.tsx
+++ b/src/pages/traceroutes/TriggerTracerouteModal.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useState } from 'react';
+import { useEffect, useMemo, useState } from 'react';
 import {
   Dialog,
   DialogContent,
@@ -13,7 +13,10 @@ import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from '@
 import { Tabs, TabsList, TabsTrigger } from '@/components/ui/tabs';
 import { NodeSearch } from '@/components/NodeSearch';
 import { NodesAndConstellationsMap, MapNode } from '@/components/nodes/NodesAndConstellationsMap';
+import { AutoTargetPreviewMap } from '@/components/traceroutes/AutoTargetPreviewMap';
+import { ToggleGroup, ToggleGroupItem } from '@/components/ui/toggle-group';
 import { ManagedNode, ObservedNode } from '@/lib/models';
+import type { TargetPreviewStrategy } from '@/lib/tracerouteTargetGeometry';
 import { Tooltip, TooltipContent, TooltipProvider, TooltipTrigger } from '@/components/ui/tooltip';
 import { Badge } from '@/components/ui/badge';
 import { Info } from 'lucide-react';
@@ -61,6 +64,7 @@ export function TriggerTracerouteModal({
   const [targetNodeId, setTargetNodeId] = useState<number | null>(null);
   const [targetNodeLabel, setTargetNodeLabel] = useState<string | null>(null);
   const [strategyChoice, setStrategyChoice] = useState<ManualTargetStrategyChoice>('auto');
+  const [halfWindowDeg, setHalfWindowDeg] = useState(45);
 
   const hasFixedTarget = fixedTargetNode != null;
 
@@ -69,6 +73,7 @@ export function TriggerTracerouteModal({
     if (!open) return;
     setMode(hasFixedTarget ? 'user' : initialMode);
     setStrategyChoice('auto');
+    setHalfWindowDeg(45);
   }, [open, initialMode, hasFixedTarget]);
 
   useEffect(() => {
@@ -80,6 +85,11 @@ export function TriggerTracerouteModal({
   const selectedManaged = managedNodes.find((m) => m.node_id === managedNodeId);
   const geo = selectedManaged?.geo_classification;
   const canIntraZone = geo?.applicable_strategies?.includes('intra_zone') ?? false;
+
+  const managedNodeIdSet = useMemo(() => new Set(managedNodes.map((m) => m.node_id)), [managedNodes]);
+
+  const previewStrategy: TargetPreviewStrategy =
+    strategyChoice === 'auto' ? 'auto' : strategyChoice === 'intra_zone' && !canIntraZone ? 'auto' : strategyChoice;
 
   const strategyForApi: 'intra_zone' | 'dx_across' | 'dx_same_side' | undefined =
     strategyChoice === 'auto'
@@ -134,7 +144,7 @@ export function TriggerTracerouteModal({
 
   return (
     <Dialog open={open} onOpenChange={onOpenChange}>
-      <DialogContent className={mode === 'user' ? 'max-w-4xl' : undefined}>
+      <DialogContent className={!hasFixedTarget ? 'max-w-4xl' : undefined}>
         <DialogHeader>
           <DialogTitle>Trigger Traceroute</DialogTitle>
           <DialogDescription>{dialogDescription}</DialogDescription>
@@ -218,6 +228,39 @@ export function TriggerTracerouteModal({
               </SelectContent>
             </Select>
           </div>
+
+          {mode === 'auto' && !hasFixedTarget && managedNodeId != null && selectedManaged && (
+            <div className="grid gap-2">
+              <Label>DX half-window (bearing ±°)</Label>
+              <ToggleGroup
+                type="single"
+                value={String(halfWindowDeg)}
+                onValueChange={(v) => {
+                  if (v) setHalfWindowDeg(parseInt(v, 10));
+                }}
+                variant="outline"
+                size="sm"
+                className="w-fit flex-wrap"
+              >
+                {[45, 60, 75, 90].map((d) => (
+                  <ToggleGroupItem key={d} value={String(d)} className="text-xs">
+                    {d}°
+                  </ToggleGroupItem>
+                ))}
+              </ToggleGroup>
+              <p className="text-xs text-muted-foreground">
+                Shaded regions approximate API target pools (client-side). Hollow dots are excluded for the selected
+                strategy.
+              </p>
+              <AutoTargetPreviewMap
+                feeder={selectedManaged}
+                candidates={observedNodes}
+                managedNodeIds={managedNodeIdSet}
+                strategy={previewStrategy}
+                halfWindowDeg={halfWindowDeg}
+              />
+            </div>
+          )}
 
           {mode === 'user' && hasFixedTarget && fixedTargetNode && (
             <>

--- a/src/test/setup.ts
+++ b/src/test/setup.ts
@@ -11,6 +11,27 @@ class ResizeObserver {
 }
 window.ResizeObserver = ResizeObserver;
 
+// Radix Select uses pointer capture; jsdom omits these on Element.
+{
+  const proto = Element.prototype as unknown as {
+    hasPointerCapture?: (id: number) => boolean;
+    setPointerCapture?: (id: number) => void;
+    releasePointerCapture?: (id: number) => void;
+  };
+  if (typeof proto.hasPointerCapture !== 'function') {
+    proto.hasPointerCapture = () => false;
+  }
+  if (typeof proto.setPointerCapture !== 'function') {
+    proto.setPointerCapture = () => {};
+  }
+  if (typeof proto.releasePointerCapture !== 'function') {
+    proto.releasePointerCapture = () => {};
+  }
+}
+
+// Radix Select scrolls the active item into view.
+window.HTMLElement.prototype.scrollIntoView = function () {};
+
 // Mock matchMedia
 Object.defineProperty(window, 'matchMedia', {
   writable: true,


### PR DESCRIPTION
# Summary

Adds a client-side preview in **Trigger Traceroute → Auto target** after a source is chosen: map shows intra-zone circle, DX-across and DX-same-side wedges (using `halfWindowDeg` 45/60/75/90), feeder icon, and observed nodes as solid (in pool) vs hollow (excluded) with a click popup explaining the exclusion reason. Classification mirrors `meshflow-api` `target_selection` / `constellations/geometry` using fields returned on `geo_classification`.

Also extends `GeoClassification` in `src/lib/models.ts`, adds `src/lib/tracerouteTargetGeometry.ts` (+ tests), and jsdom polyfills in `src/test/setup.ts` for Radix Select (pointer capture + `scrollIntoView`).

**Depends on** meshflow-api PR: https://github.com/pskillen/meshflow-api/pull/207 — merge API first so `selector_params` / `selection_centroid` are present.

## Testing performed

- `npm run build`
- `npm run test` (full Vitest suite)
- `npm run lint` (warnings only, no new errors)

Closes #208

Related #206