### PR TITLE
feat(nodes): hide never-fed managed nodes from maps

### DIFF
--- a/src/lib/managed-node-status.test.ts
+++ b/src/lib/managed-node-status.test.ts
@@ -3,8 +3,11 @@ import { describe, expect, it } from 'vitest';
 import {
   MANAGED_NODE_ONLINE_MAX_AGE_SECONDS,
   MANAGED_NODE_STALE_MAX_AGE_SECONDS,
+  filterManagedNodesForMapDisplay,
   getManagedNodeStatusTier,
+  hasManagedNodeEverFedData,
 } from './managed-node-status';
+import type { ManagedNode } from '@/lib/models';
 
 describe('getManagedNodeStatusTier', () => {
   const now = new Date('2026-04-20T12:00:00Z');
@@ -29,5 +32,37 @@ describe('getManagedNodeStatusTier', () => {
   it('returns offline above stale threshold', () => {
     const offline = new Date(now.getTime() - (MANAGED_NODE_STALE_MAX_AGE_SECONDS + 1) * 1000);
     expect(getManagedNodeStatusTier(offline, now)).toBe('offline');
+  });
+});
+
+describe('hasManagedNodeEverFedData', () => {
+  it('is false when last_packet_ingested_at is missing', () => {
+    expect(hasManagedNodeEverFedData({} as Pick<ManagedNode, 'last_packet_ingested_at'>)).toBe(false);
+    expect(hasManagedNodeEverFedData({ last_packet_ingested_at: null })).toBe(false);
+    expect(hasManagedNodeEverFedData({ last_packet_ingested_at: undefined })).toBe(false);
+  });
+
+  it('is true when last_packet_ingested_at is set', () => {
+    expect(hasManagedNodeEverFedData({ last_packet_ingested_at: new Date('2026-01-01') })).toBe(true);
+  });
+});
+
+describe('filterManagedNodesForMapDisplay', () => {
+  const base: ManagedNode = {
+    node_id: 1,
+    long_name: null,
+    short_name: 'A',
+    last_heard: null,
+    node_id_str: '!1',
+    owner: { id: 1, username: 'u' },
+    constellation: { id: 1 },
+    allow_auto_traceroute: true,
+    position: { latitude: 1, longitude: 1 },
+  };
+
+  it('drops nodes with no ingestion timestamp', () => {
+    const fed: ManagedNode = { ...base, node_id: 2, last_packet_ingested_at: new Date() };
+    const never: ManagedNode = { ...base, node_id: 3 };
+    expect(filterManagedNodesForMapDisplay([fed, never])).toEqual([fed]);
   });
 });

--- a/src/lib/managed-node-status.ts
+++ b/src/lib/managed-node-status.ts
@@ -1,3 +1,5 @@
+import type { ManagedNode } from '@/lib/models';
+
 export type ManagedNodeStatusTier = 'online' | 'stale' | 'offline' | 'never';
 
 export const MANAGED_NODE_ONLINE_MAX_AGE_SECONDS = 600;
@@ -26,4 +28,18 @@ export function managedNodeStatusTierColor(tier: ManagedNodeStatusTier): string 
   if (tier === 'stale') return '#d97706';
   if (tier === 'offline') return '#dc2626';
   return '#64748b';
+}
+
+/**
+ * True when this managed node has ever ingested a packet into Meshflow
+ * (`ManagedNodeStatus.last_packet_ingested_at` on the API). Requires
+ * `include=status` on managed-node list/detail responses for a reliable value.
+ */
+export function hasManagedNodeEverFedData(node: Pick<ManagedNode, 'last_packet_ingested_at'>): boolean {
+  return node.last_packet_ingested_at != null;
+}
+
+/** Managed nodes to draw on constellation / infrastructure maps (exclude never-fed). */
+export function filterManagedNodesForMapDisplay(nodes: ManagedNode[]): ManagedNode[] {
+  return nodes.filter(hasManagedNodeEverFedData);
 }

--- a/src/pages/Dashboard.tsx
+++ b/src/pages/Dashboard.tsx
@@ -2,7 +2,8 @@ import { NodeActivityTable } from '@/components/NodeActivityTable';
 import { NodesAndConstellationsMap } from '@/components/nodes/NodesAndConstellationsMap';
 import { useNodesSuspense, useManagedNodesSuspense, useRecentNodeCountsSuspense } from '@/hooks/api/useNodes';
 import { Card, CardHeader, CardTitle, CardDescription, CardContent } from '@/components/ui/card';
-import { Suspense } from 'react';
+import { Suspense, useMemo } from 'react';
+import { filterManagedNodesForMapDisplay } from '@/lib/managed-node-status';
 import { MeshStatsSection } from '@/components/MeshStatsSection';
 import { Table, TableBody, TableCell, TableHead, TableHeader, TableRow } from '@/components/ui/table';
 import { Link } from 'react-router-dom';
@@ -19,7 +20,8 @@ const COUNT_COLUMNS = [
 function DashboardContent() {
   const counts = useRecentNodeCountsSuspense();
   const { nodes } = useNodesSuspense();
-  const { managedNodes } = useManagedNodesSuspense();
+  const { managedNodes } = useManagedNodesSuspense({ includeStatus: true });
+  const managedNodesForMap = useMemo(() => filterManagedNodesForMapDisplay(managedNodes), [managedNodes]);
 
   return (
     <div className="flex flex-col gap-4 py-4 md:gap-6 md:py-6">
@@ -69,7 +71,7 @@ function DashboardContent() {
           <CardContent>
             <div className="h-[600px] w-full">
               <NodesAndConstellationsMap
-                managedNodes={managedNodes || []}
+                managedNodes={managedNodesForMap}
                 showConstellation={true}
                 showUnmanagedNodes={false}
               />

--- a/src/pages/map/NodeMap.tsx
+++ b/src/pages/map/NodeMap.tsx
@@ -4,6 +4,7 @@ import { NodeDetailSheet } from '@/components/nodes/NodeDetailSheet';
 import { useNodesSuspense, useManagedNodesSuspense } from '@/hooks/api/useNodes';
 import { subDays, subHours } from 'date-fns';
 import { useMemo, useState, Suspense } from 'react';
+import { filterManagedNodesForMapDisplay } from '@/lib/managed-node-status';
 import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from '@/components/ui/select';
 import { Switch } from '@/components/ui/switch';
 import { Label } from '@/components/ui/label';
@@ -51,11 +52,13 @@ function NodeMapContent() {
 
   const lastHeardAfter = useMemo(() => getLastHeardAfter(timeRange), [timeRange]);
 
-  const { managedNodes } = useManagedNodesSuspense({ pageSize: 500 });
+  const { managedNodes } = useManagedNodesSuspense({ pageSize: 500, includeStatus: true });
   const { nodes: observedNodes } = useNodesSuspense({
     lastHeardAfter,
     pageSize: 500,
   });
+
+  const managedNodesForMap = useMemo(() => filterManagedNodesForMapDisplay(managedNodes), [managedNodes]);
 
   const constellations = useMemo(() => {
     const seen = new Map<number, string>();
@@ -218,7 +221,7 @@ function NodeMapContent() {
 
           <div className="h-[500px] w-full rounded-md overflow-hidden">
             <NodesAndConstellationsMap
-              managedNodes={managedNodes}
+              managedNodes={managedNodesForMap}
               observedNodes={observedNodes}
               showConstellation={showConstellation}
               showUnmanagedNodes={showUnmanagedNodes}

--- a/src/pages/nodes/ClaimNode.tsx
+++ b/src/pages/nodes/ClaimNode.tsx
@@ -1,4 +1,4 @@
-import { useState, useEffect } from 'react';
+import { useState, useEffect, useMemo } from 'react';
 import { useParams, useNavigate, Link } from 'react-router-dom';
 import { useNodeSuspense, useManagedNodesSuspense } from '@/hooks/api/useNodes';
 import { useMeshtasticApi } from '@/hooks/api/useApi';
@@ -9,6 +9,7 @@ import { Alert, AlertDescription, AlertTitle } from '@/components/ui/alert';
 import { Loader2, AlertCircle, CheckCircle2 } from 'lucide-react';
 import { NodeClaim } from '@/lib/models';
 import { StaleReportedTime } from '@/components/nodes/StaleReportedTime';
+import { filterManagedNodesForMapDisplay } from '@/lib/managed-node-status';
 
 export function ClaimNode() {
   const { id } = useParams<{ id: string }>();
@@ -23,7 +24,11 @@ export function ClaimNode() {
   const [pollingInterval, setPollingInterval] = useState<NodeJS.Timeout | null>(null);
 
   const node = useNodeSuspense(nodeId);
-  const { managedNodes } = useManagedNodesSuspense();
+  const { managedNodes } = useManagedNodesSuspense({ includeStatus: true });
+  const managedNodesForMap = useMemo(
+    () => (managedNodes ? filterManagedNodesForMapDisplay(managedNodes) : []),
+    [managedNodes]
+  );
   const isLoadingManagedNodes = !managedNodes;
   const managedNodesError = false; // Suspense disables error state, so just set to false
 
@@ -254,7 +259,7 @@ export function ClaimNode() {
                 <>
                   <div className="mb-4">
                     <div className="h-[400px] w-full">
-                      <ConstellationsMap nodes={managedNodes} />
+                      <ConstellationsMap nodes={managedNodesForMap} />
                     </div>
                   </div>
                 </>

--- a/src/pages/nodes/ManagedNodesStatus.tsx
+++ b/src/pages/nodes/ManagedNodesStatus.tsx
@@ -23,7 +23,12 @@ import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from '@
 import { Switch } from '@/components/ui/switch';
 import { Table, TableBody, TableCell, TableHead, TableHeader, TableRow } from '@/components/ui/table';
 import { useManagedNodesSuspense } from '@/hooks/api/useNodes';
-import { ManagedNodeStatusTier, getManagedNodeStatusTier, managedNodeStatusTierColor } from '@/lib/managed-node-status';
+import {
+  ManagedNodeStatusTier,
+  filterManagedNodesForMapDisplay,
+  getManagedNodeStatusTier,
+  managedNodeStatusTierColor,
+} from '@/lib/managed-node-status';
 import { ManagedNode } from '@/lib/models';
 
 import { ManagedNodesSortKey, parseManagedNodesUrlState, updateManagedNodesUrlState } from './managed-nodes-url-state';
@@ -175,6 +180,8 @@ function ManagedNodesStatusContent() {
     return sorted;
   }, [filteredManagedNodes, filters.sort]);
 
+  const managedNodesForMap = useMemo(() => filterManagedNodesForMapDisplay(sortedManagedNodes), [sortedManagedNodes]);
+
   const counts = useMemo(() => {
     const base = { total: filteredManagedNodes.length, online: 0, stale: 0, offline: 0, never: 0 };
     for (const node of filteredManagedNodes) {
@@ -233,7 +240,7 @@ function ManagedNodesStatusContent() {
         <CardContent>
           <div className="h-[450px] rounded border">
             <NodesAndConstellationsMap
-              managedNodes={sortedManagedNodes}
+              managedNodes={managedNodesForMap}
               showConstellation={true}
               showUnmanagedNodes={false}
               drawPositionUncertainty={true}

--- a/src/pages/nodes/MeshInfrastructure.tsx
+++ b/src/pages/nodes/MeshInfrastructure.tsx
@@ -19,6 +19,7 @@ import { Label } from '@/components/ui/label';
 import { Badge } from '@/components/ui/badge';
 import { Button } from '@/components/ui/button';
 import { ObservedNode, type NodeWatch } from '@/lib/models';
+import { filterManagedNodesForMapDisplay } from '@/lib/managed-node-status';
 import { MeshWatchControls } from '@/components/nodes/MeshWatchControls';
 import { MapPinOff } from 'lucide-react';
 
@@ -110,8 +111,13 @@ function MeshInfrastructureContent() {
     return m;
   }, [watchesQuery.data]);
 
-  const { managedNodes } = useManagedNodesSuspense({ pageSize: 500, includeGeoClassification: true });
+  const { managedNodes } = useManagedNodesSuspense({
+    pageSize: 500,
+    includeStatus: true,
+    includeGeoClassification: true,
+  });
   const managedByMeshId = useMemo(() => new Map(managedNodes.map((m) => [m.node_id, m])), [managedNodes]);
+  const managedNodesForMap = useMemo(() => filterManagedNodesForMapDisplay(managedNodes), [managedNodes]);
 
   const { metricsMap } = useMultiNodeMetricsSuspense(nodes, chartDateRange);
 
@@ -202,7 +208,7 @@ function MeshInfrastructureContent() {
             <div className="h-[600px] w-full">
               <NodesAndConstellationsMap
                 observedNodes={nodesWithLocation}
-                managedNodes={managedNodes}
+                managedNodes={managedNodesForMap}
                 showConstellation={true}
                 showUnmanagedNodes={true}
                 drawPositionUncertainty={true}

--- a/src/pages/nodes/NodesList.tsx
+++ b/src/pages/nodes/NodesList.tsx
@@ -11,6 +11,7 @@ import { Card, CardHeader, CardTitle, CardContent } from '@/components/ui/card';
 import { Button } from '@/components/ui/button';
 import { ObservedNode } from '@/lib/models';
 import { Link } from 'react-router-dom';
+import { filterManagedNodesForMapDisplay } from '@/lib/managed-node-status';
 import { StaleReportedTime } from '@/components/nodes/StaleReportedTime';
 
 type TimeRangeOption = '2h' | '24h' | '7d' | '30d' | 'all';
@@ -82,7 +83,8 @@ function NodesListContent() {
     pageSize: 100,
   });
 
-  const { managedNodes } = useManagedNodesSuspense({ pageSize: 500 });
+  const { managedNodes } = useManagedNodesSuspense({ pageSize: 500, includeStatus: true });
+  const managedNodesForMap = useMemo(() => filterManagedNodesForMapDisplay(managedNodes), [managedNodes]);
 
   const sortNodes = (nodes: ObservedNode[]) => {
     return [...nodes].sort((a, b) => {
@@ -188,7 +190,7 @@ function NodesListContent() {
         <CardContent>
           <div className="h-[600px] w-full">
             <NodesAndConstellationsMap
-              managedNodes={managedNodes}
+              managedNodes={managedNodesForMap}
               observedNodes={mapNodes}
               showConstellation={true}
               showUnmanagedNodes={true}

--- a/src/pages/traceroutes/TriggerTracerouteModal.test.tsx
+++ b/src/pages/traceroutes/TriggerTracerouteModal.test.tsx
@@ -56,6 +56,7 @@ function makeManagedNode(overrides: Partial<ManagedNode> = {}): ManagedNode {
     long_name: 'Source',
     short_name: 'SRC',
     last_heard: null,
+    last_packet_ingested_at: new Date('2026-01-01T00:00:00Z'),
     node_id_str: '!00000007',
     owner: { id: 1, username: 'me' },
     constellation: { id: 1, name: 'C1' },

--- a/src/pages/traceroutes/TriggerTracerouteModal.tsx
+++ b/src/pages/traceroutes/TriggerTracerouteModal.tsx
@@ -16,6 +16,7 @@ import { NodesAndConstellationsMap, MapNode } from '@/components/nodes/NodesAndC
 import { AutoTargetPreviewMap } from '@/components/traceroutes/AutoTargetPreviewMap';
 import { ToggleGroup, ToggleGroupItem } from '@/components/ui/toggle-group';
 import { ManagedNode, ObservedNode } from '@/lib/models';
+import { filterManagedNodesForMapDisplay } from '@/lib/managed-node-status';
 import { observedNodeHeardOnOrAfter, pickTargetLastHeardCutoff } from '@/lib/observed-node-recency';
 import type { TargetPreviewStrategy } from '@/lib/tracerouteTargetGeometry';
 import { Tooltip, TooltipContent, TooltipProvider, TooltipTrigger } from '@/components/ui/tooltip';
@@ -86,7 +87,9 @@ export function TriggerTracerouteModal({
   const geo = selectedManaged?.geo_classification;
   const canIntraZone = geo?.applicable_strategies?.includes('intra_zone') ?? false;
 
-  const managedNodeIdSet = useMemo(() => new Set(managedNodes.map((m) => m.node_id)), [managedNodes]);
+  const managedNodesForMap = useMemo(() => filterManagedNodesForMapDisplay(managedNodes), [managedNodes]);
+
+  const managedNodeIdSet = useMemo(() => new Set(managedNodesForMap.map((m) => m.node_id)), [managedNodesForMap]);
 
   const [pickTargetLastHeardAfter, setPickTargetLastHeardAfter] = useState(() => pickTargetLastHeardCutoff());
 
@@ -144,7 +147,7 @@ export function TriggerTracerouteModal({
   // Clicking anything else (e.g. the fixed target itself) is a no-op.
   const handleFixedTargetMapNodeSelect = (node: MapNode | null) => {
     if (!node) return false;
-    const isManaged = managedNodes.some((m) => m.node_id === node.node_id);
+    const isManaged = managedNodesForMap.some((m) => m.node_id === node.node_id);
     if (!isManaged) return false;
     setManagedNodeId(node.node_id);
     return true;
@@ -288,7 +291,7 @@ export function TriggerTracerouteModal({
                 </p>
                 <div className="h-[300px] rounded-md border overflow-hidden">
                   <NodesAndConstellationsMap
-                    managedNodes={managedNodes}
+                    managedNodes={managedNodesForMap}
                     observedNodes={[fixedTargetNode]}
                     showConstellation={true}
                     showUnmanagedNodes={true}
@@ -326,7 +329,7 @@ export function TriggerTracerouteModal({
                 </p>
                 <div className="h-[300px] rounded-md border overflow-hidden">
                   <NodesAndConstellationsMap
-                    managedNodes={managedNodes}
+                    managedNodes={managedNodesForMap}
                     observedNodes={pickTargetObservedNodes}
                     showConstellation={true}
                     showUnmanagedNodes={true}


### PR DESCRIPTION
# Summary

- Add `hasManagedNodeEverFedData` and `filterManagedNodesForMapDisplay` using `last_packet_ingested_at` (requires `include=status` on managed-node fetches).
- Pass only feeding managed nodes into `NodesAndConstellationsMap` and `ConstellationsMap` (dashboard, node map, nodes list, mesh infrastructure, managed nodes status map, claim flow, trigger-traceroute modal maps).
- Lists and the Managed Nodes table still use the full managed-node set so “Never reported” remains visible for operators.

Closes #214

Related: meshflow-api #212 (feeder semantics).

## Testing performed

- `npm test -- --run`
- `npm run lint` (warnings only, pre-existing)
- `npm run build`
- `npm run format`
