### PR TITLE
fix(nodes): My Nodes managed liveness and GPS position hints (closes #200)

### DIFF
--- a/src/components/nodes/MyNodeCard.test.tsx
+++ b/src/components/nodes/MyNodeCard.test.tsx
@@ -1,11 +1,14 @@
 import type { ComponentProps } from 'react';
-import { describe, it, expect, vi } from 'vitest';
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
 import { render, screen } from '@testing-library/react';
 import { MemoryRouter } from 'react-router-dom';
 import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
 import type { ObservedNode } from '@/lib/models';
 
 import { MyNodeCard } from './MyNodeCard';
+import { MY_NODES_CLAIMED_RECENT_MS } from '@/lib/my-nodes-grouping';
+
+const NOW = new Date('2026-04-21T12:00:00.000Z');
 
 vi.mock('@/components/nodes/MeshWatchControls', () => ({
   MeshWatchControls: () => <div data-testid="mesh-watch">watch</div>,
@@ -64,7 +67,9 @@ describe('MyNodeCard', () => {
 
   it('shows No GPS position when coords missing', () => {
     renderCard({ node: makeNode({ latest_position: null }) });
-    expect(screen.getByText('No GPS position')).toBeInTheDocument();
+    const badge = screen.getByText('No GPS position');
+    expect(badge).toBeInTheDocument();
+    expect(badge.className).toMatch(/border-destructive/);
   });
 
   it('shows GPS position recent for fresh reported_time', () => {
@@ -103,5 +108,33 @@ describe('MyNodeCard', () => {
     });
     expect(screen.queryByText('Attention')).not.toBeInTheDocument();
     expect(screen.queryByText('Connectivity issue')).not.toBeInTheDocument();
+  });
+});
+
+describe('MyNodeCard position hint styling (fixed clock)', () => {
+  beforeEach(() => {
+    vi.useFakeTimers();
+    vi.setSystemTime(NOW);
+  });
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  it('applies warning-style border to stale GPS copy', () => {
+    const old = new Date(NOW.getTime() - MY_NODES_CLAIMED_RECENT_MS - 60_000);
+    renderCard({
+      node: makeNode({
+        latest_position: {
+          latitude: 1,
+          longitude: 2,
+          reported_time: old,
+          logged_time: null,
+          altitude: null,
+          location_source: 'gps',
+        },
+      }),
+    });
+    const badge = screen.getByText('GPS position stale (>7d)');
+    expect(badge.className).toMatch(/border-amber/);
   });
 });

--- a/src/components/nodes/MyNodeCard.tsx
+++ b/src/components/nodes/MyNodeCard.tsx
@@ -17,8 +17,19 @@ import {
 } from '@/components/ui/dropdown-menu';
 import { Tooltip, TooltipContent, TooltipProvider, TooltipTrigger } from '@/components/ui/tooltip';
 import type { ObservedNode, NodeWatch, PaginatedResponse } from '@/lib/models';
-import type { ManagedLiveness } from '@/lib/my-nodes-grouping';
+import { cn } from '@/lib/utils';
+import type { ManagedLiveness, PositionHintTreatment } from '@/lib/my-nodes-grouping';
 import { getPositionHint } from '@/lib/my-nodes-grouping';
+
+function positionTreatmentBadgeClass(t: PositionHintTreatment): string | undefined {
+  if (t === 'stale') {
+    return 'border-amber-500/70 bg-amber-50/90 text-amber-950 shadow-sm dark:border-amber-500/50 dark:bg-amber-950/35 dark:text-amber-50';
+  }
+  if (t === 'missing') {
+    return 'border-destructive/60 bg-destructive/10 text-destructive font-medium dark:border-destructive/50 dark:bg-destructive/15 dark:text-destructive';
+  }
+  return undefined;
+}
 
 export interface MyNodeCardProps {
   node: ObservedNode;
@@ -50,6 +61,7 @@ export function MyNodeCard({
   const voltage = metrics?.voltage != null ? metrics.voltage : null;
   const metricsReported = metrics?.reported_time ? new Date(metrics.reported_time) : null;
   const positionHint = getPositionHint(node);
+  const positionBadgeClass = positionTreatmentBadgeClass(positionHint.treatment);
   const displayName = node.short_name || node.node_id_str;
   const liveness =
     managedLiveness != null && managedLiveness.severity !== 'ok' && managedLiveness.message != null
@@ -130,7 +142,10 @@ export function MyNodeCard({
             <Tooltip>
               <TooltipTrigger asChild>
                 <span className="inline-flex max-w-full">
-                  <Badge variant="secondary" className="text-xs cursor-default">
+                  <Badge
+                    variant={positionHint.treatment === 'missing' ? 'outline' : 'secondary'}
+                    className={cn('text-xs cursor-default', positionBadgeClass)}
+                  >
                     {positionHint.label}
                   </Badge>
                 </span>

--- a/src/lib/my-nodes-grouping.test.ts
+++ b/src/lib/my-nodes-grouping.test.ts
@@ -151,6 +151,33 @@ describe('getManagedLiveness', () => {
     expect(r.message).toMatch(/Feeder not reporting/);
   });
 
+  it('is ok when last_packet_ingested_at is missing but radio is fresh (no false feeder warning)', () => {
+    const radio = new Date(NOW.getTime() - 60_000);
+    const r = getManagedLiveness(
+      {
+        last_packet_ingested_at: null,
+        radio_last_heard: radio,
+        last_heard: new Date(0),
+      },
+      NOW
+    );
+    expect(r.severity).toBe('ok');
+    expect(r.message).toBeNull();
+  });
+
+  it('is ok when last_packet_ingested_at is undefined and last_heard is fresh', () => {
+    const r = getManagedLiveness(
+      {
+        last_packet_ingested_at: undefined,
+        radio_last_heard: null,
+        last_heard: new Date(NOW.getTime() - 60_000),
+      },
+      NOW
+    );
+    expect(r.severity).toBe('ok');
+    expect(r.message).toBeNull();
+  });
+
   it('warns when feeder fresh and radio stale', () => {
     const feeder = new Date(NOW.getTime() - 60_000);
     const radio = new Date(NOW.getTime() - MY_NODES_CLAIMED_ONLINE_MS - 60_000);
@@ -206,7 +233,9 @@ describe('getPositionHint', () => {
 
   it('returns No GPS position for missing coords', () => {
     const n = makeObserved({ latest_position: { latitude: 0, longitude: 0 } as ObservedNode['latest_position'] });
-    expect(getPositionHint(n, NOW).label).toBe('No GPS position');
+    const h = getPositionHint(n, NOW);
+    expect(h.label).toBe('No GPS position');
+    expect(h.treatment).toBe('missing');
   });
 
   it('returns stale when reported_time older than 7d', () => {
@@ -221,7 +250,23 @@ describe('getPositionHint', () => {
         location_source: 'gps',
       },
     });
-    expect(getPositionHint(n, NOW).label).toBe('GPS position stale (>7d)');
+    const h = getPositionHint(n, NOW);
+    expect(h.label).toBe('GPS position stale (>7d)');
+    expect(h.treatment).toBe('stale');
+  });
+
+  it('marks recent position as ok treatment', () => {
+    const n = makeObserved({
+      latest_position: {
+        latitude: 1,
+        longitude: 2,
+        reported_time: new Date(NOW.getTime() - 60_000),
+        logged_time: null,
+        altitude: null,
+        location_source: 'gps',
+      },
+    });
+    expect(getPositionHint(n, NOW).treatment).toBe('ok');
   });
 });
 

--- a/src/lib/my-nodes-grouping.ts
+++ b/src/lib/my-nodes-grouping.ts
@@ -24,10 +24,14 @@ export interface ManagedLiveness {
   message: string | null;
 }
 
+/** Visual band for position copy on MyNodeCard (aligns with StaleReportedTime-style treatments). */
+export type PositionHintTreatment = 'ok' | 'stale' | 'missing';
+
 export interface PositionHint {
   label: string;
   /** Shown in tooltip when useful (e.g. exact relative age). */
   tooltip: string | null;
+  treatment: PositionHintTreatment;
 }
 
 function parseDate(value: Date | string | null | undefined): Date | null {
@@ -95,23 +99,28 @@ export function managedRadioActivityAt(
 
 /**
  * Dual-signal liveness for managed nodes on My Nodes.
- * Feeder fresh = `last_packet_ingested_at` within 10m.
+ * Feeder fresh = `last_packet_ingested_at` within 10m (when the field is present).
  * Radio fresh = `radio_last_heard` (or `last_heard`) within 2h.
+ *
+ * When `last_packet_ingested_at` is missing (e.g. API omitted status) but radio activity
+ * is within the same “online” window as claimed nodes, we do not show a feeder warning —
+ * mesh recency is the user-visible signal.
  */
 export function getManagedLiveness(
   node: Pick<ManagedNode, 'last_packet_ingested_at' | 'radio_last_heard' | 'last_heard'>,
   now: Date = new Date()
 ): ManagedLiveness {
-  const feederFresh = isFresh(node.last_packet_ingested_at, MY_NODES_FEEDER_FRESH_MS, now);
+  const noIngestedAt = node.last_packet_ingested_at == null;
+  const feederFresh = !noIngestedAt && isFresh(node.last_packet_ingested_at, MY_NODES_FEEDER_FRESH_MS, now);
   const radioAt = managedRadioActivityAt(node);
   const radioFresh = isFresh(radioAt, MY_NODES_CLAIMED_ONLINE_MS, now);
 
+  if (radioFresh && (feederFresh || noIngestedAt)) {
+    return { feeder: 'fresh', radio: 'fresh', severity: 'ok', message: null };
+  }
+
   const feeder: 'fresh' | 'stale' = feederFresh ? 'fresh' : 'stale';
   const radio: 'fresh' | 'stale' = radioFresh ? 'fresh' : 'stale';
-
-  if (feederFresh && radioFresh) {
-    return { feeder, radio, severity: 'ok', message: null };
-  }
 
   const feederAge = agePhrase(node.last_packet_ingested_at);
   const radioAge = agePhrase(radioAt);
@@ -160,12 +169,12 @@ export function getPositionHint(node: ObservedNode, now: Date = new Date()): Pos
     | undefined;
 
   if (!pos) {
-    return { label: 'No GPS position', tooltip: null };
+    return { label: 'No GPS position', tooltip: null, treatment: 'missing' };
   }
   const lat = pos.latitude;
   const lon = pos.longitude;
   if (!hasValidCoords(lat, lon)) {
-    return { label: 'No GPS position', tooltip: null };
+    return { label: 'No GPS position', tooltip: null, treatment: 'missing' };
   }
 
   const reported = parseDate(pos.reported_time ?? null);
@@ -173,6 +182,7 @@ export function getPositionHint(node: ObservedNode, now: Date = new Date()): Pos
     return {
       label: 'GPS position recent',
       tooltip: 'Position reported; no exact timestamp on record.',
+      treatment: 'ok',
     };
   }
   const ageMs = now.getTime() - reported.getTime();
@@ -180,17 +190,20 @@ export function getPositionHint(node: ObservedNode, now: Date = new Date()): Pos
     return {
       label: 'GPS position recent',
       tooltip: `Reported ${formatRecencyRelative(reported)}`,
+      treatment: 'ok',
     };
   }
   if (ageMs <= POSITION_STALE_MS) {
     return {
       label: 'GPS position recent',
       tooltip: `Reported ${formatRecencyRelative(reported)}`,
+      treatment: 'ok',
     };
   }
   return {
     label: 'GPS position stale (>7d)',
     tooltip: `Reported ${formatRecencyRelative(reported)}`,
+    treatment: 'stale',
   };
 }
 

--- a/src/pages/nodes/MyNodes.test.tsx
+++ b/src/pages/nodes/MyNodes.test.tsx
@@ -183,6 +183,19 @@ describe('MyNodes', () => {
     expect(screen.getByText(/Managed node offline/)).toBeInTheDocument();
   });
 
+  it('does not show feeder-not-reporting when last_packet_ingested_at is missing but radio is fresh', () => {
+    const managed = makeManaged({
+      node_id: 8,
+      last_packet_ingested_at: null,
+      radio_last_heard: new Date(NOW.getTime() - 60_000),
+    });
+    useMyClaimedNodesSuspense.mockReturnValue({ myClaimedNodes: [] });
+    useMyManagedNodesSuspense.mockReturnValue({ myManagedNodes: [managed] });
+    renderMyNodes();
+    expect(screen.queryByText(/Feeder not reporting/)).not.toBeInTheDocument();
+    expect(screen.queryByText('Attention')).not.toBeInTheDocument();
+  });
+
   it('renders map section title and map component', () => {
     useMyClaimedNodesSuspense.mockReturnValue({ myClaimedNodes: [makeObserved()] });
     useMyManagedNodesSuspense.mockReturnValue({ myManagedNodes: [] });


### PR DESCRIPTION
## Summary

- **Feeder warning**: If `last_packet_ingested_at` is missing (e.g. API omitted status) but mesh activity (`radio_last_heard` or `last_heard`) is within the same 2h window we use for claimed “online” nodes, we no longer show the yellow “Feeder not reporting” / “last packet never” banner. A defined but stale `last_packet_ingested_at` with fresh radio still warns as before.
- **GPS copy**: `getPositionHint` now includes a `treatment` (`ok` | `stale` | `missing`). `MyNodeCard` uses amber border/background for stale and destructive styling for no-GPS, consistent with `StaleReportedTime`-style date bands. Dark mode uses the same token families for contrast.
- **Tests**: Extended `getManagedLiveness` and `getPositionHint` unit tests, `MyNodeCard` class checks, and a `MyNodes` test that a managed node with `last_packet_ingested_at: null` and fresh radio does not show the feeder warning.

Closes #200

## Testing performed

- `npm test -- --run`
- `npm run lint` (pre-existing warnings only; no new errors)
- `npm run format` before commit (husky pre-commit also ran lint + tests)