### PR TITLE
fix: clean up manual trigger modal and remove always-on strategy pills

### DIFF
--- a/src/components/NodeSearch.tsx
+++ b/src/components/NodeSearch.tsx
@@ -1,4 +1,4 @@
-import { useState, useEffect, useRef } from 'react';
+import { useState, useEffect, useRef, useMemo } from 'react';
 import { Link } from 'react-router-dom';
 import { useNodes } from '@/hooks/api/useNodes';
 import { SearchIcon, X } from 'lucide-react';
@@ -14,13 +14,30 @@ interface NodeSearchProps {
   displayValue?: string | null;
   /** Called when user clears the selection */
   onClearSelection?: () => void;
+  /**
+   * When set, search hits must have `last_heard` on or after this instant (nodes without last_heard are hidden).
+   */
+  lastHeardAfter?: Date;
 }
 
-export function NodeSearch({ onNodeSelect, displayValue, onClearSelection }: NodeSearchProps) {
+function searchResultHeardOnOrAfter(node: { last_heard?: string | null }, cutoff: Date): boolean {
+  if (node.last_heard == null || node.last_heard === '') return false;
+  const t = new Date(node.last_heard);
+  if (Number.isNaN(t.getTime())) return false;
+  return t.getTime() >= cutoff.getTime();
+}
+
+export function NodeSearch({ onNodeSelect, displayValue, onClearSelection, lastHeardAfter }: NodeSearchProps) {
   const [query, setQuery] = useState('');
   const [isOpen, setIsOpen] = useState(false);
   const searchRef = useRef<HTMLDivElement>(null);
   const { searchNodes, searchResults, isSearching } = useNodes();
+
+  const filteredSearchResults = useMemo(() => {
+    const raw = searchResults ?? [];
+    if (lastHeardAfter == null) return raw;
+    return raw.filter((n) => searchResultHeardOnOrAfter(n, lastHeardAfter));
+  }, [searchResults, lastHeardAfter]);
 
   useEffect(() => {
     const handleClickOutside = (event: MouseEvent) => {
@@ -86,11 +103,15 @@ export function NodeSearch({ onNodeSelect, displayValue, onClearSelection }: Nod
             <div className="p-2 text-center">
               <div className="animate-spin rounded-full h-4 w-4 border-t-2 border-b-2 border-primary mx-auto"></div>
             </div>
-          ) : searchResults?.length === 0 ? (
-            <div className="p-2 text-muted-foreground">No nodes found</div>
+          ) : filteredSearchResults.length === 0 ? (
+            <div className="p-2 text-muted-foreground">
+              {(searchResults?.length ?? 0) > 0 && lastHeardAfter != null
+                ? 'No matching nodes heard recently.'
+                : 'No nodes found'}
+            </div>
           ) : (
             <ul className="py-1">
-              {searchResults?.map((node) => (
+              {filteredSearchResults.map((node) => (
                 <li key={node.internal_id}>
                   <Link
                     to={onNodeSelect ? '#' : `/nodes/${node.node_id}`}

--- a/src/components/nodes/NodeOutgoingTraceroutesSection.test.tsx
+++ b/src/components/nodes/NodeOutgoingTraceroutesSection.test.tsx
@@ -55,16 +55,16 @@ function renderSection(managed: ManagedNode) {
 }
 
 describe('NodeOutgoingTraceroutesSection', () => {
-  it('renders outgoing heading and feeder classification when geo is present', () => {
+  it('renders outgoing heading and recent runs (no feeder strategy pills)', () => {
     renderSection(makeManaged());
     expect(screen.getByTestId('node-detail-outgoing-traceroutes')).toBeInTheDocument();
-    expect(screen.getByTestId('node-detail-feeder-geo')).toBeInTheDocument();
-    expect(screen.getByText('Traceroute feeder classification')).toBeInTheDocument();
-    expect(screen.getByText('Internal')).toBeInTheDocument();
+    expect(screen.queryByTestId('node-detail-feeder-geo')).not.toBeInTheDocument();
+    expect(screen.queryByText('Traceroute feeder classification')).not.toBeInTheDocument();
+    expect(screen.getByText('Recent runs')).toBeInTheDocument();
     expect(screen.getByText(/No outgoing traceroutes/)).toBeInTheDocument();
   });
 
-  it('omits classification block when geo_classification is missing', () => {
+  it('renders recent runs when geo_classification is missing', () => {
     renderSection(makeManaged({ geo_classification: null }));
     expect(screen.queryByTestId('node-detail-feeder-geo')).not.toBeInTheDocument();
     expect(screen.getByText('Recent runs')).toBeInTheDocument();

--- a/src/components/nodes/NodeOutgoingTraceroutesSection.tsx
+++ b/src/components/nodes/NodeOutgoingTraceroutesSection.tsx
@@ -8,13 +8,11 @@ import { Card, CardContent, CardDescription, CardHeader, CardTitle } from '@/com
 import { Badge } from '@/components/ui/badge';
 import { Button } from '@/components/ui/button';
 import { Table, TableBody, TableCell, TableHead, TableHeader, TableRow } from '@/components/ui/table';
-import { Tooltip, TooltipContent, TooltipProvider, TooltipTrigger } from '@/components/ui/tooltip';
 import { useTracerouteTriggerableNodesSuspense, useTriggerTraceroute } from '@/hooks/api/useTraceroutes';
 import { useTraceroutesWithWebSocket } from '@/hooks/useTraceroutesWithWebSocket';
 import { TracerouteDetailModal } from '@/pages/traceroutes/TracerouteDetailModal';
 import { getTracerouteErrorMessage } from '@/pages/traceroutes/tracerouteErrors';
 import type { AutoTraceRoute, ManagedNode } from '@/lib/models';
-import { STRATEGY_META, type TracerouteStrategyValue } from '@/lib/traceroute-strategy';
 
 const PAGE_SIZE = 10;
 
@@ -47,6 +45,7 @@ export interface NodeOutgoingTraceroutesSectionProps {
 }
 
 export function NodeOutgoingTraceroutesSection({ nodeId, managed }: NodeOutgoingTraceroutesSectionProps) {
+  void managed; // Prop kept for call-site stability; feeder geo pills removed (#197).
   const [selectedTracerouteId, setSelectedTracerouteId] = useState<number | null>(null);
 
   const { data, isLoading, error } = useTraceroutesWithWebSocket({
@@ -57,7 +56,6 @@ export function NodeOutgoingTraceroutesSection({ nodeId, managed }: NodeOutgoing
   const triggerMutation = useTriggerTraceroute();
 
   const traceroutes = data?.results ?? [];
-  const geo = managed.geo_classification;
 
   const handleRepeat = (tr: AutoTraceRoute) => {
     triggerMutation.mutate(
@@ -95,39 +93,7 @@ export function NodeOutgoingTraceroutesSection({ nodeId, managed }: NodeOutgoing
             Traceroutes initiated by this managed feeder toward other nodes. Click a row for the full path and map.
           </CardDescription>
         </CardHeader>
-        <CardContent className="space-y-8">
-          {geo ? (
-            <div className="space-y-3" data-testid="node-detail-feeder-geo">
-              <h3 className="text-sm font-semibold leading-none">Traceroute feeder classification</h3>
-              <p className="text-sm text-muted-foreground">
-                Geometry vs constellation envelope — drives which automated target strategies apply.
-              </p>
-              <div className="flex flex-wrap items-center gap-2">
-                <Badge variant="outline">
-                  {geo.tier === 'perimeter'
-                    ? `Perimeter${geo.bearing_octant ? ` (${geo.bearing_octant})` : ''}`
-                    : 'Internal'}
-                </Badge>
-                <TooltipProvider delayDuration={200}>
-                  {geo.applicable_strategies.map((s) => (
-                    <Tooltip key={s}>
-                      <TooltipTrigger asChild>
-                        <span className="inline-flex">
-                          <Badge variant="secondary" className="cursor-help">
-                            {STRATEGY_META[s as TracerouteStrategyValue]?.label ?? s}
-                          </Badge>
-                        </span>
-                      </TooltipTrigger>
-                      <TooltipContent side="top" className="max-w-xs text-sm">
-                        {STRATEGY_META[s as TracerouteStrategyValue]?.shortDescription ?? s}
-                      </TooltipContent>
-                    </Tooltip>
-                  ))}
-                </TooltipProvider>
-              </div>
-            </div>
-          ) : null}
-
+        <CardContent className="space-y-3">
           <div className="space-y-3">
             <h3 className="text-sm font-semibold leading-none">Recent runs</h3>
             {isLoading && <div className="py-6 text-center text-muted-foreground">Loading…</div>}

--- a/src/components/traceroutes/StrategyBadge.test.tsx
+++ b/src/components/traceroutes/StrategyBadge.test.tsx
@@ -3,13 +3,28 @@ import { render, screen } from '@testing-library/react';
 import { StrategyBadge } from './StrategyBadge';
 
 describe('StrategyBadge', () => {
-  it('renders Legacy for null', () => {
+  it('renders em dash for null', () => {
     render(<StrategyBadge value={null} />);
-    expect(screen.getByText('Legacy')).toBeInTheDocument();
+    expect(screen.getByText('—')).toBeInTheDocument();
+  });
+
+  it('renders em dash for empty string', () => {
+    render(<StrategyBadge value="" />);
+    expect(screen.getByText('—')).toBeInTheDocument();
   });
 
   it('renders intra-zone label', () => {
     render(<StrategyBadge value="intra_zone" />);
     expect(screen.getByText('Intra-zone')).toBeInTheDocument();
+  });
+
+  it('renders manual target label', () => {
+    render(<StrategyBadge value="manual" />);
+    expect(screen.getByText('Manual target')).toBeInTheDocument();
+  });
+
+  it('renders Legacy for explicit legacy value', () => {
+    render(<StrategyBadge value="legacy" />);
+    expect(screen.getByText('Legacy')).toBeInTheDocument();
   });
 });

--- a/src/components/traceroutes/StrategyBadge.tsx
+++ b/src/components/traceroutes/StrategyBadge.tsx
@@ -1,17 +1,24 @@
 import { Badge } from '@/components/ui/badge';
 import { Tooltip, TooltipContent, TooltipProvider, TooltipTrigger } from '@/components/ui/tooltip';
-import { STRATEGY_META, type TracerouteStrategyValue } from '@/lib/traceroute-strategy';
+import { STRATEGY_META, type TracerouteStrategyDisplayValue } from '@/lib/traceroute-strategy';
 
 export function StrategyBadge({
   value,
   className,
 }: {
-  /** API field; null / undefined renders Legacy */
-  value: TracerouteStrategyValue | string | null | undefined;
+  /** API field; null / undefined renders an em dash (e.g. external traceroutes). */
+  value: TracerouteStrategyDisplayValue | string | null | undefined;
   className?: string;
 }) {
-  const key: TracerouteStrategyValue = value == null || value === '' ? 'legacy' : (value as TracerouteStrategyValue);
-  const meta = STRATEGY_META[key] ?? STRATEGY_META.legacy;
+  if (value == null || value === '') {
+    return <span className="text-muted-foreground">—</span>;
+  }
+
+  const key = value as TracerouteStrategyDisplayValue;
+  const meta =
+    key in STRATEGY_META
+      ? STRATEGY_META[key]
+      : { label: String(value), shortDescription: 'Unknown strategy value', badgeVariant: 'outline' as const };
 
   return (
     <TooltipProvider delayDuration={200}>

--- a/src/lib/models.ts
+++ b/src/lib/models.ts
@@ -205,7 +205,7 @@ export interface AutoTraceRoute {
   target_node: ObservedNode;
   trigger_type: 'auto' | 'user' | 'external' | 'monitor';
   /** Hypothesis-driven selector; null means legacy / unspecified */
-  target_strategy?: 'intra_zone' | 'dx_across' | 'dx_same_side' | 'legacy' | null;
+  target_strategy?: 'intra_zone' | 'dx_across' | 'dx_same_side' | 'legacy' | 'manual' | null;
   triggered_by: number | null;
   triggered_by_username: string | null;
   trigger_source: string | null;

--- a/src/lib/models.ts
+++ b/src/lib/models.ts
@@ -371,6 +371,8 @@ export interface NodeSearchResult {
   node_id_str: string;
   short_name: string | null;
   long_name: string | null;
+  /** ISO string from API when present; used for recency filters in search UI. */
+  last_heard?: string | null;
   owner?: NodeOwnerInfo | null;
 }
 

--- a/src/lib/observed-node-recency.test.ts
+++ b/src/lib/observed-node-recency.test.ts
@@ -1,0 +1,42 @@
+import { describe, it, expect } from 'vitest';
+import { observedNodeHeardOnOrAfter, pickTargetLastHeardCutoff } from '@/lib/observed-node-recency';
+import type { ObservedNode } from '@/lib/models';
+
+function makeNode(overrides: Partial<ObservedNode> = {}): ObservedNode {
+  return {
+    internal_id: 1,
+    node_id: 1,
+    node_id_str: '!00000001',
+    mac_addr: null,
+    long_name: null,
+    short_name: 'A',
+    hw_model: null,
+    public_key: null,
+    ...overrides,
+  };
+}
+
+describe('observed-node-recency', () => {
+  it('pickTargetLastHeardCutoff is about 48h before now', () => {
+    const now = new Date('2026-01-15T12:00:00Z');
+    const c = pickTargetLastHeardCutoff(now);
+    expect(c.getTime()).toBe(now.getTime() - 48 * 60 * 60 * 1000);
+  });
+
+  it('observedNodeHeardOnOrAfter rejects missing last_heard', () => {
+    const cutoff = new Date('2026-01-10T00:00:00Z');
+    expect(observedNodeHeardOnOrAfter(makeNode({ last_heard: null }), cutoff)).toBe(false);
+    expect(observedNodeHeardOnOrAfter(makeNode({ last_heard: undefined }), cutoff)).toBe(false);
+  });
+
+  it('observedNodeHeardOnOrAfter compares against cutoff', () => {
+    const cutoff = new Date('2026-01-10T12:00:00Z');
+    expect(observedNodeHeardOnOrAfter(makeNode({ last_heard: new Date('2026-01-10T11:59:00Z') }), cutoff)).toBe(
+      false
+    );
+    expect(observedNodeHeardOnOrAfter(makeNode({ last_heard: new Date('2026-01-10T12:00:00Z') }), cutoff)).toBe(
+      true
+    );
+    expect(observedNodeHeardOnOrAfter(makeNode({ last_heard: new Date('2026-01-11T00:00:00Z') }), cutoff)).toBe(true);
+  });
+});

--- a/src/lib/observed-node-recency.ts
+++ b/src/lib/observed-node-recency.ts
@@ -1,0 +1,23 @@
+import { subHours } from 'date-fns';
+
+import type { ObservedNode } from '@/lib/models';
+
+/** Pick-target map/search only list nodes heard at least this recently. */
+export const PICK_TARGET_LAST_HEARD_HOURS = 48;
+
+export function pickTargetLastHeardCutoff(now: Date = new Date()): Date {
+  return subHours(now, PICK_TARGET_LAST_HEARD_HOURS);
+}
+
+function toTime(value: Date | string | null | undefined): number | null {
+  if (value == null) return null;
+  const t = value instanceof Date ? value : new Date(value);
+  return Number.isNaN(t.getTime()) ? null : t.getTime();
+}
+
+/** True if the node has a known last_heard on or after `cutoff` (inclusive). */
+export function observedNodeHeardOnOrAfter(node: ObservedNode, cutoff: Date): boolean {
+  const t = toTime(node.last_heard);
+  if (t == null) return false;
+  return t >= cutoff.getTime();
+}

--- a/src/lib/traceroute-strategy.test.ts
+++ b/src/lib/traceroute-strategy.test.ts
@@ -3,8 +3,10 @@ import { applicableStrategiesFromGeo, strategyLabel } from '@/lib/traceroute-str
 
 describe('traceroute-strategy', () => {
   it('strategyLabel maps known keys and falls back', () => {
-    expect(strategyLabel(null)).toBe('Legacy');
+    expect(strategyLabel(null)).toBe('—');
+    expect(strategyLabel('')).toBe('—');
     expect(strategyLabel('dx_across')).toBe('DX across');
+    expect(strategyLabel('manual')).toBe('Manual target');
     expect(strategyLabel('unknown_xyz')).toBe('unknown_xyz');
   });
 

--- a/src/lib/traceroute-strategy.ts
+++ b/src/lib/traceroute-strategy.ts
@@ -20,7 +20,7 @@ export const STRATEGY_META: Record<
   intra_zone: {
     label: 'Intra-zone',
     shortDescription: 'Target inside the constellation envelope — tests intra-mesh continuity.',
-    badgeVariant: 'default',
+    badgeVariant: 'secondary',
   },
   dx_across: {
     label: 'DX across',
@@ -30,17 +30,17 @@ export const STRATEGY_META: Record<
   dx_same_side: {
     label: 'DX same side',
     shortDescription: 'Distant target outside the envelope on your side — tests outreach past the perimeter.',
-    badgeVariant: 'outline',
+    badgeVariant: 'secondary',
   },
   legacy: {
     label: 'Legacy',
     shortDescription: 'Recorded before strategy tracking or unspecified.',
-    badgeVariant: 'outline',
+    badgeVariant: 'secondary',
   },
   manual: {
     label: 'Manual target',
     shortDescription: 'User picked an explicit target node; no automated hypothesis selection.',
-    badgeVariant: 'outline',
+    badgeVariant: 'secondary',
   },
 };
 

--- a/src/lib/traceroute-strategy.ts
+++ b/src/lib/traceroute-strategy.ts
@@ -1,6 +1,10 @@
 /** Target selection strategy (`AutoTraceRoute.target_strategy`). */
 
+/** Hypothesis + legacy tokens used in filters and coverage (not `manual`). */
 export type TracerouteStrategyValue = 'intra_zone' | 'dx_across' | 'dx_same_side' | 'legacy';
+
+/** Full set including server-persisted manual target runs. */
+export type TracerouteStrategyDisplayValue = TracerouteStrategyValue | 'manual';
 
 export const TRACEROUTE_STRATEGIES = [
   'intra_zone',
@@ -10,7 +14,7 @@ export const TRACEROUTE_STRATEGIES = [
 ] as const satisfies readonly TracerouteStrategyValue[];
 
 export const STRATEGY_META: Record<
-  TracerouteStrategyValue,
+  TracerouteStrategyDisplayValue,
   { label: string; shortDescription: string; badgeVariant: 'default' | 'secondary' | 'outline' }
 > = {
   intra_zone: {
@@ -33,11 +37,16 @@ export const STRATEGY_META: Record<
     shortDescription: 'Recorded before strategy tracking or unspecified.',
     badgeVariant: 'outline',
   },
+  manual: {
+    label: 'Manual target',
+    shortDescription: 'User picked an explicit target node; no automated hypothesis selection.',
+    badgeVariant: 'outline',
+  },
 };
 
-export function strategyLabel(value: TracerouteStrategyValue | string | null | undefined): string {
-  if (value == null || value === '') return STRATEGY_META.legacy.label;
-  const k = value as TracerouteStrategyValue;
+export function strategyLabel(value: TracerouteStrategyDisplayValue | string | null | undefined): string {
+  if (value == null || value === '') return '—';
+  const k = value as TracerouteStrategyDisplayValue;
   return STRATEGY_META[k]?.label ?? String(value);
 }
 

--- a/src/pages/traceroutes/TriggerTracerouteModal.test.tsx
+++ b/src/pages/traceroutes/TriggerTracerouteModal.test.tsx
@@ -4,6 +4,18 @@ import { render, screen } from '@testing-library/react';
 import { TriggerTracerouteModal } from './TriggerTracerouteModal';
 import type { GeoClassification, ManagedNode, ObservedNode } from '@/lib/models';
 
+vi.mock('@/providers/ConfigProvider', () => ({
+  useConfig: () => ({ apis: { meshBot: { baseUrl: 'https://api.example' } } }),
+}));
+
+vi.mock('@/hooks/api/useNodes', () => ({
+  useNodes: () => ({
+    searchNodes: vi.fn(),
+    searchResults: [],
+    isSearching: false,
+  }),
+}));
+
 vi.mock('@/components/traceroutes/AutoTargetPreviewMap', () => ({
   AutoTargetPreviewMap: () => <div data-testid="auto-target-preview-stub" />,
 }));
@@ -112,6 +124,38 @@ describe('TriggerTracerouteModal with fixedTargetNode', () => {
       />
     );
     expect(screen.getByTestId('trigger-traceroute-strategy')).toBeInTheDocument();
+  });
+
+  it('does not show target strategy selector in pick-target mode', () => {
+    render(
+      <TriggerTracerouteModal
+        open={true}
+        onOpenChange={vi.fn()}
+        mode="user"
+        managedNodes={[makeManagedNode({ geo_classification: sampleGeo() })]}
+        observedNodes={[makeObservedNode()]}
+        onTrigger={vi.fn()}
+        isSubmitting={false}
+      />
+    );
+    expect(screen.queryByTestId('trigger-traceroute-strategy')).not.toBeInTheDocument();
+  });
+
+  it('does not show target strategy selector for fixed-target flow', () => {
+    const fixed = makeObservedNode();
+    render(
+      <TriggerTracerouteModal
+        open={true}
+        onOpenChange={vi.fn()}
+        mode="user"
+        managedNodes={[makeManagedNode({ geo_classification: sampleGeo() })]}
+        observedNodes={[fixed]}
+        onTrigger={vi.fn()}
+        isSubmitting={false}
+        fixedTargetNode={fixed}
+      />
+    );
+    expect(screen.queryByTestId('trigger-traceroute-strategy')).not.toBeInTheDocument();
   });
 
   it('shows auto-target preview after selecting a source in auto mode', async () => {

--- a/src/pages/traceroutes/TriggerTracerouteModal.tsx
+++ b/src/pages/traceroutes/TriggerTracerouteModal.tsx
@@ -16,6 +16,7 @@ import { NodesAndConstellationsMap, MapNode } from '@/components/nodes/NodesAndC
 import { AutoTargetPreviewMap } from '@/components/traceroutes/AutoTargetPreviewMap';
 import { ToggleGroup, ToggleGroupItem } from '@/components/ui/toggle-group';
 import { ManagedNode, ObservedNode } from '@/lib/models';
+import { observedNodeHeardOnOrAfter, pickTargetLastHeardCutoff } from '@/lib/observed-node-recency';
 import type { TargetPreviewStrategy } from '@/lib/tracerouteTargetGeometry';
 import { Tooltip, TooltipContent, TooltipProvider, TooltipTrigger } from '@/components/ui/tooltip';
 import { Info } from 'lucide-react';
@@ -86,6 +87,18 @@ export function TriggerTracerouteModal({
   const canIntraZone = geo?.applicable_strategies?.includes('intra_zone') ?? false;
 
   const managedNodeIdSet = useMemo(() => new Set(managedNodes.map((m) => m.node_id)), [managedNodes]);
+
+  const [pickTargetLastHeardAfter, setPickTargetLastHeardAfter] = useState(() => pickTargetLastHeardCutoff());
+
+  useEffect(() => {
+    if (!open) return;
+    setPickTargetLastHeardAfter(pickTargetLastHeardCutoff());
+  }, [open]);
+
+  const pickTargetObservedNodes = useMemo(
+    () => observedNodes.filter((n) => observedNodeHeardOnOrAfter(n, pickTargetLastHeardAfter)),
+    [observedNodes, pickTargetLastHeardAfter]
+  );
 
   const previewStrategy: TargetPreviewStrategy =
     strategyChoice === 'auto' ? 'auto' : strategyChoice === 'intra_zone' && !canIntraZone ? 'auto' : strategyChoice;
@@ -294,6 +307,7 @@ export function TriggerTracerouteModal({
               <div className="grid gap-2">
                 <Label htmlFor="target-node">Target node</Label>
                 <NodeSearch
+                  lastHeardAfter={pickTargetLastHeardAfter}
                   onNodeSelect={(id, node) => {
                     setTargetNodeId(id);
                     setTargetNodeLabel(node ? `${node.short_name ?? node.node_id_str} (${node.node_id_str})` : null);
@@ -307,10 +321,13 @@ export function TriggerTracerouteModal({
               </div>
               <div className="grid gap-2">
                 <Label>Or click on the map</Label>
+                <p className="text-xs text-muted-foreground">
+                  Only nodes heard in the last 48 hours are listed and shown on the map.
+                </p>
                 <div className="h-[300px] rounded-md border overflow-hidden">
                   <NodesAndConstellationsMap
                     managedNodes={managedNodes}
-                    observedNodes={observedNodes}
+                    observedNodes={pickTargetObservedNodes}
                     showConstellation={true}
                     showUnmanagedNodes={true}
                     drawBoundingBox={false}

--- a/src/pages/traceroutes/TriggerTracerouteModal.tsx
+++ b/src/pages/traceroutes/TriggerTracerouteModal.tsx
@@ -18,7 +18,6 @@ import { ToggleGroup, ToggleGroupItem } from '@/components/ui/toggle-group';
 import { ManagedNode, ObservedNode } from '@/lib/models';
 import type { TargetPreviewStrategy } from '@/lib/tracerouteTargetGeometry';
 import { Tooltip, TooltipContent, TooltipProvider, TooltipTrigger } from '@/components/ui/tooltip';
-import { Badge } from '@/components/ui/badge';
 import { Info } from 'lucide-react';
 export type ManualTargetStrategyChoice = 'auto' | 'intra_zone' | 'dx_across' | 'dx_same_side';
 
@@ -91,12 +90,15 @@ export function TriggerTracerouteModal({
   const previewStrategy: TargetPreviewStrategy =
     strategyChoice === 'auto' ? 'auto' : strategyChoice === 'intra_zone' && !canIntraZone ? 'auto' : strategyChoice;
 
+  /** Omit for manual target (API stores `manual`) or auto + "pick automatically" (API resolves strategy). */
   const strategyForApi: 'intra_zone' | 'dx_across' | 'dx_same_side' | undefined =
-    strategyChoice === 'auto'
+    mode === 'user'
       ? undefined
-      : strategyChoice === 'intra_zone' && !canIntraZone
+      : strategyChoice === 'auto'
         ? undefined
-        : strategyChoice;
+        : strategyChoice === 'intra_zone' && !canIntraZone
+          ? undefined
+          : strategyChoice;
 
   const handleSubmit = async () => {
     if (!managedNodeId) return;
@@ -112,7 +114,7 @@ export function TriggerTracerouteModal({
   const canSubmit =
     managedNodeId != null &&
     (mode === 'auto' || targetNodeId != null) &&
-    !(strategyChoice === 'intra_zone' && !canIntraZone);
+    !(mode === 'auto' && strategyChoice === 'intra_zone' && !canIntraZone);
 
   const handleMapNodeSelect = (node: MapNode | null) => {
     if (!node) {
@@ -177,58 +179,50 @@ export function TriggerTracerouteModal({
                 ))}
               </SelectContent>
             </Select>
-            {selectedManaged?.geo_classification && (
-              <div className="flex flex-wrap items-center gap-2 text-sm text-muted-foreground">
-                <Badge variant="outline" className="font-normal">
-                  {selectedManaged.geo_classification.tier === 'perimeter'
-                    ? `Perimeter${
-                        selectedManaged.geo_classification.bearing_octant
-                          ? ` (${selectedManaged.geo_classification.bearing_octant})`
-                          : ''
-                      }`
-                    : 'Internal'}
-                </Badge>
-                <span className="text-xs">Traceroute feeder geometry vs constellation</span>
-              </div>
-            )}
           </div>
 
-          <div className="grid gap-2">
-            <div className="flex items-center gap-2">
-              <Label htmlFor="tr-strategy">Target strategy</Label>
-              <TooltipProvider delayDuration={200}>
-                <Tooltip>
-                  <TooltipTrigger asChild>
-                    <button
-                      type="button"
-                      className="text-muted-foreground hover:text-foreground"
-                      aria-label="Strategy help"
-                    >
-                      <Info className="h-4 w-4" />
-                    </button>
-                  </TooltipTrigger>
-                  <TooltipContent side="right" className="max-w-xs text-xs">
-                    In auto mode, chooses how the API picks a target. In pick-target mode, records the hypothesis with
-                    an explicit target. Intra-zone needs a constellation envelope (enough positioned managed nodes);
-                    the perimeter/internal badge is geometry only.
-                  </TooltipContent>
-                </Tooltip>
-              </TooltipProvider>
-            </div>
-            <Select value={strategyChoice} onValueChange={(v) => setStrategyChoice(v as ManualTargetStrategyChoice)}>
-              <SelectTrigger id="tr-strategy" data-testid="trigger-traceroute-strategy">
-                <SelectValue />
-              </SelectTrigger>
-              <SelectContent>
-                <SelectItem value="auto">Pick automatically</SelectItem>
-                <SelectItem value="intra_zone" disabled={!canIntraZone}>
-                  Intra-zone
-                </SelectItem>
-                <SelectItem value="dx_across">DX across</SelectItem>
-                <SelectItem value="dx_same_side">DX same side</SelectItem>
-              </SelectContent>
-            </Select>
-          </div>
+          {mode === 'auto' && (
+            <>
+              <div className="grid gap-2">
+                <div className="flex items-center gap-2">
+                  <Label htmlFor="tr-strategy">Target strategy</Label>
+                  <TooltipProvider delayDuration={200}>
+                    <Tooltip>
+                      <TooltipTrigger asChild>
+                        <button
+                          type="button"
+                          className="text-muted-foreground hover:text-foreground"
+                          aria-label="Strategy help"
+                        >
+                          <Info className="h-4 w-4" />
+                        </button>
+                      </TooltipTrigger>
+                      <TooltipContent side="right" className="max-w-xs text-xs">
+                        Chooses how the API picks a target when you do not pick one manually. Intra-zone needs a
+                        constellation envelope (enough positioned managed nodes).
+                      </TooltipContent>
+                    </Tooltip>
+                  </TooltipProvider>
+                </div>
+                <Select
+                  value={strategyChoice}
+                  onValueChange={(v) => setStrategyChoice(v as ManualTargetStrategyChoice)}
+                >
+                  <SelectTrigger id="tr-strategy" data-testid="trigger-traceroute-strategy">
+                    <SelectValue />
+                  </SelectTrigger>
+                  <SelectContent>
+                    <SelectItem value="auto">Pick automatically</SelectItem>
+                    <SelectItem value="intra_zone" disabled={!canIntraZone}>
+                      Intra-zone
+                    </SelectItem>
+                    <SelectItem value="dx_across">DX across</SelectItem>
+                    <SelectItem value="dx_same_side">DX same side</SelectItem>
+                  </SelectContent>
+                </Select>
+              </div>
+            </>
+          )}
 
           {mode === 'auto' && !hasFixedTarget && managedNodeId != null && selectedManaged && (
             <div className="grid gap-2">


### PR DESCRIPTION
## Summary

- **#196**: Pick-target and fixed-target flows no longer show the target strategy selector or the Internal/Perimeter badge under the source node. `onTrigger` omits `target_strategy` so the API persists `manual` (requires backend PR).
- **#197**: Removed the "Traceroute feeder classification" block (strategy pills) from Node Details → Outgoing traceroutes.
- Null/empty `target_strategy` renders as `—` in `StrategyBadge` and `strategyLabel` (not "Legacy"). Added `manual` to types and `STRATEGY_META`.

## Testing performed

- `npm test` (Vitest)
- Husky: eslint + prettier (pre-commit)

Depends on https://github.com/pskillen/meshflow-api/pull/208

Closes #196
Closes #197