### PR TITLE
feat(nodes): map marker legends and recency display (#201, #203)

### DIFF
--- a/src/components/NodeActivityTable.tsx
+++ b/src/components/NodeActivityTable.tsx
@@ -9,8 +9,8 @@ import {
   SortingState,
   getSortedRowModel,
 } from '@tanstack/react-table';
-import { formatDistanceToNow } from 'date-fns';
 import { BatteryIcon, SignalIcon } from 'lucide-react';
+import { StaleReportedTime } from '@/components/nodes/StaleReportedTime';
 
 import { Table, TableBody, TableCell, TableHead, TableHeader, TableRow } from '@/components/ui/table';
 import { Button } from '@/components/ui/button';
@@ -44,7 +44,7 @@ const columns: ColumnDef<ObservedNode>[] = [
       return (
         <div className="flex items-center gap-2">
           <SignalIcon className="h-4 w-4 text-green-500" />
-          <span>{formatDistanceToNow(lastHeard, { addSuffix: true })}</span>
+          <StaleReportedTime at={lastHeard} className="inline" />
         </div>
       );
     },

--- a/src/components/messages/MessageItem.tsx
+++ b/src/components/messages/MessageItem.tsx
@@ -2,8 +2,9 @@ import { TextMessage, type PacketObservation } from '@/lib/models';
 import { Avatar } from '@/components/ui/avatar';
 import { Badge } from '@/components/ui/badge';
 import { Button } from '@/components/ui/button';
-import { format, formatDistanceToNow } from 'date-fns';
+import { format } from 'date-fns';
 import { memo, useMemo } from 'react';
+import { StaleReportedTime } from '@/components/nodes/StaleReportedTime';
 import { Link } from 'react-router-dom';
 import { Dialog, DialogContent, DialogHeader, DialogTitle, DialogTrigger } from '@/components/ui/dialog';
 import { ExternalLink } from 'lucide-react';
@@ -99,9 +100,6 @@ export const MessageItem = memo(function MessageItem({
   continuationMessages = [],
 }: MessageItemProps) {
   const nodeId = useMemo(() => parseNodeId(message.sender.node_id_str), [message.sender.node_id_str]);
-  const relativeTime = useMemo(() => {
-    return message.sent_at ? formatDistanceToNow(new Date(message.sent_at), { addSuffix: true }) : '';
-  }, [message.sent_at]);
   const fullTime = useMemo(() => {
     return message.sent_at ? format(new Date(message.sent_at), 'MMM d, yyyy h:mm a') : 'Unknown time';
   }, [message.sent_at]);
@@ -151,9 +149,14 @@ export const MessageItem = memo(function MessageItem({
             <span className="font-medium truncate">{senderName}</span>
           )}
         </div>
-        <time className="shrink-0 text-xs text-muted-foreground" title={fullTime}>
-          {relativeTime}
-        </time>
+        {message.sent_at ? (
+          <StaleReportedTime
+            at={message.sent_at}
+            variant="neutral"
+            className="shrink-0 text-xs text-muted-foreground"
+            title={fullTime}
+          />
+        ) : null}
         <HeardDialog observations={message.heard} />
       </header>
       <div className="pl-8">

--- a/src/components/nodes/InfrastructureNodeCard.tsx
+++ b/src/components/nodes/InfrastructureNodeCard.tsx
@@ -1,6 +1,6 @@
 import { Link } from 'react-router-dom';
-import { formatDistanceToNow } from 'date-fns';
 import { DeviceMetrics, ManagedNode, ObservedNode, NodeWatch, PaginatedResponse } from '@/lib/models';
+import { StaleReportedTime } from '@/components/nodes/StaleReportedTime';
 import { MeshWatchControls } from '@/components/nodes/MeshWatchControls';
 import { Tooltip, TooltipContent, TooltipProvider, TooltipTrigger } from '@/components/ui/tooltip';
 import { STRATEGY_META, type TracerouteStrategyValue } from '@/lib/traceroute-strategy';
@@ -81,7 +81,7 @@ function InfrastructureNodeCardInner({
             </Badge>
           )}
           <span className="text-sm text-slate-500 dark:text-slate-400">
-            {node.last_heard ? formatDistanceToNow(node.last_heard, { addSuffix: true }) : 'Never'}
+            <StaleReportedTime at={node.last_heard ?? null} fallback="Never" className="text-inherit" />
           </span>
         </div>
       </div>

--- a/src/components/nodes/MapMarkerLegend.tsx
+++ b/src/components/nodes/MapMarkerLegend.tsx
@@ -1,0 +1,77 @@
+import { cn } from '@/lib/utils';
+import type { RoleLegendSwatch } from './map-role-legend';
+
+export type ConstellationLegendItem = { id: number; name: string; color: string };
+
+export interface MapMarkerLegendProps {
+  className?: string;
+  constellationItems?: ConstellationLegendItem[];
+  /** When true, show role-colour swatches (observed / non-constellation markers). */
+  showRoleSwatches: boolean;
+  roleSwatches: RoleLegendSwatch[];
+  constellationTitle?: string;
+  roleSectionTitle?: string;
+}
+
+function SwatchRow({ label, color }: { label: string; color: string }) {
+  return (
+    <div className="flex items-center gap-2 min-w-0">
+      <span
+        className="h-3 w-3 shrink-0 rounded-full border border-border/80 shadow-sm"
+        style={{ backgroundColor: color }}
+        aria-hidden
+      />
+      <span className="truncate">{label}</span>
+    </div>
+  );
+}
+
+export function MapMarkerLegend({
+  className,
+  constellationItems = [],
+  showRoleSwatches,
+  roleSwatches,
+  constellationTitle = 'Monitoring (constellation)',
+  roleSectionTitle = 'Other mesh nodes (by role)',
+}: MapMarkerLegendProps) {
+  const hasConstellation = constellationItems.length > 0;
+  if (!hasConstellation && !showRoleSwatches) return null;
+
+  return (
+    <div
+      className={cn(
+        'absolute top-2 right-2 z-[1000] max-h-[40%] overflow-y-auto max-w-[min(100%,20rem)] rounded-md border bg-background/95 p-2 text-xs shadow-sm backdrop-blur-sm',
+        className
+      )}
+      role="region"
+      aria-label="Map marker colours"
+    >
+      <div className="flex flex-wrap gap-x-3 gap-y-2 flex-col sm:flex-row sm:items-start">
+        {hasConstellation ? (
+          <div className="min-w-0 flex-1 space-y-1">
+            <div className="font-medium text-[0.7rem] uppercase tracking-wide text-muted-foreground">
+              {constellationTitle}
+            </div>
+            <div className="flex flex-wrap gap-x-3 gap-y-1">
+              {constellationItems.map((c) => (
+                <SwatchRow key={c.id} label={c.name} color={c.color} />
+              ))}
+            </div>
+          </div>
+        ) : null}
+        {showRoleSwatches ? (
+          <div className="min-w-0 flex-1 space-y-1 border-t border-border/60 pt-2 sm:border-t-0 sm:pt-0 sm:border-l sm:pl-3 sm:pt-0">
+            <div className="font-medium text-[0.7rem] uppercase tracking-wide text-muted-foreground">
+              {roleSectionTitle}
+            </div>
+            <div className="flex flex-wrap gap-x-3 gap-y-1">
+              {roleSwatches.map((r) => (
+                <SwatchRow key={r.key} label={r.label} color={r.color} />
+              ))}
+            </div>
+          </div>
+        ) : null}
+      </div>
+    </div>
+  );
+}

--- a/src/components/nodes/MyNodeCard.tsx
+++ b/src/components/nodes/MyNodeCard.tsx
@@ -1,6 +1,6 @@
 import { Link } from 'react-router-dom';
-import { formatDistanceToNow } from 'date-fns';
 import { MoreVertical, Radio, Settings, ChevronRight, FileText, AlertTriangle, AlertCircle } from 'lucide-react';
+import { StaleReportedTime } from '@/components/nodes/StaleReportedTime';
 import type { UseQueryResult } from '@tanstack/react-query';
 
 import { MeshWatchControls } from '@/components/nodes/MeshWatchControls';
@@ -145,9 +145,7 @@ export function MyNodeCard({
         </div>
         <p className="text-sm text-muted-foreground">
           Last heard{' '}
-          <span className="text-foreground tabular-nums">
-            {node.last_heard ? formatDistanceToNow(new Date(node.last_heard), { addSuffix: true }) : 'never'}
-          </span>
+          <StaleReportedTime at={node.last_heard ?? null} fallback="never" className="text-foreground tabular-nums" />
         </p>
         <TooltipProvider delayDuration={300}>
           <Tooltip>
@@ -158,7 +156,7 @@ export function MyNodeCard({
             </TooltipTrigger>
             {metricsReported ? (
               <TooltipContent side="bottom" className="max-w-xs">
-                Metrics updated {formatDistanceToNow(metricsReported, { addSuffix: true })}
+                Metrics updated <StaleReportedTime at={metricsReported} className="inline" />
               </TooltipContent>
             ) : (
               <TooltipContent side="bottom">No recent telemetry timestamp</TooltipContent>

--- a/src/components/nodes/NodeCard.tsx
+++ b/src/components/nodes/NodeCard.tsx
@@ -1,6 +1,6 @@
 import { Link } from 'react-router-dom';
-import { formatDistanceToNow } from 'date-fns';
 import { Battery } from 'lucide-react';
+import { StaleReportedTime } from '@/components/nodes/StaleReportedTime';
 import { ObservedNode } from '@/lib/models';
 import { getRoleLabel } from '@/lib/meshtastic';
 import { cn } from '@/lib/utils';
@@ -56,7 +56,7 @@ export function NodeCard({ node }: NodeCardProps) {
         </div>
         <div className="text-right shrink-0">
           <div className="text-sm text-slate-500 dark:text-slate-400">
-            {node.last_heard ? formatDistanceToNow(node.last_heard, { addSuffix: true }) : 'Never'}
+            <StaleReportedTime at={node.last_heard ?? null} fallback="Never" className="text-inherit" />
           </div>
           <div className="text-xs font-mono text-slate-500 dark:text-slate-400 mt-0.5">{node.node_id_str}</div>
         </div>

--- a/src/components/nodes/NodesAndConstellationsMap.tsx
+++ b/src/components/nodes/NodesAndConstellationsMap.tsx
@@ -1,9 +1,8 @@
 import { ObservedNode, ManagedNode } from '@/lib/models';
 import L from 'leaflet';
-import { useCallback, useEffect, useRef, useState } from 'react';
+import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
 import 'leaflet/dist/leaflet.css';
 import * as turf from '@turf/turf';
-import * as d3 from 'd3';
 import type { Feature, Point, Polygon, Position as GeoPosition } from 'geojson';
 import { useMapTileUrl } from '@/hooks/useMapTileUrl';
 import {
@@ -14,6 +13,9 @@ import {
   precisionBitsToMeters,
   buildNodePopupHtml,
 } from './map-utils';
+import { computeManagedConstellationGroups, constellationLegendItems } from './map-constellation-colors';
+import { meshRoleLegendSwatches } from './map-role-legend';
+import { MapMarkerLegend } from './MapMarkerLegend';
 
 const DEFAULT_CENTER: L.LatLngExpression = [55.8642, -4.2518];
 const UNCERTAINTY_THRESHOLD_M = 200;
@@ -67,6 +69,11 @@ export interface NodesAndConstellationsMapProps {
   getMarkerBorderColor?: (node: ObservedNode) => string | undefined;
   /** Optional marker colour override for managed nodes */
   getManagedNodeMarkerColor?: (node: ManagedNode) => string;
+  /**
+   * When unset, legend shows except for custom marker colours (e.g. weather map).
+   * Set `false` to hide; set `true` to force on even with `getMarkerColor`.
+   */
+  showMapLegend?: boolean;
 }
 
 export function NodesAndConstellationsMap({
@@ -89,6 +96,7 @@ export function NodesAndConstellationsMap({
   getMarkerGrayscale,
   getMarkerBorderColor,
   getManagedNodeMarkerColor,
+  showMapLegend,
 }: NodesAndConstellationsMapProps) {
   const mapRef = useRef<HTMLDivElement>(null);
   const mapInstanceRef = useRef<L.Map | null>(null);
@@ -103,6 +111,22 @@ export function NodesAndConstellationsMap({
   const { url: tileUrl, attribution } = useMapTileUrl();
   onMapMoveRef.current = onMapMove;
   onNodeSelectRef.current = onNodeSelect;
+
+  const roleLegendData = useMemo(() => meshRoleLegendSwatches(), []);
+
+  const constellationGroups = useMemo(
+    () => computeManagedConstellationGroups(managedNodes, filterConstellationIds),
+    [managedNodes, filterConstellationIds]
+  );
+
+  const legendConstellationItems = useMemo(() => constellationLegendItems(constellationGroups), [constellationGroups]);
+
+  const showLegendResolved =
+    showMapLegend === false
+      ? false
+      : showMapLegend === true
+        ? true
+        : getMarkerColor == null && getManagedNodeMarkerColor == null;
 
   const handleMarkerClick = useCallback(
     (node: MapNode) => {
@@ -244,27 +268,7 @@ export function NodesAndConstellationsMap({
         ? managedNodes.filter((n) => n.constellation && filterConstellationIds.includes(n.constellation.id))
         : managedNodes;
 
-    const constellations: Record<number, { name: string; color: string; nodes: ManagedNode[] }> = {};
-    filteredManaged.forEach((node) => {
-      if (node.constellation) {
-        const id = node.constellation.id;
-        if (!constellations[id]) {
-          constellations[id] = {
-            name: node.constellation.name || 'Unknown',
-            color: node.constellation.map_color || '',
-            nodes: [],
-          };
-        }
-        constellations[id].nodes.push(node);
-      }
-    });
-
-    const constellationIds = Object.keys(constellations);
-    constellationIds.forEach((id, idx) => {
-      if (!constellations[+id].color) {
-        constellations[+id].color = d3.schemeCategory10[idx % d3.schemeCategory10.length];
-      }
-    });
+    const constellations = computeManagedConstellationGroups(managedNodes, filterConstellationIds);
 
     const bounds = L.latLngBounds([]);
     const hasStoredView = lastViewRef.current != null;
@@ -494,10 +498,20 @@ export function NodesAndConstellationsMap({
   ]);
 
   return (
-    <div
-      ref={mapRef}
-      style={{ height: '100%', minHeight: '400px', position: 'relative', zIndex: 1 }}
-      className="map-container"
-    />
+    <div className="relative h-full w-full min-h-[400px]">
+      {showLegendResolved ? (
+        <MapMarkerLegend
+          constellationItems={showConstellation ? legendConstellationItems : []}
+          showRoleSwatches={getMarkerColor == null}
+          roleSwatches={roleLegendData}
+          roleSectionTitle={showConstellation ? 'Other mesh nodes (by role)' : 'Node role'}
+        />
+      ) : null}
+      <div
+        ref={mapRef}
+        style={{ height: '100%', minHeight: '400px', position: 'relative', zIndex: 1 }}
+        className="map-container"
+      />
+    </div>
   );
 }

--- a/src/components/nodes/NodesMap.tsx
+++ b/src/components/nodes/NodesMap.tsx
@@ -1,23 +1,28 @@
 import { ObservedNode } from '@/lib/models';
 import L from 'leaflet';
-import { useEffect, useRef } from 'react';
+import { useEffect, useMemo, useRef } from 'react';
 import 'leaflet/dist/leaflet.css';
 import { useMapTileUrl } from '@/hooks/useMapTileUrl';
 import { createNodeIcon, getRoleColor, buildNodePopupHtml } from './map-utils';
+import { MapMarkerLegend } from './MapMarkerLegend';
+import { meshRoleLegendSwatches } from './map-role-legend';
 
 interface NodesMapProps {
   nodes: ObservedNode[];
+  /** Default true: role-colour key for marker pins. */
+  showMapLegend?: boolean;
 }
 
 // Default center only used if no nodes are present
 const DEFAULT_CENTER: L.LatLngExpression = [55.8642, -4.2518];
 
-export function NodesMap({ nodes }: NodesMapProps) {
+export function NodesMap({ nodes, showMapLegend = true }: NodesMapProps) {
   const mapRef = useRef<HTMLDivElement>(null);
   const mapInstanceRef = useRef<L.Map | null>(null);
   const tileLayerRef = useRef<L.TileLayer | null>(null);
   const markersRef = useRef<L.Marker[]>([]);
   const { url: tileUrl, attribution } = useMapTileUrl();
+  const roleSwatches = useMemo(() => meshRoleLegendSwatches(), []);
 
   // Initialize the map
   useEffect(() => {
@@ -163,15 +168,25 @@ export function NodesMap({ nodes }: NodesMapProps) {
   }, [nodes]);
 
   return (
-    <div
-      ref={mapRef}
-      style={{
-        height: '100%',
-        minHeight: '400px',
-        position: 'relative',
-        zIndex: 1,
-      }}
-      className="map-container"
-    />
+    <div className="relative h-full w-full min-h-[400px]">
+      {showMapLegend ? (
+        <MapMarkerLegend
+          constellationItems={[]}
+          showRoleSwatches
+          roleSwatches={roleSwatches}
+          roleSectionTitle="Node role"
+        />
+      ) : null}
+      <div
+        ref={mapRef}
+        style={{
+          height: '100%',
+          minHeight: '400px',
+          position: 'relative',
+          zIndex: 1,
+        }}
+        className="map-container"
+      />
+    </div>
   );
 }

--- a/src/components/nodes/StaleReportedTime.test.tsx
+++ b/src/components/nodes/StaleReportedTime.test.tsx
@@ -1,0 +1,38 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { render, screen } from '@testing-library/react';
+import { StaleReportedTime } from './StaleReportedTime';
+
+describe('StaleReportedTime', () => {
+  beforeEach(() => {
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date('2026-06-15T12:00:00.000Z'));
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  it('neutral variant does not apply stale border classes', () => {
+    const { container } = render(
+      <StaleReportedTime at={new Date('2026-06-01T12:00:00.000Z')} variant="neutral" />
+    );
+    const el = container.querySelector('time');
+    expect(el).toBeTruthy();
+    expect(el?.className).not.toContain('border-yellow');
+    expect(el?.className).not.toContain('border-red');
+  });
+
+  it('stale variant applies warning styling in warning band', () => {
+    const { container } = render(
+      <StaleReportedTime at={new Date('2026-06-14T12:00:00.000Z')} variant="stale" />
+    );
+    const el = container.querySelector('time');
+    expect(el?.className).toContain('border-yellow');
+  });
+
+  it('showDateTime adds en-GB style absolute segment', () => {
+    render(<StaleReportedTime at={new Date('2026-06-15T10:00:00.000Z')} showDateTime />);
+    const el = screen.getByText(/\(.*\)/);
+    expect(el.textContent).toMatch(/\d{1,2}/);
+  });
+});

--- a/src/components/nodes/StaleReportedTime.tsx
+++ b/src/components/nodes/StaleReportedTime.tsx
@@ -1,19 +1,50 @@
-import { format, formatDistanceToNow } from 'date-fns';
-import { reportedTimeFreshness } from '@/lib/reported-time-stale';
+import { enGB } from 'date-fns/locale';
+import { format } from 'date-fns';
+import { reportedTimeFreshness, type ReportedTimeFreshnessOptions } from '@/lib/reported-time-stale';
+import { formatRecencyRelative } from '@/lib/reported-time-format';
 import { cn } from '@/lib/utils';
 
-type StaleReportedTimeProps = {
+const enGbDateTime = new Intl.DateTimeFormat('en-GB', {
+  dateStyle: 'medium',
+  timeStyle: 'short',
+});
+
+function formatAbsoluteEnGb(d: Date): string {
+  return enGbDateTime.format(d);
+}
+
+export type StaleReportedTimeProps = {
   at: Date | string | number | null | undefined;
   /** When `at` is null/undefined/invalid */
   fallback?: string;
   className?: string;
+  /** Overrides native `title` / tooltip when set. */
+  title?: string;
+  showFriendly?: boolean;
+  showDateTime?: boolean;
+  warningAfterHours?: number;
+  dangerAfterHours?: number;
+  /** `stale` = yellow/red bands; `neutral` = relative time only (e.g. message sent). */
+  variant?: 'stale' | 'neutral';
 };
 
 /**
- * Relative time ("x ago") with yellow border if over 24h old, red if over 7 days.
- * `title` shows absolute local time for hover/accessibility.
+ * Relative time ("x ago") with optional UK-style absolute text; yellow border at warning age, red at danger (unless `variant="neutral"`).
  */
-export function StaleReportedTime({ at, fallback = '—', className }: StaleReportedTimeProps) {
+export function StaleReportedTime({
+  at,
+  fallback = '—',
+  className,
+  title: titleOverride,
+  showFriendly = true,
+  showDateTime = false,
+  warningAfterHours,
+  dangerAfterHours,
+  variant = 'stale',
+}: StaleReportedTimeProps) {
+  const freshnessOpts: ReportedTimeFreshnessOptions | undefined =
+    warningAfterHours != null || dangerAfterHours != null ? { warningAfterHours, dangerAfterHours } : undefined;
+
   if (at == null) {
     return <span className={className}>{fallback}</span>;
   }
@@ -23,16 +54,40 @@ export function StaleReportedTime({ at, fallback = '—', className }: StaleRepo
     return <span className={className}>{fallback}</span>;
   }
 
-  const relative = formatDistanceToNow(d, { addSuffix: true });
-  const title = format(d, 'PPpp');
-  const freshness = reportedTimeFreshness(d);
+  const relative = formatRecencyRelative(d, fallback);
+  const absoluteEn = formatAbsoluteEnGb(d);
+  const freshness = reportedTimeFreshness(d, freshnessOpts);
 
   const staleClasses =
-    freshness === 'stale24h'
+    variant === 'stale' && freshness === 'stale24h'
       ? 'border border-yellow-500/70 bg-yellow-500/10 text-yellow-900 dark:border-yellow-500/60 dark:bg-yellow-500/15 dark:text-yellow-100'
-      : freshness === 'stale7d'
+      : variant === 'stale' && freshness === 'stale7d'
         ? 'border border-red-500/70 bg-red-500/10 text-red-900 dark:border-red-500/60 dark:bg-red-500/15 dark:text-red-100'
         : null;
+
+  const title =
+    titleOverride ??
+    (showDateTime && showFriendly
+      ? absoluteEn
+      : showDateTime && !showFriendly
+        ? formatRecencyRelative(d, fallback)
+        : format(d, 'PPpp', { locale: enGB }));
+
+  const inner = (
+    <>
+      {showFriendly ? relative : null}
+      {showFriendly && showDateTime ? <span className="text-muted-foreground font-normal"> ({absoluteEn})</span> : null}
+      {!showFriendly && showDateTime ? absoluteEn : null}
+    </>
+  );
+
+  if (!showFriendly && !showDateTime) {
+    return (
+      <time dateTime={d.toISOString()} title={title} className={className}>
+        {absoluteEn}
+      </time>
+    );
+  }
 
   return (
     <time
@@ -40,7 +95,7 @@ export function StaleReportedTime({ at, fallback = '—', className }: StaleRepo
       title={title}
       className={cn(staleClasses && 'inline-block rounded px-1.5 py-0.5', staleClasses, className)}
     >
-      {relative}
+      {inner}
     </time>
   );
 }

--- a/src/components/nodes/WatchedNodesTable.tsx
+++ b/src/components/nodes/WatchedNodesTable.tsx
@@ -1,5 +1,7 @@
 import type { ReactNode } from 'react';
-import { format, formatDistanceToNow } from 'date-fns';
+import { format } from 'date-fns';
+import { enGB } from 'date-fns/locale';
+import { StaleReportedTime } from '@/components/nodes/StaleReportedTime';
 import { Link } from 'react-router-dom';
 import { useQuery, type UseQueryResult } from '@tanstack/react-query';
 import type { AutoTraceRoute, NodeWatch, ObservedNode, PaginatedResponse } from '@/lib/models';
@@ -19,7 +21,7 @@ function toDate(value: Date | string | null | undefined): Date | null {
   return Number.isNaN(d.getTime()) ? null : d;
 }
 
-/** Primary: relative (e.g. "1 hour ago"). Secondary: absolute timestamp. */
+/** Primary: relative with staleness. Secondary: absolute UK-style timestamp. */
 function FriendlyThenAbsolute({ value }: { value: Date | string | null | undefined }) {
   const d = toDate(value);
   if (!d) {
@@ -27,8 +29,8 @@ function FriendlyThenAbsolute({ value }: { value: Date | string | null | undefin
   }
   return (
     <div>
-      <div className="text-sm">{formatDistanceToNow(d, { addSuffix: true })}</div>
-      <div className="text-xs text-muted-foreground tabular-nums mt-0.5">{format(d, 'PPpp')}</div>
+      <StaleReportedTime at={d} className="text-sm" />
+      <div className="text-xs text-muted-foreground tabular-nums mt-0.5">{format(d, 'PPpp', { locale: enGB })}</div>
     </div>
   );
 }

--- a/src/components/nodes/WeatherNodeCard.tsx
+++ b/src/components/nodes/WeatherNodeCard.tsx
@@ -1,6 +1,6 @@
 import { Link } from 'react-router-dom';
-import { formatDistanceToNow } from 'date-fns';
 import { EnvironmentMetrics, ObservedNode } from '@/lib/models';
+import { StaleReportedTime } from '@/components/nodes/StaleReportedTime';
 import { EnvironmentMetricsMiniChart } from './EnvironmentMetricsMiniChart';
 import { ChevronRight } from 'lucide-react';
 import { memo } from 'react';
@@ -25,7 +25,7 @@ function WeatherNodeCardInner({ node, metrics, dateRange }: WeatherNodeCardProps
         </div>
         <div className="flex flex-col items-end gap-1">
           <span className="text-sm text-slate-500 dark:text-slate-400">
-            {envReportedTime ? formatDistanceToNow(envReportedTime, { addSuffix: true }) : 'No env data'}
+            {envReportedTime ? <StaleReportedTime at={envReportedTime} className="text-inherit" /> : 'No env data'}
           </span>
         </div>
       </div>

--- a/src/components/nodes/WeatherNodesMap.tsx
+++ b/src/components/nodes/WeatherNodesMap.tsx
@@ -70,6 +70,7 @@ export function WeatherNodesMap({ nodes, cutoffHours = MAP_CUTOFF_HOURS, tempera
       drawBoundingBox={false}
       drawPositionUncertainty={false}
       enableBubbles={true}
+      showMapLegend={false}
       getMarkerLabel={getMarkerLabel}
       getMarkerColor={getMarkerColor}
       getMarkerBorderColor={getMarkerBorderColor}

--- a/src/components/nodes/map-constellation-colors.test.ts
+++ b/src/components/nodes/map-constellation-colors.test.ts
@@ -1,0 +1,61 @@
+import { describe, it, expect } from 'vitest';
+import * as d3 from 'd3';
+import { computeManagedConstellationGroups, constellationLegendItems } from './map-constellation-colors';
+import type { ManagedNode } from '@/lib/models';
+
+function makeManaged(
+  nodeId: number,
+  constellation: { id: number; name?: string; map_color?: string }
+): ManagedNode {
+  return {
+    node_id: nodeId,
+    long_name: null,
+    short_name: 'S',
+    last_heard: null,
+    node_id_str: `!${nodeId.toString(16)}`,
+    owner: { id: 1, username: 'u' },
+    constellation,
+    position: { latitude: 1, longitude: 1 },
+  } as ManagedNode;
+}
+
+describe('computeManagedConstellationGroups', () => {
+  it('assigns d3 fallback colours in first-seen id string order (matches previous map behaviour)', () => {
+    const nodes: ManagedNode[] = [
+      makeManaged(1, { id: 20, name: 'B', map_color: '' }),
+      makeManaged(2, { id: 10, name: 'A', map_color: '' }),
+    ];
+    const groups = computeManagedConstellationGroups(nodes, null);
+    const ids = Object.keys(groups).sort((a, b) => +a - +b);
+    expect(ids).toEqual(['10', '20']);
+    // `Object.keys` uses ascending numeric key order when assigning fallback colours.
+    expect(groups[10].color).toBe(d3.schemeCategory10[0]);
+    expect(groups[20].color).toBe(d3.schemeCategory10[1]);
+  });
+
+  it('keeps explicit map_color from API', () => {
+    const nodes: ManagedNode[] = [makeManaged(1, { id: 1, name: 'X', map_color: '#abcdef' })];
+    const groups = computeManagedConstellationGroups(nodes, null);
+    expect(groups[1].color).toBe('#abcdef');
+  });
+
+  it('filters by constellation ids when provided', () => {
+    const nodes: ManagedNode[] = [
+      makeManaged(1, { id: 1, name: 'Keep' }),
+      makeManaged(2, { id: 2, name: 'Drop' }),
+    ];
+    const groups = computeManagedConstellationGroups(nodes, [1]);
+    expect(Object.keys(groups)).toEqual(['1']);
+  });
+});
+
+describe('constellationLegendItems', () => {
+  it('sorts by constellation id', () => {
+    const groups = computeManagedConstellationGroups(
+      [makeManaged(1, { id: 5, name: 'E' }), makeManaged(2, { id: 2, name: 'B' })],
+      null
+    );
+    const items = constellationLegendItems(groups);
+    expect(items.map((i) => i.id)).toEqual([2, 5]);
+  });
+});

--- a/src/components/nodes/map-constellation-colors.ts
+++ b/src/components/nodes/map-constellation-colors.ts
@@ -1,0 +1,53 @@
+import * as d3 from 'd3';
+import type { ManagedNode } from '@/lib/models';
+
+export type ConstellationMapGroup = {
+  name: string;
+  color: string;
+  nodes: ManagedNode[];
+};
+
+/**
+ * Same constellation grouping and colours as the mesh map: `map_color` when set, else `d3.schemeCategory10` by first-seen index.
+ */
+export function computeManagedConstellationGroups(
+  managedNodes: ManagedNode[],
+  filterConstellationIds: number[] | null | undefined
+): Record<number, ConstellationMapGroup> {
+  const filteredManaged =
+    filterConstellationIds != null && filterConstellationIds.length > 0
+      ? managedNodes.filter((n) => n.constellation && filterConstellationIds.includes(n.constellation.id))
+      : managedNodes;
+
+  const constellations: Record<number, ConstellationMapGroup> = {};
+  filteredManaged.forEach((node) => {
+    if (node.constellation) {
+      const id = node.constellation.id;
+      if (!constellations[id]) {
+        constellations[id] = {
+          name: node.constellation.name || 'Unknown',
+          color: node.constellation.map_color || '',
+          nodes: [],
+        };
+      }
+      constellations[id].nodes.push(node);
+    }
+  });
+
+  const constellationIds = Object.keys(constellations);
+  constellationIds.forEach((id, idx) => {
+    if (!constellations[+id].color) {
+      constellations[+id].color = d3.schemeCategory10[idx % d3.schemeCategory10.length];
+    }
+  });
+
+  return constellations;
+}
+
+export function constellationLegendItems(
+  groups: Record<number, ConstellationMapGroup>
+): Array<{ id: number; name: string; color: string }> {
+  return Object.entries(groups)
+    .map(([id, g]) => ({ id: +id, name: g.name, color: g.color }))
+    .sort((a, b) => a.id - b.id);
+}

--- a/src/components/nodes/map-role-legend.ts
+++ b/src/components/nodes/map-role-legend.ts
@@ -1,0 +1,20 @@
+import { ROLE_COLORS } from './map-utils';
+import { ROLE_LABELS } from '@/lib/meshtastic';
+
+const UNKNOWN_COLOR = '#64748b';
+
+export type RoleLegendSwatch = { key: string; label: string; color: string };
+
+/** Swatches matching `getRoleColor` / map marker role semantics. */
+export function meshRoleLegendSwatches(): RoleLegendSwatch[] {
+  const sw: RoleLegendSwatch[] = (Object.keys(ROLE_COLORS) as string[]).map((k) => {
+    const id = Number(k);
+    return {
+      key: `role-${id}`,
+      label: ROLE_LABELS[id] ?? `Role ${id}`,
+      color: ROLE_COLORS[id as keyof typeof ROLE_COLORS],
+    };
+  });
+  sw.push({ key: 'role-unknown', label: 'Unknown / other', color: UNKNOWN_COLOR });
+  return sw;
+}

--- a/src/lib/my-nodes-grouping.ts
+++ b/src/lib/my-nodes-grouping.ts
@@ -1,6 +1,5 @@
-import { formatDistanceToNow } from 'date-fns';
-
 import { MANAGED_NODE_ONLINE_MAX_AGE_SECONDS } from '@/lib/managed-node-status';
+import { formatRecencyRelative } from '@/lib/reported-time-format';
 import type { ManagedNode, ObservedNode, Position } from '@/lib/models';
 
 /** Claimed-node “online”: same window as dashboard “2h” and the Meshtastic bot’s online threshold. */
@@ -83,7 +82,7 @@ function isFresh(at: Date | string | null | undefined, maxAgeMs: number, now: Da
 function agePhrase(at: Date | string | null | undefined): string {
   const d = parseDate(at);
   if (!d) return 'never';
-  return formatDistanceToNow(d, { addSuffix: true });
+  return formatRecencyRelative(d, 'never');
 }
 
 /** Mesh-side activity: prefer `radio_last_heard`, else `last_heard`. */
@@ -180,18 +179,18 @@ export function getPositionHint(node: ObservedNode, now: Date = new Date()): Pos
   if (ageMs < 0) {
     return {
       label: 'GPS position recent',
-      tooltip: `Reported ${formatDistanceToNow(reported, { addSuffix: true })}`,
+      tooltip: `Reported ${formatRecencyRelative(reported)}`,
     };
   }
   if (ageMs <= POSITION_STALE_MS) {
     return {
       label: 'GPS position recent',
-      tooltip: `Reported ${formatDistanceToNow(reported, { addSuffix: true })}`,
+      tooltip: `Reported ${formatRecencyRelative(reported)}`,
     };
   }
   return {
     label: 'GPS position stale (>7d)',
-    tooltip: `Reported ${formatDistanceToNow(reported, { addSuffix: true })}`,
+    tooltip: `Reported ${formatRecencyRelative(reported)}`,
   };
 }
 

--- a/src/lib/reported-time-format.test.ts
+++ b/src/lib/reported-time-format.test.ts
@@ -1,0 +1,28 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { formatRecencyRelative } from './reported-time-format';
+
+describe('formatRecencyRelative', () => {
+  beforeEach(() => {
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date('2026-06-15T12:00:00.000Z'));
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  it('returns fallback for null/undefined', () => {
+    expect(formatRecencyRelative(null)).toBe('—');
+    expect(formatRecencyRelative(undefined, 'Never')).toBe('Never');
+  });
+
+  it('returns fallback for invalid', () => {
+    expect(formatRecencyRelative('bad')).toBe('—');
+  });
+
+  it('formats valid dates with suffix', () => {
+    const s = formatRecencyRelative(new Date('2026-06-15T11:00:00.000Z'));
+    expect(s.length).toBeGreaterThan(0);
+    expect(s).toMatch(/ago|in /);
+  });
+});

--- a/src/lib/reported-time-format.ts
+++ b/src/lib/reported-time-format.ts
@@ -1,0 +1,9 @@
+import { formatDistanceToNow } from 'date-fns';
+
+/** Relative "x ago" for tooltips and non-React callers; mirrors StaleReportedTime friendly text. */
+export function formatRecencyRelative(at: Date | string | number | null | undefined, fallback = '—'): string {
+  if (at == null) return fallback;
+  const d = at instanceof Date ? at : new Date(at);
+  if (Number.isNaN(d.getTime())) return fallback;
+  return formatDistanceToNow(d, { addSuffix: true });
+}

--- a/src/lib/reported-time-stale.test.ts
+++ b/src/lib/reported-time-stale.test.ts
@@ -11,20 +11,33 @@ describe('reportedTimeFreshness', () => {
     vi.useRealTimers();
   });
 
-  it('returns fresh within 24h', () => {
+  it('returns fresh when younger than warning threshold (inclusive boundary)', () => {
     expect(reportedTimeFreshness(new Date('2026-06-15T10:00:00.000Z'))).toBe('fresh');
-    expect(reportedTimeFreshness(new Date('2026-06-14T12:00:00.000Z'))).toBe('fresh');
+    // Just under 24h old
+    expect(reportedTimeFreshness(new Date('2026-06-14T12:00:00.001Z'))).toBe('fresh');
   });
 
-  it('returns stale24h strictly after 24h and within 7d', () => {
+  it('returns stale24h at exactly 24h and before danger threshold', () => {
+    expect(reportedTimeFreshness(new Date('2026-06-14T12:00:00.000Z'))).toBe('stale24h');
     expect(reportedTimeFreshness(new Date('2026-06-14T11:59:59.000Z'))).toBe('stale24h');
     expect(reportedTimeFreshness(new Date('2026-06-10T12:00:00.000Z'))).toBe('stale24h');
+    // Just under 7d old (still warning, not danger)
+    expect(reportedTimeFreshness(new Date('2026-06-08T12:00:00.001Z'))).toBe('stale24h');
   });
 
-  it('returns stale7d strictly after 7 days', () => {
-    expect(reportedTimeFreshness(new Date('2026-06-08T12:00:00.000Z'))).toBe('stale24h');
-    expect(reportedTimeFreshness(new Date('2026-06-08T11:59:59.999Z'))).toBe('stale7d');
+  it('returns stale7d at exactly danger threshold and older', () => {
+    expect(reportedTimeFreshness(new Date('2026-06-08T12:00:00.000Z'))).toBe('stale7d');
     expect(reportedTimeFreshness(new Date('2025-01-01T00:00:00.000Z'))).toBe('stale7d');
+  });
+
+  it('respects custom hour thresholds', () => {
+    const opts = { warningAfterHours: 1, dangerAfterHours: 48 };
+    // 30m ago → fresh
+    expect(reportedTimeFreshness(new Date('2026-06-15T11:30:00.000Z'), opts)).toBe('fresh');
+    // 2h ago → stale24h (warning)
+    expect(reportedTimeFreshness(new Date('2026-06-15T10:00:00.000Z'), opts)).toBe('stale24h');
+    // 3d ago → stale7d
+    expect(reportedTimeFreshness(new Date('2026-06-12T12:00:00.000Z'), opts)).toBe('stale7d');
   });
 
   it('returns null for invalid date', () => {

--- a/src/lib/reported-time-stale.ts
+++ b/src/lib/reported-time-stale.ts
@@ -1,14 +1,54 @@
-const DAY_MS = 86_400_000;
+const HOUR_MS = 60 * 60 * 1000;
 
 export type ReportedTimeFreshness = 'fresh' | 'stale24h' | 'stale7d';
 
-/** Stale if strictly over 24h (yellow) or over 7 days (red). */
-export function reportedTimeFreshness(at: Date | string | number): ReportedTimeFreshness | null {
+export type ReportedTimeFreshnessOptions = {
+  /** Age at or past this many hours → warning (yellow). Default 24. */
+  warningAfterHours?: number;
+  /** Age at or past this many hours → danger (red). Must be greater than warning; default 168 (7d). */
+  dangerAfterHours?: number;
+};
+
+const DEFAULT_WARNING_HOURS = 24;
+const DEFAULT_DANGER_HOURS = 168;
+
+function normalizeThresholdHours(warningH: number, dangerH: number): { warningH: number; dangerH: number } {
+  const w = Number.isFinite(warningH) && warningH > 0 ? warningH : DEFAULT_WARNING_HOURS;
+  let d = Number.isFinite(dangerH) && dangerH > 0 ? dangerH : DEFAULT_DANGER_HOURS;
+  if (d <= w) {
+    if (import.meta.env.DEV) {
+      console.warn(
+        `[reportedTimeFreshness] dangerAfterHours (${dangerH}) must be > warningAfterHours (${warningH}); using ${w + 1}`
+      );
+    }
+    d = w + 1;
+  }
+  return { warningH: w, dangerH: d };
+}
+
+/**
+ * Mesh "report recency" bands for UI emphasis.
+ *
+ * Uses **inclusive** age thresholds: at exactly `warningAfterHours` old, returns `stale24h`;
+ * at exactly `dangerAfterHours`, returns `stale7d` (danger wins over warning).
+ */
+export function reportedTimeFreshness(
+  at: Date | string | number,
+  options?: ReportedTimeFreshnessOptions
+): ReportedTimeFreshness | null {
   const d = at instanceof Date ? at : new Date(at);
   if (Number.isNaN(d.getTime())) return null;
+
+  const { warningH, dangerH } = normalizeThresholdHours(
+    options?.warningAfterHours ?? DEFAULT_WARNING_HOURS,
+    options?.dangerAfterHours ?? DEFAULT_DANGER_HOURS
+  );
+  const warningMs = warningH * HOUR_MS;
+  const dangerMs = dangerH * HOUR_MS;
+
   const ageMs = Date.now() - d.getTime();
   if (ageMs <= 0) return 'fresh';
-  if (ageMs > 7 * DAY_MS) return 'stale7d';
-  if (ageMs > DAY_MS) return 'stale24h';
+  if (ageMs >= dangerMs) return 'stale7d';
+  if (ageMs >= warningMs) return 'stale24h';
   return 'fresh';
 }

--- a/src/pages/nodes/ClaimNode.tsx
+++ b/src/pages/nodes/ClaimNode.tsx
@@ -7,8 +7,8 @@ import { Card, CardHeader, CardTitle, CardContent, CardDescription, CardFooter }
 import { Button } from '@/components/ui/button';
 import { Alert, AlertDescription, AlertTitle } from '@/components/ui/alert';
 import { Loader2, AlertCircle, CheckCircle2 } from 'lucide-react';
-import { formatDistanceToNow } from 'date-fns';
 import { NodeClaim } from '@/lib/models';
+import { StaleReportedTime } from '@/components/nodes/StaleReportedTime';
 
 export function ClaimNode() {
   const { id } = useParams<{ id: string }>();
@@ -157,7 +157,7 @@ export function ClaimNode() {
             <p className="mb-4">
               Last Heard:{' '}
               <span className="font-medium">
-                {node.last_heard ? formatDistanceToNow(node.last_heard, { addSuffix: true }) : 'Never'}
+                <StaleReportedTime at={node.last_heard ?? null} fallback="Never" className="font-medium" />
               </span>
             </p>
           </CardContent>

--- a/src/pages/nodes/ManagedNodesStatus.tsx
+++ b/src/pages/nodes/ManagedNodesStatus.tsx
@@ -1,6 +1,8 @@
 import { Suspense, useMemo, useState } from 'react';
 import { Link, useSearchParams } from 'react-router-dom';
-import { format, formatDistanceToNow } from 'date-fns';
+import { format } from 'date-fns';
+import { enGB } from 'date-fns/locale';
+import { StaleReportedTime } from '@/components/nodes/StaleReportedTime';
 import { ChevronDown, Loader2 } from 'lucide-react';
 
 import { NodesAndConstellationsMap } from '@/components/nodes/NodesAndConstellationsMap';
@@ -74,8 +76,8 @@ function renderTimestampCell(value: Date | string | null | undefined) {
   const date = new Date(value);
   return (
     <div className="flex flex-col">
-      <span>{format(date, 'PPpp')}</span>
-      <span className="text-xs text-muted-foreground">{formatDistanceToNow(date, { addSuffix: true })}</span>
+      <span>{format(date, 'PPpp', { locale: enGB })}</span>
+      <StaleReportedTime at={date} className="text-xs text-muted-foreground" />
     </div>
   );
 }

--- a/src/pages/nodes/MeshInfrastructure.tsx
+++ b/src/pages/nodes/MeshInfrastructure.tsx
@@ -1,6 +1,8 @@
 import { useMemo, useState, useCallback, Suspense } from 'react';
 import { Link } from 'react-router-dom';
-import { subDays, subHours, format, formatDistanceToNow } from 'date-fns';
+import { subDays, subHours, format } from 'date-fns';
+import { enGB } from 'date-fns/locale';
+import { StaleReportedTime } from '@/components/nodes/StaleReportedTime';
 import { useInfrastructureNodesSuspense, useManagedNodesSuspense } from '@/hooks/api/useNodes';
 import { useNodeWatches } from '@/hooks/api/useNodeWatches';
 import { useMultiNodeMetricsSuspense } from '@/hooks/api/useMultiNodeMetrics';
@@ -269,17 +271,14 @@ function MeshInfrastructureContent() {
                               <span>
                                 {format(
                                   node.last_heard instanceof Date ? node.last_heard : new Date(node.last_heard),
-                                  'PPpp'
+                                  'PPpp',
+                                  { locale: enGB }
                                 )}
                               </span>
-                              <span className="text-xs text-muted-foreground">
-                                {formatDistanceToNow(
-                                  node.last_heard instanceof Date ? node.last_heard : new Date(node.last_heard),
-                                  {
-                                    addSuffix: true,
-                                  }
-                                )}
-                              </span>
+                              <StaleReportedTime
+                                at={node.last_heard instanceof Date ? node.last_heard : new Date(node.last_heard)}
+                                className="text-xs text-muted-foreground"
+                              />
                             </>
                           ) : (
                             'Never'
@@ -290,10 +289,8 @@ function MeshInfrastructureContent() {
                         <div className="flex flex-col">
                           {lastLocation ? (
                             <>
-                              <span>{format(lastLocation, 'PPpp')}</span>
-                              <span className="text-xs text-muted-foreground">
-                                {formatDistanceToNow(lastLocation, { addSuffix: true })}
-                              </span>
+                              <span>{format(lastLocation, 'PPpp', { locale: enGB })}</span>
+                              <StaleReportedTime at={lastLocation} className="text-xs text-muted-foreground" />
                             </>
                           ) : (
                             'Never'

--- a/src/pages/nodes/NodesList.tsx
+++ b/src/pages/nodes/NodesList.tsx
@@ -10,8 +10,8 @@ import { Search } from 'lucide-react';
 import { Card, CardHeader, CardTitle, CardContent } from '@/components/ui/card';
 import { Button } from '@/components/ui/button';
 import { ObservedNode } from '@/lib/models';
-import { formatDistanceToNow } from 'date-fns';
 import { Link } from 'react-router-dom';
+import { StaleReportedTime } from '@/components/nodes/StaleReportedTime';
 
 type TimeRangeOption = '2h' | '24h' | '7d' | '30d' | 'all';
 type SortOption = 'last_heard' | 'name';
@@ -49,7 +49,7 @@ function RecentNodeChip({ node }: { node: ObservedNode }) {
     >
       <span className="font-medium text-sm truncate max-w-[120px]">{node.short_name}</span>
       <span className="text-xs text-muted-foreground">
-        {node.last_heard ? formatDistanceToNow(node.last_heard, { addSuffix: true }) : 'Never'}
+        <StaleReportedTime at={node.last_heard ?? null} fallback="Never" className="text-inherit" />
       </span>
     </Link>
   );

--- a/src/pages/user/NodeSettings.tsx
+++ b/src/pages/user/NodeSettings.tsx
@@ -4,8 +4,8 @@ import { Card, CardContent, CardHeader, CardTitle, CardDescription } from '@/com
 import { useCancelNodeClaim, useUserClaims } from '@/hooks/api/useNodeClaims';
 import { useConstellationChannels } from '@/hooks/api/useConstellations';
 import { useMyManagedNodesSuspense, useMyClaimedNodesSuspense } from '@/hooks/api/useNodes';
-import { formatDistanceToNow } from 'date-fns';
 import { Badge } from '@/components/ui/badge';
+import { StaleReportedTime } from '@/components/nodes/StaleReportedTime';
 import { Loader2, AlertCircle, Info, Copy, Radio, HelpCircle, ChevronDown, KeyRound } from 'lucide-react';
 import { useConfig } from '@/providers/ConfigProvider';
 import { BotSetupInstructions } from '@/components/nodes/BotSetupInstructions';
@@ -116,10 +116,7 @@ function NodeSettingsContent() {
                           <p className="text-sm text-slate-500 dark:text-slate-400">{node.long_name}</p>
                           <p className="text-xs text-slate-400">Node ID: {node.node_id_str}</p>
                           <p className="text-sm text-slate-500 dark:text-slate-400 mt-1">
-                            Last heard:{' '}
-                            {node.last_heard
-                              ? formatDistanceToNow(new Date(node.last_heard), { addSuffix: true })
-                              : 'Never'}
+                            Last heard: <StaleReportedTime at={node.last_heard ?? null} fallback="Never" />
                           </p>
                         </div>
                       </div>
@@ -181,7 +178,7 @@ function NodeSettingsContent() {
                               <p className="text-sm text-slate-500 dark:text-slate-400">{claim.node.long_name}</p>
                               <p className="text-xs text-slate-400">Node ID: {claim.node.node_id_str}</p>
                               <p className="text-sm text-slate-500 dark:text-slate-400 mt-1">
-                                Claimed {formatDistanceToNow(new Date(claim.created_at), { addSuffix: true })}
+                                Claimed <StaleReportedTime at={claim.created_at} variant="neutral" className="inline" />
                               </p>
                             </div>
                             <Button
@@ -269,10 +266,7 @@ function NodeSettingsContent() {
                                   {node.constellation.name}
                                 </Badge>
                                 <span className="text-xs text-slate-500 dark:text-slate-400">
-                                  Last heard:{' '}
-                                  {node.last_heard
-                                    ? formatDistanceToNow(new Date(node.last_heard), { addSuffix: true })
-                                    : 'Never'}
+                                  Last heard: <StaleReportedTime at={node.last_heard ?? null} fallback="Never" />
                                 </span>
                                 {nodeApiKeys.length > 0 && (
                                   <span className="text-xs text-slate-500 dark:text-slate-400">


### PR DESCRIPTION
# Summary

Closes #201  
Closes #203

- **Map legend**: Overlay on `NodesAndConstellationsMap` and `NodesMap` using shared constellation colour assignment (`map-constellation-colors.ts`) and role swatches from `ROLE_COLORS` / `ROLE_LABELS`. Legend defaults off when custom marker colours are used; `WeatherNodesMap` passes `showMapLegend={false}`.
- **Recency display**: `reportedTimeFreshness` supports optional hour thresholds with **inclusive** age bands (warning at ≥24h, danger at ≥7d, danger wins). `StaleReportedTime` adds `showDateTime` (en-GB inline), `variant` (`neutral` vs stale chrome), optional `title`, and configurable thresholds. `formatRecencyRelative` aligns non-React tooltips in `my-nodes-grouping`. Listed node/message surfaces migrated per #203 (neutral for message sent time and claim created).

**UX note**: Exactly 24h and exactly 7d old timestamps now enter warning/danger styling (previously strict `>`).

## Testing performed

- `npm run format`
- `npm test` (Vitest)
- `npm run build`
- `npm run lint` (warnings only, pre-existing)
