### PR TITLE
feat(watches): mesh watches status dashboard (#211)

### DIFF
--- a/src/components/nodes/MapMarkerLegend.tsx
+++ b/src/components/nodes/MapMarkerLegend.tsx
@@ -11,6 +11,9 @@ export interface MapMarkerLegendProps {
   roleSwatches: RoleLegendSwatch[];
   constellationTitle?: string;
   roleSectionTitle?: string;
+  /** Optional first column (e.g. mesh watch monitoring status colours). */
+  statusSwatches?: RoleLegendSwatch[];
+  statusSectionTitle?: string;
 }
 
 function SwatchRow({ label, color }: { label: string; color: string }) {
@@ -33,9 +36,12 @@ export function MapMarkerLegend({
   roleSwatches,
   constellationTitle = 'Monitoring (constellation)',
   roleSectionTitle = 'Other mesh nodes (by role)',
+  statusSwatches,
+  statusSectionTitle = 'Watch status',
 }: MapMarkerLegendProps) {
   const hasConstellation = constellationItems.length > 0;
-  if (!hasConstellation && !showRoleSwatches) return null;
+  const hasStatus = Boolean(statusSwatches?.length);
+  if (!hasConstellation && !showRoleSwatches && !hasStatus) return null;
 
   return (
     <div
@@ -59,8 +65,30 @@ export function MapMarkerLegend({
             </div>
           </div>
         ) : null}
+        {hasStatus ? (
+          <div
+            className={cn(
+              'min-w-0 flex-1 space-y-1',
+              hasConstellation && 'border-t border-border/60 pt-2 sm:border-t-0 sm:pt-0 sm:border-l sm:pl-3'
+            )}
+          >
+            <div className="font-medium text-[0.7rem] uppercase tracking-wide text-muted-foreground">
+              {statusSectionTitle}
+            </div>
+            <div className="flex flex-wrap gap-x-3 gap-y-1">
+              {statusSwatches!.map((s) => (
+                <SwatchRow key={s.key} label={s.label} color={s.color} />
+              ))}
+            </div>
+          </div>
+        ) : null}
         {showRoleSwatches ? (
-          <div className="min-w-0 flex-1 space-y-1 border-t border-border/60 pt-2 sm:border-t-0 sm:pt-0 sm:border-l sm:pl-3 sm:pt-0">
+          <div
+            className={cn(
+              'min-w-0 flex-1 space-y-1 border-t border-border/60 pt-2 sm:border-t-0 sm:pt-0 sm:border-l sm:pl-3 sm:pt-0',
+              (hasConstellation || hasStatus) && 'sm:pt-0'
+            )}
+          >
             <div className="font-medium text-[0.7rem] uppercase tracking-wide text-muted-foreground">
               {roleSectionTitle}
             </div>

--- a/src/components/nodes/NodesMap.test.tsx
+++ b/src/components/nodes/NodesMap.test.tsx
@@ -1,7 +1,8 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest';
-import { render, waitFor } from '@testing-library/react';
+import { render, screen, waitFor } from '@testing-library/react';
 import type { ObservedNode } from '@/lib/models';
 import { NodesMap } from './NodesMap';
+import { watchMonitoringStatusLegendSwatches } from '@/lib/watch-monitoring-status';
 
 vi.mock('@/hooks/useMapTileUrl', () => ({
   useMapTileUrl: () => ({
@@ -99,5 +100,20 @@ describe('NodesMap', () => {
       />
     );
     await waitFor(() => expect(mapMocks.fitBounds).toHaveBeenCalled());
+  });
+
+  it('shows watch status legend instead of node role when status colours are provided', () => {
+    render(
+      <NodesMap
+        nodes={[nodeWithPosition(1, 55.1, -4.2)]}
+        markerColorsByNodeId={new Map([[1, '#dc2626']])}
+        mapLegendStatusSwatches={watchMonitoringStatusLegendSwatches()}
+        mapLegendStatusTitle="Watch status"
+      />
+    );
+    const legend = screen.getByRole('region', { name: /Map marker colours/i });
+    expect(legend).toHaveTextContent('Watch status');
+    expect(legend).toHaveTextContent('Offline');
+    expect(screen.queryByText('Node role')).not.toBeInTheDocument();
   });
 });

--- a/src/components/nodes/NodesMap.tsx
+++ b/src/components/nodes/NodesMap.tsx
@@ -6,23 +6,46 @@ import { useMapTileUrl } from '@/hooks/useMapTileUrl';
 import { createNodeIcon, getRoleColor, buildNodePopupHtml } from './map-utils';
 import { MapMarkerLegend } from './MapMarkerLegend';
 import { meshRoleLegendSwatches } from './map-role-legend';
+import type { RoleLegendSwatch } from './map-role-legend';
 
 interface NodesMapProps {
   nodes: ObservedNode[];
   /** Default true: role-colour key for marker pins. */
   showMapLegend?: boolean;
+  /** When set, marker pins use these colours by `node_id` instead of Meshtastic role. */
+  markerColorsByNodeId?: ReadonlyMap<number, string> | Record<number, string>;
+  /** Legend rows when using `markerColorsByNodeId` (e.g. watch monitoring status). */
+  mapLegendStatusSwatches?: RoleLegendSwatch[];
+  mapLegendStatusTitle?: string;
 }
 
 // Default center only used if no nodes are present
 const DEFAULT_CENTER: L.LatLngExpression = [55.8642, -4.2518];
 
-export function NodesMap({ nodes, showMapLegend = true }: NodesMapProps) {
+function colorMapFromProp(
+  markerColorsByNodeId: ReadonlyMap<number, string> | Record<number, string> | undefined
+): ReadonlyMap<number, string> | null {
+  if (!markerColorsByNodeId) return null;
+  return markerColorsByNodeId instanceof Map
+    ? markerColorsByNodeId
+    : new Map(Object.entries(markerColorsByNodeId).map(([k, v]) => [Number(k), v]));
+}
+
+export function NodesMap({
+  nodes,
+  showMapLegend = true,
+  markerColorsByNodeId,
+  mapLegendStatusSwatches,
+  mapLegendStatusTitle,
+}: NodesMapProps) {
   const mapRef = useRef<HTMLDivElement>(null);
   const mapInstanceRef = useRef<L.Map | null>(null);
   const tileLayerRef = useRef<L.TileLayer | null>(null);
   const markersRef = useRef<L.Marker[]>([]);
   const { url: tileUrl, attribution } = useMapTileUrl();
   const roleSwatches = useMemo(() => meshRoleLegendSwatches(), []);
+  const colorByNodeId = useMemo(() => colorMapFromProp(markerColorsByNodeId), [markerColorsByNodeId]);
+  const useStatusLegend = Boolean(colorByNodeId?.size && mapLegendStatusSwatches?.length);
 
   // Initialize the map
   useEffect(() => {
@@ -146,8 +169,10 @@ export function NodesMap({ nodes, showMapLegend = true }: NodesMapProps) {
     nodesWithPosition.forEach((node) => {
       const position: L.LatLngExpression = [node.latest_position!.latitude!, node.latest_position!.longitude!];
 
+      const pinColor = colorByNodeId?.get(node.node_id) ?? getRoleColor(node.role);
+
       const marker = L.marker(position, {
-        icon: createNodeIcon(node.short_name || node.node_id_str.toString(), getRoleColor(node.role), false),
+        icon: createNodeIcon(node.short_name || node.node_id_str.toString(), pinColor, false),
       })
         .bindPopup(buildNodePopupHtml(node))
         .addTo(map);
@@ -165,16 +190,18 @@ export function NodesMap({ nodes, showMapLegend = true }: NodesMapProps) {
         maxZoom: 15,
       });
     }
-  }, [nodes]);
+  }, [nodes, colorByNodeId]);
 
   return (
     <div className="relative h-full w-full min-h-[400px]">
       {showMapLegend ? (
         <MapMarkerLegend
           constellationItems={[]}
-          showRoleSwatches
+          showRoleSwatches={!useStatusLegend}
           roleSwatches={roleSwatches}
           roleSectionTitle="Node role"
+          statusSwatches={useStatusLegend ? mapLegendStatusSwatches : undefined}
+          statusSectionTitle={mapLegendStatusTitle}
         />
       ) : null}
       <div

--- a/src/components/nodes/WatchDashboardSummary.test.tsx
+++ b/src/components/nodes/WatchDashboardSummary.test.tsx
@@ -1,0 +1,51 @@
+import { describe, it, expect, vi } from 'vitest';
+import { render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import type { NodeWatch, ObservedNode } from '@/lib/models';
+import { WatchDashboardSummary } from './WatchDashboardSummary';
+import { countWatchesByMonitoringStatus } from '@/lib/watch-monitoring-status';
+
+function makeNode(overrides: Partial<ObservedNode> = {}): ObservedNode {
+  return {
+    internal_id: 1,
+    node_id: 50,
+    node_id_str: '!00000032',
+    mac_addr: null,
+    long_name: null,
+    short_name: 'JumpMe',
+    hw_model: null,
+    public_key: null,
+    last_heard: new Date('2026-04-21T12:00:00.000Z'),
+    latest_position: null,
+    ...overrides,
+  } as ObservedNode;
+}
+
+function makeWatch(id: number, node: Partial<ObservedNode>): NodeWatch {
+  return {
+    id,
+    observed_node: makeNode({ internal_id: id, node_id: 50 + id, ...node }) as NodeWatch['observed_node'],
+    offline_after: 3600,
+    enabled: true,
+    created_at: '2026-04-21T00:00:00Z',
+  };
+}
+
+describe('WatchDashboardSummary', () => {
+  it('calls onJumpToWatch with watch id when a jump row is clicked', async () => {
+    const user = userEvent.setup();
+    const onJump = vi.fn();
+    const watches = [
+      makeWatch(7, {
+        short_name: 'Alpha',
+        node_id_str: '!aaaaaaaa',
+        last_heard: new Date('2026-04-21T12:00:00.000Z'),
+      }),
+    ];
+    const counts = countWatchesByMonitoringStatus(watches);
+    render(<WatchDashboardSummary watches={watches} counts={counts} onJumpToWatch={onJump} />);
+
+    await user.click(screen.getByRole('button', { name: /Alpha/i }));
+    expect(onJump).toHaveBeenCalledWith(7);
+  });
+});

--- a/src/components/nodes/WatchDashboardSummary.tsx
+++ b/src/components/nodes/WatchDashboardSummary.tsx
@@ -1,0 +1,57 @@
+import { Button } from '@/components/ui/button';
+import { cn } from '@/lib/utils';
+import type { NodeWatch } from '@/lib/models';
+import {
+  deriveWatchMonitoringStatus,
+  WATCH_STATUS_LABEL,
+  type WatchMonitoringStatus,
+} from '@/lib/watch-monitoring-status';
+
+const SUMMARY_ORDER: WatchMonitoringStatus[] = ['offline', 'verifying', 'unknown', 'online'];
+
+export interface WatchDashboardSummaryProps {
+  watches: NodeWatch[];
+  counts: Record<WatchMonitoringStatus, number>;
+  onJumpToWatch: (watchId: number) => void;
+}
+
+export function WatchDashboardSummary({ watches, counts, onJumpToWatch }: WatchDashboardSummaryProps) {
+  return (
+    <div className="bg-background rounded-lg border p-4 space-y-4">
+      <div className="grid grid-cols-2 sm:grid-cols-4 gap-3">
+        {SUMMARY_ORDER.map((s) => (
+          <div key={s} className="rounded-md border bg-card/50 p-3 text-center">
+            <div className="text-2xl font-semibold tabular-nums">{counts[s]}</div>
+            <div className="text-xs text-muted-foreground">{WATCH_STATUS_LABEL[s]}</div>
+          </div>
+        ))}
+      </div>
+      <div>
+        <h2 className="text-sm font-medium mb-2">Jump to watch</h2>
+        <div className="grid grid-cols-1 sm:grid-cols-2 gap-2">
+          {watches.map((w) => {
+            const n = w.observed_node;
+            const st = deriveWatchMonitoringStatus(w);
+            return (
+              <Button
+                key={w.id}
+                type="button"
+                variant="outline"
+                className="h-auto min-h-11 justify-start text-left py-2 px-3"
+                onClick={() => onJumpToWatch(w.id)}
+              >
+                <span className="flex flex-col items-start gap-0.5 min-w-0">
+                  <span className="font-medium truncate w-full">{n.short_name || n.node_id_str}</span>
+                  <span className="text-xs text-muted-foreground font-mono">{n.node_id_str}</span>
+                  <span className={cn('text-xs', st === 'offline' && 'text-destructive font-medium')}>
+                    {WATCH_STATUS_LABEL[st]}
+                  </span>
+                </span>
+              </Button>
+            );
+          })}
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/src/components/nodes/WatchedNodesTable.test.tsx
+++ b/src/components/nodes/WatchedNodesTable.test.tsx
@@ -1,0 +1,229 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { render, screen, waitFor, within } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { MemoryRouter } from 'react-router-dom';
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import type { AutoTraceRoute, NodeWatch, ObservedNode, ObservedNodeWatchSummary } from '@/lib/models';
+import type { ComponentProps } from 'react';
+import { WatchedNodesTable } from './WatchedNodesTable';
+
+vi.mock('@/components/nodes/MeshWatchControls', () => ({
+  MeshWatchControls: () => <div data-testid="mesh-watch-controls" />,
+}));
+
+const getTraceroutes = vi.fn();
+
+vi.mock('@/hooks/api/useApi', () => ({
+  useMeshtasticApi: () => ({
+    getTraceroutes,
+  }),
+}));
+
+function makeObservedNode(overrides: Partial<ObservedNodeWatchSummary> = {}): ObservedNode {
+  return {
+    internal_id: 1,
+    node_id: 100,
+    node_id_str: '!00000064',
+    mac_addr: null,
+    long_name: 'Long',
+    short_name: 'SN100',
+    hw_model: null,
+    public_key: null,
+    last_heard: new Date('2026-04-21T12:00:00.000Z'),
+    latest_position: null,
+    ...overrides,
+  } as ObservedNode;
+}
+
+function makeWatch(overrides: Partial<NodeWatch> & { node?: Partial<ObservedNodeWatchSummary> } = {}): NodeWatch {
+  const { node: nodeOverrides, id: idOverride, ...rest } = overrides;
+  const id = idOverride ?? 1;
+  const node = makeObservedNode({
+    internal_id: id,
+    node_id: 100 + id,
+    short_name: `SN${id}`,
+    ...nodeOverrides,
+  });
+  return {
+    ...rest,
+    id,
+    observed_node: node as NodeWatch['observed_node'],
+    offline_after: rest.offline_after ?? 3600,
+    enabled: rest.enabled ?? true,
+    created_at: rest.created_at ?? '2026-04-21T00:00:00Z',
+  };
+}
+
+function renderTable(props: Partial<ComponentProps<typeof WatchedNodesTable>> & { watches?: NodeWatch[] } = {}) {
+  const client = new QueryClient({ defaultOptions: { queries: { retry: false } } });
+  const recentLastHeard = new Date(Date.now() - 15 * 60 * 1000);
+  const watches =
+    props.watches ??
+    ([
+      makeWatch({
+        id: 1,
+        node: {
+          node_id: 1,
+          internal_id: 10,
+          node_id_str: '!00000001',
+          short_name: 'OnlineN',
+          last_heard: recentLastHeard,
+          monitoring_offline_confirmed_at: null,
+          monitoring_verification_started_at: null,
+        },
+      }),
+      makeWatch({
+        id: 2,
+        node: {
+          node_id: 2,
+          internal_id: 20,
+          node_id_str: '!00000002',
+          short_name: 'OffN',
+          monitoring_offline_confirmed_at: '2026-04-21T11:00:00Z',
+          last_heard: new Date('2026-04-20T12:00:00.000Z'),
+        },
+      }),
+    ] as NodeWatch[]);
+  return render(
+    <QueryClientProvider client={client}>
+      <MemoryRouter>
+        <WatchedNodesTable
+          watches={watches}
+          watchesQuery={{ isLoading: false, isError: false }}
+          onOpenTraceroute={props.onOpenTraceroute ?? vi.fn()}
+          onRequestTriggerTraceroute={props.onRequestTriggerTraceroute ?? vi.fn()}
+          canTriggerTraceroute={props.canTriggerTraceroute ?? true}
+        />
+      </MemoryRouter>
+    </QueryClientProvider>
+  );
+}
+
+describe('WatchedNodesTable', () => {
+  beforeEach(() => {
+    getTraceroutes.mockResolvedValue({ results: [], count: 0, next: null, previous: null });
+  });
+
+  it('renders Offline section before Online section', () => {
+    renderTable();
+    const headings = screen.getAllByRole('heading', { level: 3 });
+    expect(headings[0]).toHaveTextContent(/^Offline/);
+    expect(headings.map((h) => h.textContent)).toEqual(
+      expect.arrayContaining([expect.stringMatching(/^Offline/), expect.stringMatching(/^Online/)])
+    );
+    const offlineIdx = headings.findIndex((h) => h.textContent?.startsWith('Offline'));
+    const onlineIdx = headings.findIndex((h) => h.textContent?.startsWith('Online'));
+    expect(offlineIdx).toBeLessThan(onlineIdx);
+  });
+
+  it('hides latest traceroutes table for online watches', () => {
+    const recent = new Date(Date.now() - 10 * 60 * 1000);
+    renderTable({
+      watches: [
+        makeWatch({
+          id: 1,
+          node: {
+            node_id: 1,
+            short_name: 'OnlyOnline',
+            last_heard: recent,
+            monitoring_offline_confirmed_at: null,
+            monitoring_verification_started_at: null,
+          },
+        }),
+      ],
+    });
+    expect(screen.getByText(/Node is currently online/)).toBeInTheDocument();
+    expect(screen.queryByText('Latest traceroutes (this target)')).not.toBeInTheDocument();
+  });
+
+  it('loads traceroute rows for offline watches', async () => {
+    const tr: AutoTraceRoute = {
+      id: 50,
+      source_node: {
+        node_id: 200,
+        short_name: 'SRC',
+        node_id_str: '!c8',
+        long_name: null,
+        last_heard: null,
+        owner: { id: 1, username: 'u' },
+        constellation: { id: 1 },
+        allow_auto_traceroute: true,
+        position: { latitude: null, longitude: null },
+      },
+      target_node: makeObservedNode({ node_id: 2 }),
+      trigger_type: 'monitor',
+      triggered_by: null,
+      triggered_by_username: null,
+      trigger_source: null,
+      triggered_at: '2026-04-21T10:00:00Z',
+      status: 'completed',
+      route: [],
+      route_back: [],
+      raw_packet: null,
+      completed_at: '2026-04-21T10:00:01Z',
+      error_message: null,
+    };
+    getTraceroutes.mockResolvedValue({ results: [tr], count: 1, next: null, previous: null });
+
+    renderTable({
+      watches: [
+        makeWatch({
+          id: 2,
+          node: {
+            node_id: 2,
+            short_name: 'OffOnly',
+            monitoring_offline_confirmed_at: '2026-04-21T11:00:00Z',
+          },
+        }),
+      ],
+    });
+
+    const offlineHeading = screen.getByRole('heading', { name: /Offline \(1\)/ });
+    const section = offlineHeading.closest('section');
+    expect(section).toBeTruthy();
+    await waitFor(() => {
+      expect(within(section!).getByText('SRC')).toBeInTheDocument();
+    });
+  });
+
+  it('calls onRequestTriggerTraceroute when trigger button is clicked', async () => {
+    const user = userEvent.setup();
+    const onTrigger = vi.fn();
+    renderTable({
+      watches: [
+        makeWatch({
+          id: 3,
+          node: {
+            node_id: 3,
+            short_name: 'Trig',
+            monitoring_offline_confirmed_at: '2026-04-21T11:00:00Z',
+          },
+        }),
+      ],
+      onRequestTriggerTraceroute: onTrigger,
+    });
+    await user.click(screen.getByRole('button', { name: /Trigger traceroute/i }));
+    expect(onTrigger).toHaveBeenCalledTimes(1);
+    expect(onTrigger.mock.calls[0][0].node_id).toBe(3);
+  });
+
+  it('disables trigger button when canTriggerTraceroute is false', () => {
+    const recent = new Date(Date.now() - 10 * 60 * 1000);
+    renderTable({
+      canTriggerTraceroute: false,
+      watches: [
+        makeWatch({
+          id: 99,
+          node: {
+            node_id: 99,
+            short_name: 'Solo',
+            last_heard: recent,
+            monitoring_offline_confirmed_at: null,
+            monitoring_verification_started_at: null,
+          },
+        }),
+      ],
+    });
+    expect(screen.getByRole('button', { name: /Trigger traceroute/i })).toBeDisabled();
+  });
+});

--- a/src/components/nodes/WatchedNodesTable.tsx
+++ b/src/components/nodes/WatchedNodesTable.tsx
@@ -1,4 +1,5 @@
 import type { ReactNode } from 'react';
+import { useMemo } from 'react';
 import { format } from 'date-fns';
 import { enGB } from 'date-fns/locale';
 import { StaleReportedTime } from '@/components/nodes/StaleReportedTime';
@@ -10,9 +11,18 @@ import { Card, CardHeader, CardTitle, CardDescription } from '@/components/ui/ca
 import { Badge } from '@/components/ui/badge';
 import { MeshWatchControls } from '@/components/nodes/MeshWatchControls';
 import { useMeshtasticApi } from '@/hooks/api/useApi';
-import { BatteryIcon } from 'lucide-react';
+import { BatteryIcon, RouteIcon } from 'lucide-react';
+import { Button } from '@/components/ui/button';
+import { cn } from '@/lib/utils';
+import {
+  deriveWatchMonitoringStatus,
+  WATCH_STATUS_LABEL,
+  type WatchMonitoringStatus,
+} from '@/lib/watch-monitoring-status';
 
 const LATEST_TRACEROUTES = 5;
+
+const GROUP_ORDER: WatchMonitoringStatus[] = ['offline', 'verifying', 'unknown', 'online'];
 
 function toDate(value: Date | string | null | undefined): Date | null {
   if (value == null) return null;
@@ -126,6 +136,9 @@ export interface WatchedNodesTableProps {
   watches: NodeWatch[];
   watchesQuery: Pick<UseQueryResult<PaginatedResponse<NodeWatch>>, 'isLoading' | 'isError'>;
   onOpenTraceroute: (id: number) => void;
+  onRequestTriggerTraceroute?: (node: ObservedNode) => void;
+  /** When false, trigger button is disabled with a short explanation. */
+  canTriggerTraceroute?: boolean;
 }
 
 function observedAsNode(watch: NodeWatch): ObservedNode {
@@ -169,82 +182,178 @@ function BatteryBlock({ node }: { node: ObservedNode }) {
   );
 }
 
-export function WatchedNodesTable({ watches, watchesQuery, onOpenTraceroute }: WatchedNodesTableProps) {
+function statusBadgeVariant(status: WatchMonitoringStatus): 'default' | 'secondary' | 'destructive' | 'outline' {
+  if (status === 'offline') return 'destructive';
+  if (status === 'verifying') return 'secondary';
+  if (status === 'online') return 'default';
+  return 'outline';
+}
+
+function WatchCard({
+  watch,
+  watchesQuery,
+  onOpenTraceroute,
+  onRequestTriggerTraceroute,
+  canTriggerTraceroute,
+}: {
+  watch: NodeWatch;
+  watchesQuery: Pick<UseQueryResult<PaginatedResponse<NodeWatch>>, 'isLoading' | 'isError'>;
+  onOpenTraceroute: (id: number) => void;
+  onRequestTriggerTraceroute?: (node: ObservedNode) => void;
+  canTriggerTraceroute?: boolean;
+}) {
+  const node = observedAsNode(watch);
+  const status = deriveWatchMonitoringStatus(watch);
+  const showTraceroutes = status !== 'online';
+
+  return (
+    <div
+      id={`watch-card-${watch.id}`}
+      tabIndex={-1}
+      className={cn(
+        'rounded-lg border-2 bg-card text-card-foreground shadow-sm p-4 space-y-4 outline-none scroll-mt-24',
+        status === 'offline' && 'border-destructive ring-2 ring-destructive/25',
+        status !== 'offline' && 'border-slate-300 dark:border-slate-400'
+      )}
+    >
+      <div className="flex flex-wrap items-start justify-between gap-3">
+        <div className="flex flex-wrap items-center gap-2">
+          <Badge variant={statusBadgeVariant(status)}>{WATCH_STATUS_LABEL[status]}</Badge>
+        </div>
+        {onRequestTriggerTraceroute && (
+          <Button
+            type="button"
+            variant="outline"
+            size="sm"
+            className="shrink-0"
+            disabled={!canTriggerTraceroute}
+            title={canTriggerTraceroute ? undefined : 'No eligible source nodes for traceroute'}
+            onClick={() => onRequestTriggerTraceroute(node)}
+          >
+            <RouteIcon className="h-4 w-4 mr-1.5" aria-hidden />
+            Trigger traceroute
+          </Button>
+        )}
+      </div>
+
+      <div className="grid gap-6 sm:grid-cols-2 lg:grid-cols-4">
+        <div>
+          <FieldLabel>Node</FieldLabel>
+          <Link to={`/nodes/${node.node_id}`} className="font-medium text-teal-600 dark:text-teal-400 hover:underline">
+            {node.short_name || node.node_id_str}
+          </Link>
+          <div className="text-xs text-muted-foreground font-mono mt-0.5">{node.node_id_str}</div>
+        </div>
+        <div>
+          <FieldLabel>Last heard</FieldLabel>
+          {node.last_heard ? (
+            <FriendlyThenAbsolute value={node.last_heard} />
+          ) : (
+            <span className="text-muted-foreground text-sm">Never</span>
+          )}
+        </div>
+        <div>
+          <FieldLabel>Battery</FieldLabel>
+          <BatteryBlock node={node} />
+        </div>
+        <div>
+          <FieldLabel>Watch</FieldLabel>
+          <MeshWatchControls
+            node={node}
+            watch={watch}
+            watchesQuery={watchesQuery}
+            idPrefix={`watch-dash-${watch.id}`}
+            compact
+          />
+        </div>
+      </div>
+
+      {showTraceroutes ? (
+        <div className="border-t border-slate-300 pt-4 dark:border-slate-500">
+          <FieldLabel>Latest traceroutes (this target)</FieldLabel>
+          <div className="rounded-md border border-slate-300 overflow-x-auto dark:border-slate-500">
+            <Table>
+              <TableHeader>
+                <TableRow>
+                  <TableHead>TR sender</TableHead>
+                  <TableHead>Type</TableHead>
+                  <TableHead>Status</TableHead>
+                  <TableHead>Route</TableHead>
+                  <TableHead>Triggered</TableHead>
+                </TableRow>
+              </TableHeader>
+              <TableBody>
+                <WatchTracerouteHistoryRows targetNodeId={node.node_id} onOpenTraceroute={onOpenTraceroute} />
+              </TableBody>
+            </Table>
+          </div>
+        </div>
+      ) : (
+        <div className="border-t border-slate-300 pt-4 dark:border-slate-500">
+          <p className="text-sm text-muted-foreground">
+            Node is currently online; traceroute history is hidden here.{' '}
+            <Link to="/traceroutes" className="text-teal-600 dark:text-teal-400 hover:underline">
+              Open full traceroute history
+            </Link>
+            .
+          </p>
+        </div>
+      )}
+    </div>
+  );
+}
+
+export function WatchedNodesTable({
+  watches,
+  watchesQuery,
+  onOpenTraceroute,
+  onRequestTriggerTraceroute,
+  canTriggerTraceroute,
+}: WatchedNodesTableProps) {
+  const grouped = useMemo(() => {
+    const m = new Map<WatchMonitoringStatus, NodeWatch[]>();
+    for (const s of GROUP_ORDER) m.set(s, []);
+    for (const w of watches) {
+      const s = deriveWatchMonitoringStatus(w);
+      m.get(s)!.push(w);
+    }
+    return m;
+  }, [watches]);
+
   return (
     <Card>
       <CardHeader>
         <CardTitle className="flex items-center gap-2">Watched nodes</CardTitle>
         <CardDescription>
-          Mesh monitoring watches for your account. Each block is one watched node.{' '}
+          Mesh monitoring watches for your account, grouped by status. Offline and verifying nodes are listed first.{' '}
           <Link to="/traceroutes" className="text-teal-600 dark:text-teal-400 hover:underline">
             Open full traceroute history
           </Link>
           .
         </CardDescription>
       </CardHeader>
-      <div className="p-4 flex flex-col gap-4">
-        {watches.map((watch) => {
-          const node = observedAsNode(watch);
+      <div className="p-4 flex flex-col gap-8">
+        {GROUP_ORDER.map((groupStatus) => {
+          const list = grouped.get(groupStatus) ?? [];
+          if (list.length === 0) return null;
           return (
-            <div
-              key={watch.id}
-              className="rounded-lg border-2 border-slate-300 bg-card text-card-foreground shadow-sm dark:border-slate-400 p-4 space-y-4"
-            >
-              <div className="grid gap-6 sm:grid-cols-2 lg:grid-cols-4">
-                <div>
-                  <FieldLabel>Node</FieldLabel>
-                  <Link
-                    to={`/nodes/${node.node_id}`}
-                    className="font-medium text-teal-600 dark:text-teal-400 hover:underline"
-                  >
-                    {node.short_name || node.node_id_str}
-                  </Link>
-                  <div className="text-xs text-muted-foreground font-mono mt-0.5">{node.node_id_str}</div>
-                </div>
-                <div>
-                  <FieldLabel>Last heard</FieldLabel>
-                  {node.last_heard ? (
-                    <FriendlyThenAbsolute value={node.last_heard} />
-                  ) : (
-                    <span className="text-muted-foreground text-sm">Never</span>
-                  )}
-                </div>
-                <div>
-                  <FieldLabel>Battery</FieldLabel>
-                  <BatteryBlock node={node} />
-                </div>
-                <div>
-                  <FieldLabel>Watch</FieldLabel>
-                  <MeshWatchControls
-                    node={node}
+            <section key={groupStatus} aria-labelledby={`watch-group-${groupStatus}`}>
+              <h3 id={`watch-group-${groupStatus}`} className="text-sm font-semibold mb-3">
+                {WATCH_STATUS_LABEL[groupStatus]} ({list.length})
+              </h3>
+              <div className="flex flex-col gap-4">
+                {list.map((watch) => (
+                  <WatchCard
+                    key={watch.id}
                     watch={watch}
                     watchesQuery={watchesQuery}
-                    idPrefix={`watch-dash-${watch.id}`}
-                    compact
+                    onOpenTraceroute={onOpenTraceroute}
+                    onRequestTriggerTraceroute={onRequestTriggerTraceroute}
+                    canTriggerTraceroute={canTriggerTraceroute}
                   />
-                </div>
+                ))}
               </div>
-
-              <div className="border-t border-slate-300 pt-4 dark:border-slate-500">
-                <FieldLabel>Latest traceroutes (this target)</FieldLabel>
-                <div className="rounded-md border border-slate-300 overflow-x-auto dark:border-slate-500">
-                  <Table>
-                    <TableHeader>
-                      <TableRow>
-                        <TableHead>TR sender</TableHead>
-                        <TableHead>Type</TableHead>
-                        <TableHead>Status</TableHead>
-                        <TableHead>Route</TableHead>
-                        <TableHead>Triggered</TableHead>
-                      </TableRow>
-                    </TableHeader>
-                    <TableBody>
-                      <WatchTracerouteHistoryRows targetNodeId={node.node_id} onOpenTraceroute={onOpenTraceroute} />
-                    </TableBody>
-                  </Table>
-                </div>
-              </div>
-            </div>
+            </section>
           );
         })}
       </div>

--- a/src/components/traceroutes/AutoTargetPreviewMap.tsx
+++ b/src/components/traceroutes/AutoTargetPreviewMap.tsx
@@ -100,9 +100,7 @@ export function AutoTargetPreviewMap({
 
   const { envelope, centroid } = useMemo(() => {
     const env = geo?.envelope ?? null;
-    const cen =
-      geo?.selection_centroid ??
-      (env ? { lat: env.centroid_lat, lon: env.centroid_lon } : null);
+    const cen = geo?.selection_centroid ?? (env ? { lat: env.centroid_lat, lon: env.centroid_lon } : null);
     return { envelope: env, centroid: cen };
   }, [geo?.envelope, geo?.selection_centroid]);
 

--- a/src/lib/watch-monitoring-status.test.ts
+++ b/src/lib/watch-monitoring-status.test.ts
@@ -1,0 +1,156 @@
+import { describe, it, expect } from 'vitest';
+import type { NodeWatch, ObservedNodeWatchSummary } from '@/lib/models';
+import {
+  compareWatchesByMonitoringStatus,
+  countWatchesByMonitoringStatus,
+  deriveWatchMonitoringStatus,
+  sortWatchesByMonitoringStatus,
+  WATCH_STATUS_SORT_RANK,
+} from './watch-monitoring-status';
+
+function makeWatch(overrides: {
+  watch?: Partial<NodeWatch>;
+  node?: Partial<ObservedNodeWatchSummary>;
+}): NodeWatch {
+  const node: ObservedNodeWatchSummary = {
+    internal_id: 1,
+    node_id: 42,
+    node_id_str: '!0000002a',
+    mac_addr: null,
+    long_name: null,
+    short_name: 'N42',
+    hw_model: null,
+    public_key: null,
+    last_heard: new Date('2026-01-01T12:00:00.000Z'),
+    latest_device_metrics: null,
+    latest_environment_metrics: null,
+    latest_power_metrics: null,
+    latest_position: null,
+    owner: null,
+    ...overrides.node,
+  };
+  return {
+    id: 1,
+    observed_node: node,
+    offline_after: 3600,
+    enabled: true,
+    created_at: '2026-01-01T00:00:00Z',
+    ...overrides.watch,
+  };
+}
+
+describe('deriveWatchMonitoringStatus', () => {
+  const now = new Date('2026-01-01T13:00:00.000Z').getTime();
+
+  it('returns offline when monitoring_offline_confirmed_at is set', () => {
+    const w = makeWatch({
+      node: {
+        monitoring_offline_confirmed_at: '2026-01-01T12:30:00Z',
+        last_heard: new Date('2026-01-01T12:59:00.000Z'),
+      },
+    });
+    expect(deriveWatchMonitoringStatus(w, now)).toBe('offline');
+  });
+
+  it('returns verifying when verification started and not offline', () => {
+    const w = makeWatch({
+      node: {
+        monitoring_verification_started_at: '2026-01-01T12:30:00Z',
+        monitoring_offline_confirmed_at: null,
+      },
+    });
+    expect(deriveWatchMonitoringStatus(w, now)).toBe('verifying');
+  });
+
+  it('returns online when last_heard is within offline_after', () => {
+    const w = makeWatch({
+      watch: { offline_after: 7200 },
+      node: {
+        monitoring_verification_started_at: null,
+        last_heard: new Date('2026-01-01T12:30:00.000Z'),
+      },
+    });
+    expect(deriveWatchMonitoringStatus(w, now)).toBe('online');
+  });
+
+  it('returns unknown when last_heard is older than offline_after and not verifying', () => {
+    const w = makeWatch({
+      watch: { offline_after: 1800 },
+      node: {
+        monitoring_verification_started_at: null,
+        last_heard: new Date('2026-01-01T12:00:00.000Z'),
+      },
+    });
+    expect(deriveWatchMonitoringStatus(w, now)).toBe('unknown');
+  });
+
+  it('returns unknown when last_heard is missing', () => {
+    const w = makeWatch({ node: { last_heard: null } });
+    expect(deriveWatchMonitoringStatus(w, now)).toBe('unknown');
+  });
+});
+
+describe('sortWatchesByMonitoringStatus', () => {
+  it('orders offline before online', () => {
+    const now = new Date('2026-01-01T15:00:00.000Z').getTime();
+    const online = makeWatch({
+      watch: { id: 1, offline_after: 3600 },
+      node: {
+        node_id: 1,
+        last_heard: new Date('2026-01-01T14:30:00.000Z'),
+        monitoring_offline_confirmed_at: null,
+        monitoring_verification_started_at: null,
+      },
+    });
+    const offline = makeWatch({
+      watch: { id: 2, offline_after: 3600 },
+      node: {
+        node_id: 2,
+        monitoring_offline_confirmed_at: '2026-01-01T14:00:00Z',
+        last_heard: new Date('2026-01-01T14:30:00.000Z'),
+      },
+    });
+    const sorted = sortWatchesByMonitoringStatus([online, offline], now);
+    expect(sorted.map((w) => w.id)).toEqual([2, 1]);
+    expect(WATCH_STATUS_SORT_RANK.offline < WATCH_STATUS_SORT_RANK.online).toBe(true);
+  });
+});
+
+describe('countWatchesByMonitoringStatus', () => {
+  it('aggregates by status', () => {
+    const now = new Date('2026-01-01T13:00:00.000Z').getTime();
+    const watches = [
+      makeWatch({
+        watch: { id: 1 },
+        node: { monitoring_offline_confirmed_at: '2026-01-01T12:00:00Z' },
+      }),
+      makeWatch({
+        watch: { id: 2, offline_after: 7200 },
+        node: { node_id: 3, last_heard: new Date('2026-01-01T12:30:00.000Z') },
+      }),
+    ];
+    expect(countWatchesByMonitoringStatus(watches, now)).toEqual({
+      offline: 1,
+      verifying: 0,
+      unknown: 0,
+      online: 1,
+    });
+  });
+});
+
+describe('compareWatchesByMonitoringStatus', () => {
+  it('sorts unknown with older last_heard before newer within same rank', () => {
+    const now = new Date('2026-01-01T15:00:00.000Z').getTime();
+    const newerUnknown = makeWatch({
+      watch: { id: 1, offline_after: 60 },
+      node: { node_id: 10, last_heard: new Date('2026-01-01T14:50:00.000Z') },
+    });
+    const olderUnknown = makeWatch({
+      watch: { id: 2, offline_after: 60 },
+      node: { node_id: 11, last_heard: new Date('2026-01-01T14:00:00.000Z') },
+    });
+    const sorted = [newerUnknown, olderUnknown].sort((a, b) => compareWatchesByMonitoringStatus(a, b, now));
+    expect(sorted[0].id).toBe(2);
+    expect(sorted[1].id).toBe(1);
+  });
+});

--- a/src/lib/watch-monitoring-status.ts
+++ b/src/lib/watch-monitoring-status.ts
@@ -1,0 +1,113 @@
+import type { NodeWatch } from '@/lib/models';
+
+/** Mesh monitoring status for a watched node (UI + map + sorting). */
+export type WatchMonitoringStatus = 'offline' | 'verifying' | 'unknown' | 'online';
+
+/** Sort rank: lower = show first. */
+export const WATCH_STATUS_SORT_RANK: Record<WatchMonitoringStatus, number> = {
+  offline: 0,
+  verifying: 1,
+  unknown: 2,
+  online: 3,
+};
+
+export const WATCH_STATUS_MAP_COLOR: Record<WatchMonitoringStatus, string> = {
+  offline: '#dc2626',
+  verifying: '#d97706',
+  unknown: '#64748b',
+  online: '#16a34a',
+};
+
+export const WATCH_STATUS_LABEL: Record<WatchMonitoringStatus, string> = {
+  offline: 'Offline',
+  verifying: 'Verifying',
+  unknown: 'Unknown / stale',
+  online: 'Online',
+};
+
+function toTimeMs(value: Date | string | null | undefined): number | null {
+  if (value == null) return null;
+  const d = value instanceof Date ? value : new Date(value);
+  const t = d.getTime();
+  return Number.isNaN(t) ? null : t;
+}
+
+/**
+ * Derive monitoring status for a watch using API hints and last_heard vs silence threshold.
+ *
+ * Precedence: offline confirmed > verifying > online (heard within threshold) > unknown.
+ */
+export function deriveWatchMonitoringStatus(watch: NodeWatch, nowMs: number = Date.now()): WatchMonitoringStatus {
+  const n = watch.observed_node;
+  if (n.monitoring_offline_confirmed_at) {
+    return 'offline';
+  }
+  if (n.monitoring_verification_started_at) {
+    return 'verifying';
+  }
+
+  const offlineAfterSec = watch.offline_after ?? n.offline_after;
+  const lastHeardMs = toTimeMs(n.last_heard);
+
+  if (lastHeardMs == null) {
+    return 'unknown';
+  }
+  if (offlineAfterSec == null || offlineAfterSec <= 0) {
+    return 'unknown';
+  }
+
+  const ageSec = (nowMs - lastHeardMs) / 1000;
+  if (ageSec <= offlineAfterSec) {
+    return 'online';
+  }
+  return 'unknown';
+}
+
+/** Stable sort: status rank, then last heard ascending (stale first), then node_id. */
+export function compareWatchesByMonitoringStatus(a: NodeWatch, b: NodeWatch, nowMs?: number): number {
+  const t = nowMs ?? Date.now();
+  const sa = deriveWatchMonitoringStatus(a, t);
+  const sb = deriveWatchMonitoringStatus(b, t);
+  const ra = WATCH_STATUS_SORT_RANK[sa];
+  const rb = WATCH_STATUS_SORT_RANK[sb];
+  if (ra !== rb) return ra - rb;
+
+  const la = toTimeMs(a.observed_node.last_heard);
+  const lb = toTimeMs(b.observed_node.last_heard);
+  if (la != null && lb != null && la !== lb) return la - lb;
+  if (la == null && lb != null) return 1;
+  if (la != null && lb == null) return -1;
+
+  return a.observed_node.node_id - b.observed_node.node_id;
+}
+
+export function sortWatchesByMonitoringStatus(watches: NodeWatch[], nowMs?: number): NodeWatch[] {
+  const t = nowMs ?? Date.now();
+  return [...watches].sort((a, b) => compareWatchesByMonitoringStatus(a, b, t));
+}
+
+export function countWatchesByMonitoringStatus(
+  watches: NodeWatch[],
+  nowMs?: number
+): Record<WatchMonitoringStatus, number> {
+  const t = nowMs ?? Date.now();
+  const counts: Record<WatchMonitoringStatus, number> = {
+    offline: 0,
+    verifying: 0,
+    unknown: 0,
+    online: 0,
+  };
+  for (const w of watches) {
+    counts[deriveWatchMonitoringStatus(w, t)] += 1;
+  }
+  return counts;
+}
+
+/** Legend rows for map (same shape as role swatches). */
+export function watchMonitoringStatusLegendSwatches(): { key: string; label: string; color: string }[] {
+  return (Object.keys(WATCH_STATUS_LABEL) as WatchMonitoringStatus[]).map((status) => ({
+    key: `watch-status-${status}`,
+    label: WATCH_STATUS_LABEL[status],
+    color: WATCH_STATUS_MAP_COLOR[status],
+  }));
+}

--- a/src/pages/nodes/monitor.tsx
+++ b/src/pages/nodes/monitor.tsx
@@ -1,13 +1,27 @@
-import { useMemo, useState } from 'react';
+import { useEffect, useMemo, useState } from 'react';
 import { Link } from 'react-router-dom';
+import { useInfiniteQuery } from '@tanstack/react-query';
+import { toast } from 'sonner';
 import { useNodeWatches } from '@/hooks/api/useNodeWatches';
 import { NodesMap } from '@/components/nodes/NodesMap';
 import { WatchedNodesTable } from '@/components/nodes/WatchedNodesTable';
+import { WatchDashboardSummary } from '@/components/nodes/WatchDashboardSummary';
 import { MonitoredNodesBatteryChart } from '@/components/nodes/MonitoredNodesBatteryChart';
 import { MonitoredNodesChannelUtilChart } from '@/components/nodes/MonitoredNodesChannelUtilChart';
 import { TracerouteDetailModal } from '@/pages/traceroutes/TracerouteDetailModal';
+import { TriggerTracerouteModal } from '@/pages/traceroutes/TriggerTracerouteModal';
+import { getTracerouteErrorMessage } from '@/pages/traceroutes/tracerouteErrors';
 import { Accordion, AccordionContent, AccordionItem, AccordionTrigger } from '@/components/ui/accordion';
 import type { NodeWatch, ObservedNode } from '@/lib/models';
+import { useMeshtasticApi } from '@/hooks/api/useApi';
+import { useTracerouteTriggerableNodes, useTriggerTraceroute } from '@/hooks/api/useTraceroutes';
+import {
+  countWatchesByMonitoringStatus,
+  deriveWatchMonitoringStatus,
+  sortWatchesByMonitoringStatus,
+  WATCH_STATUS_MAP_COLOR,
+  watchMonitoringStatusLegendSwatches,
+} from '@/lib/watch-monitoring-status';
 
 function nodeFromWatch(watch: NodeWatch): ObservedNode {
   return watch.observed_node as unknown as ObservedNode;
@@ -16,9 +30,70 @@ function nodeFromWatch(watch: NodeWatch): ObservedNode {
 export default function MonitorNodesPage() {
   const watchesQuery = useNodeWatches();
   const [selectedTracerouteId, setSelectedTracerouteId] = useState<number | null>(null);
+  const [triggerModalOpen, setTriggerModalOpen] = useState(false);
+  const [triggerTarget, setTriggerTarget] = useState<ObservedNode | null>(null);
 
-  const watches = watchesQuery.data?.results ?? [];
-  const nodesForCharts = useMemo(() => (watchesQuery.data?.results ?? []).map(nodeFromWatch), [watchesQuery.data]);
+  const watches = useMemo(() => watchesQuery.data?.results ?? [], [watchesQuery.data?.results]);
+  const sortedWatches = useMemo(() => sortWatchesByMonitoringStatus(watches), [watches]);
+  const watchCounts = useMemo(() => countWatchesByMonitoringStatus(watches), [watches]);
+  const nodesForCharts = useMemo(() => sortedWatches.map(nodeFromWatch), [sortedWatches]);
+
+  const markerColorsByNodeId = useMemo(() => {
+    const m = new Map<number, string>();
+    for (const w of sortedWatches) {
+      const st = deriveWatchMonitoringStatus(w);
+      m.set(w.observed_node.node_id, WATCH_STATUS_MAP_COLOR[st]);
+    }
+    return m;
+  }, [sortedWatches]);
+
+  const api = useMeshtasticApi();
+  const triggerableQuery = useTracerouteTriggerableNodes();
+  const triggerMutation = useTriggerTraceroute();
+
+  const managedPages = useInfiniteQuery({
+    queryKey: ['managed-nodes', 500, 'status+geo'] as const,
+    queryFn: ({ pageParam = 1 }) =>
+      api.getManagedNodes({
+        page: pageParam as number,
+        page_size: 500,
+        includeStatus: true,
+        includeGeoClassification: true,
+      }),
+    initialPageParam: 1,
+    getNextPageParam: (last, allPages) => (last.next ? allPages.length + 1 : undefined),
+    enabled: watches.length > 0,
+  });
+
+  useEffect(() => {
+    if (managedPages.hasNextPage && !managedPages.isFetchingNextPage && !managedPages.isError) {
+      void managedPages.fetchNextPage();
+    }
+  }, [
+    managedPages.hasNextPage,
+    managedPages.isFetchingNextPage,
+    managedPages.isError,
+    managedPages.fetchNextPage,
+    managedPages,
+  ]);
+
+  const modalManagedNodes = useMemo(() => {
+    const triggerable = triggerableQuery.data ?? [];
+    const pages = managedPages.data?.pages.flatMap((p) => p.results) ?? [];
+    const byId = new Map(pages.map((m) => [m.node_id, m]));
+    return triggerable.map((t) => {
+      const full = byId.get(t.node_id);
+      return full ? { ...t, ...full } : t;
+    });
+  }, [triggerableQuery.data, managedPages.data?.pages]);
+
+  const canTriggerTraceroute = (triggerableQuery.data?.length ?? 0) > 0;
+
+  const scrollToWatch = (watchId: number) => {
+    const el = document.getElementById(`watch-card-${watchId}`);
+    el?.scrollIntoView({ behavior: 'smooth', block: 'start' });
+    (el as HTMLElement | null)?.focus({ preventScroll: true });
+  };
 
   return (
     <div className="container mx-auto p-4 space-y-6">
@@ -60,15 +135,27 @@ export default function MonitorNodesPage() {
 
       {!watchesQuery.isLoading && !watchesQuery.isError && watches.length > 0 && (
         <>
+          <WatchDashboardSummary watches={sortedWatches} counts={watchCounts} onJumpToWatch={scrollToWatch} />
+
           <div className="h-[400px] bg-background rounded-lg border">
-            <NodesMap nodes={nodesForCharts} />
+            <NodesMap
+              nodes={nodesForCharts}
+              markerColorsByNodeId={markerColorsByNodeId}
+              mapLegendStatusSwatches={watchMonitoringStatusLegendSwatches()}
+              mapLegendStatusTitle="Watch status"
+            />
           </div>
 
           <div className="bg-background rounded-lg border">
             <WatchedNodesTable
-              watches={watches}
+              watches={sortedWatches}
               watchesQuery={watchesQuery}
               onOpenTraceroute={setSelectedTracerouteId}
+              onRequestTriggerTraceroute={(node) => {
+                setTriggerTarget(node);
+                setTriggerModalOpen(true);
+              }}
+              canTriggerTraceroute={canTriggerTraceroute}
             />
           </div>
 
@@ -93,6 +180,30 @@ export default function MonitorNodesPage() {
         tracerouteId={selectedTracerouteId}
         open={selectedTracerouteId != null}
         onOpenChange={(open) => !open && setSelectedTracerouteId(null)}
+      />
+
+      <TriggerTracerouteModal
+        open={triggerModalOpen}
+        onOpenChange={(open) => {
+          setTriggerModalOpen(open);
+          if (!open) setTriggerTarget(null);
+        }}
+        mode="user"
+        managedNodes={modalManagedNodes}
+        observedNodes={triggerTarget ? [triggerTarget] : []}
+        fixedTargetNode={triggerTarget ?? undefined}
+        onTrigger={async (managedNodeId, targetNodeId, targetStrategy) => {
+          try {
+            await triggerMutation.mutateAsync({ managedNodeId, targetNodeId, targetStrategy });
+            setTriggerModalOpen(false);
+            setTriggerTarget(null);
+          } catch (err) {
+            toast.error('Traceroute failed', {
+              description: getTracerouteErrorMessage(err),
+            });
+          }
+        }}
+        isSubmitting={triggerMutation.isPending}
       />
     </div>
   );


### PR DESCRIPTION
## Summary

Implements [issue #211](https://github.com/pskillen/meshtastic-bot-ui/issues/211): the Mesh watches page (`/nodes/monitor`) is now a status-first dashboard.

- **Status helper** (`src/lib/watch-monitoring-status.ts`): derives `offline` / `verifying` / `unknown` / `online` from watch API hints and `last_heard` vs `offline_after`, with sort order and map colours.
- **Summary panel** (`WatchDashboardSummary`): counts by status and a two-column jump list that scrolls/focuses the matching watch card.
- **Watched nodes table**: groups cards by status (offline first), highlights offline cards, hides the latest-traceroute table for **online** watches (with a short message + link to full history), keeps traceroute rows for problem states.
- **Trigger traceroute**: per-watch button opens `TriggerTracerouteModal` with fixed target; merges triggerable managed nodes with full managed-node data for the modal (same pattern as node detail).
- **Map**: `NodesMap` accepts optional per-node pin colours and a watch-status legend; default role-based maps unchanged elsewhere.

## Testing performed

- `npm run format`
- `npm run lint` (warnings only, pre-existing across repo)
- `npm test` / `vitest run` — all 192 tests pass
- New/updated tests: `watch-monitoring-status.test.ts`, `WatchedNodesTable.test.tsx`, `WatchDashboardSummary.test.tsx`, `NodesMap.test.tsx`

Closes #211