### PR TITLE
feat(dx-monitoring): staff DX visibility dashboard

### DIFF
--- a/docs/design-conventions.md
+++ b/docs/design-conventions.md
@@ -1,0 +1,17 @@
+# Design Conventions
+
+This document captures UI design conventions for Meshtastic Bot UI. It is intentionally small for now and will grow as we settle more patterns.
+
+## Node Labels
+
+When displaying nodes, prefer human-readable names as the primary label:
+
+- Use the short name, long name, or both where available.
+- Treat the Meshtastic string ID (`node_id_str`, for example `!12345678`) as supporting detail, not the main label.
+- Use the string ID as the fallback only when no short or long name is available.
+
+## Detail Views
+
+Use popup modals for focused detail views. Avoid slide-out drawers unless a future site-wide pattern deliberately introduces them.
+
+For example, traceroute detail uses a centered modal; similar inspection flows should follow that pattern for consistency.

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -27,6 +27,7 @@ import { UserPage } from '@/pages/user/UserPage';
 import { ProtectedRoute } from '@/components/auth/ProtectedRoute';
 import { AppLayout } from '@/components/layouts/AppLayout';
 import MonitorNodes from '@/pages/nodes/monitor';
+import DxMonitoringPage from '@/pages/nodes/DxMonitoringPage';
 
 const ManagedNodesStatus = lazy(() => import('@/pages/nodes/ManagedNodesStatus'));
 
@@ -64,6 +65,7 @@ function App() {
                   <Route path="/weather" element={<Weather />} />
                   <Route path="/nodes/my-nodes" element={<MyNodes />} />
                   <Route path="/nodes/monitor" element={<MonitorNodes />} />
+                  <Route path="/nodes/dx-monitoring" element={<DxMonitoringPage />} />
                   <Route path="/nodes/:id/claim" element={<ClaimNode />} />
                   <Route path="/nodes/:id" element={<NodeDetails />} />
                   <Route path="/map" element={<NodeMap />} />

--- a/src/components/nav-main.tsx
+++ b/src/components/nav-main.tsx
@@ -9,6 +9,7 @@ import {
   NetworkIcon,
   RadioIcon,
   RouteIcon,
+  ScanSearchIcon,
   ServerIcon,
   SignalIcon,
   type LucideIcon,
@@ -26,6 +27,7 @@ import {
   SidebarMenuSubItem,
 } from '@/components/ui/sidebar';
 import { useWebSocket } from '@/providers/WebSocketProvider';
+import { authService } from '@/lib/auth/authService';
 
 type NavChild = {
   title: string;
@@ -52,6 +54,7 @@ export function NavMain() {
   const { hasUnreadMessages, unreadMessages, markAllAsRead } = useWebSocket();
   const navigate = useNavigate();
   const { pathname } = useLocation();
+  const showDxMonitoring = Boolean(authService.getCurrentUser()?.is_staff);
 
   const handleMessagesClick = (e: React.MouseEvent<HTMLAnchorElement>) => {
     e.preventDefault();
@@ -70,6 +73,7 @@ export function NavMain() {
         { title: 'My nodes', url: '/nodes/my-nodes', icon: RadioIcon },
         { title: 'Managed nodes', url: '/nodes/managed-nodes', icon: ActivityIcon },
         { title: 'Watches', url: '/nodes/monitor', icon: ActivityIcon },
+        ...(showDxMonitoring ? [{ title: 'DX monitoring', url: '/nodes/dx-monitoring', icon: ScanSearchIcon }] : []),
         { title: 'Mesh infra', url: '/nodes/infrastructure', icon: ServerIcon },
       ],
     },

--- a/src/hooks/api/useDxMonitoring.ts
+++ b/src/hooks/api/useDxMonitoring.ts
@@ -1,0 +1,74 @@
+import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query';
+import { useMeshtasticApi } from './useApi';
+import type { DxEventsQueryParams } from '@/lib/types';
+
+export const dxEventsQueryKey = (params: DxEventsQueryParams) => ['dx', 'events', params] as const;
+
+export const dxEventDetailQueryKey = (id: string | null) => ['dx', 'event', id ?? ''] as const;
+
+const DX_POLL_MS = 60_000;
+const DX_STALE_MS = 30_000;
+
+export function useDxEvents(params: DxEventsQueryParams, enabled: boolean) {
+  const api = useMeshtasticApi();
+  return useQuery({
+    queryKey: dxEventsQueryKey(params),
+    queryFn: () => api.getDxEvents(params),
+    enabled,
+    refetchInterval: DX_POLL_MS,
+    staleTime: DX_STALE_MS,
+  });
+}
+
+export function useDxEventDetail(id: string | null, enabled: boolean) {
+  const api = useMeshtasticApi();
+  return useQuery({
+    queryKey: dxEventDetailQueryKey(id),
+    queryFn: () => api.getDxEvent(id!),
+    enabled: Boolean(enabled && id),
+    refetchInterval: DX_POLL_MS,
+    staleTime: DX_STALE_MS,
+  });
+}
+
+export function useDxActiveEventCount(enabled: boolean) {
+  const api = useMeshtasticApi();
+  return useQuery({
+    queryKey: ['dx', 'stats', 'active_now'] as const,
+    queryFn: () => api.getDxEvents({ active_now: true, page_size: 1, page: 1 }),
+    enabled,
+    select: (d) => d.count,
+    refetchInterval: DX_POLL_MS,
+    staleTime: DX_STALE_MS,
+  });
+}
+
+export function useDxRecentEventCount(enabled: boolean, recentDays = 7) {
+  const api = useMeshtasticApi();
+  return useQuery({
+    queryKey: ['dx', 'stats', 'recent', recentDays] as const,
+    queryFn: () =>
+      api.getDxEvents({
+        recent_only: true,
+        recent_days: recentDays,
+        page_size: 1,
+        page: 1,
+      }),
+    enabled,
+    select: (d) => d.count,
+    refetchInterval: DX_POLL_MS,
+    staleTime: DX_STALE_MS,
+  });
+}
+
+export function useDxNodeExclusionMutation() {
+  const api = useMeshtasticApi();
+  const queryClient = useQueryClient();
+  return useMutation({
+    mutationFn: (body: { node_id: number; exclude_from_detection: boolean; exclude_notes?: string }) =>
+      api.postDxNodeExclusion(body),
+    onSuccess: () => {
+      queryClient.invalidateQueries({ queryKey: ['dx'] });
+    },
+  });
+}

--- a/src/lib/api/meshtastic-api.ts
+++ b/src/lib/api/meshtastic-api.ts
@@ -24,6 +24,9 @@ import {
   DiscordNotificationPrefs,
   NodeWatch,
   MonitoringOfflineAfterResponse,
+  DxEventListItem,
+  DxEventDetail,
+  DxNodeExclusionResponse,
 } from '../models';
 import {
   ApiConfig,
@@ -31,6 +34,7 @@ import {
   DateRangeIntervalParams,
   PaginationParams,
   StatsSnapshotsParams,
+  DxEventsQueryParams,
 } from '@/lib/types';
 import { parseNodeWatchFromAPI, parseObservedNodeFromAPI } from './api-utils';
 import type { RfProfile, RfProfileUpdateBody, RfPropagationPollResult, RfPropagationRenderRow } from '@/lib/models';
@@ -1030,5 +1034,40 @@ export class MeshtasticApi extends BaseApi {
     body: { offline_after: number }
   ): Promise<MonitoringOfflineAfterResponse> {
     return this.patch<MonitoringOfflineAfterResponse>(`/monitoring/nodes/${observedNodeId}/offline-after/`, body);
+  }
+
+  // ===== DX monitoring (staff-only) =====
+
+  async getDxEvents(params?: DxEventsQueryParams): Promise<PaginatedResponse<DxEventListItem>> {
+    const searchParams = new URLSearchParams();
+    if (params?.page) searchParams.append('page', params.page.toString());
+    if (params?.page_size) searchParams.append('page_size', params.page_size.toString());
+    if (params?.state) searchParams.append('state', params.state);
+    if (params?.reason_code) searchParams.append('reason_code', params.reason_code);
+    if (params?.constellation != null) searchParams.append('constellation', String(params.constellation));
+    if (params?.destination_node_id != null) {
+      searchParams.append('destination_node_id', String(params.destination_node_id));
+    }
+    if (params?.last_observer_id) searchParams.append('last_observer_id', params.last_observer_id);
+    if (params?.active_now) searchParams.append('active_now', 'true');
+    if (params?.recent_only) searchParams.append('recent_only', 'true');
+    if (params?.recent_days != null) searchParams.append('recent_days', String(params.recent_days));
+    if (params?.last_observed_after) searchParams.append('last_observed_after', params.last_observed_after);
+    if (params?.last_observed_before) searchParams.append('last_observed_before', params.last_observed_before);
+    if (params?.first_observed_after) searchParams.append('first_observed_after', params.first_observed_after);
+    if (params?.first_observed_before) searchParams.append('first_observed_before', params.first_observed_before);
+    return this.get<PaginatedResponse<DxEventListItem>>('/dx/events/', searchParams);
+  }
+
+  async getDxEvent(id: string): Promise<DxEventDetail> {
+    return this.get<DxEventDetail>(`/dx/events/${id}/`);
+  }
+
+  async postDxNodeExclusion(body: {
+    node_id: number;
+    exclude_from_detection: boolean;
+    exclude_notes?: string;
+  }): Promise<DxNodeExclusionResponse> {
+    return this.post<DxNodeExclusionResponse>('/dx/nodes/exclusion/', body);
   }
 }

--- a/src/lib/auth/authService.ts
+++ b/src/lib/auth/authService.ts
@@ -25,6 +25,8 @@ export interface User {
   email?: string;
   first_name?: string;
   last_name?: string;
+  /** From `/api/auth/user/`; staff may access DX monitoring APIs. */
+  is_staff?: boolean;
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
   [key: string]: any; // For any additional fields
 }

--- a/src/lib/models.ts
+++ b/src/lib/models.ts
@@ -537,3 +537,73 @@ export interface NodeWatch {
   enabled: boolean;
   created_at: string;
 }
+
+/** DX monitoring (meshflow-api `/api/dx/`, staff-only). */
+export type DxReasonCode = 'new_distant_node' | 'returned_dx_node' | 'distant_observation';
+export type DxEventState = 'active' | 'closed';
+
+export interface DxNodeMetadataPublic {
+  exclude_from_detection: boolean;
+  exclude_notes: string;
+  updated_at: string | null;
+}
+
+export interface DxDestinationNode {
+  internal_id: string;
+  node_id: number;
+  node_id_str: string;
+  short_name: string;
+  long_name: string;
+  dx_metadata: DxNodeMetadataPublic;
+}
+
+export interface DxManagedNodeMinimal {
+  internal_id: string;
+  node_id: number;
+  node_id_str: string;
+  name: string;
+}
+
+export interface DxConstellationMinimal {
+  id: number;
+  name: string;
+}
+
+export interface DxEventListItem {
+  id: string;
+  constellation: DxConstellationMinimal;
+  destination: DxDestinationNode;
+  reason_code: DxReasonCode;
+  state: DxEventState;
+  first_observed_at: string;
+  last_observed_at: string;
+  active_until: string;
+  observation_count: number;
+  last_observer: DxManagedNodeMinimal | null;
+  best_distance_km: number | null;
+  last_distance_km: number | null;
+  metadata: Record<string, unknown>;
+  evidence_count: number;
+}
+
+export interface DxEventObservationRow {
+  id: string;
+  observed_at: string;
+  distance_km: number | null;
+  metadata: Record<string, unknown>;
+  observer: DxManagedNodeMinimal;
+  raw_packet: string;
+  packet_observation: number;
+}
+
+export interface DxEventDetail extends DxEventListItem {
+  observations: DxEventObservationRow[];
+}
+
+export interface DxNodeExclusionResponse {
+  node_id: number;
+  node_id_str: string;
+  exclude_from_detection: boolean;
+  exclude_notes: string;
+  updated_at: string | null;
+}

--- a/src/lib/types.ts
+++ b/src/lib/types.ts
@@ -28,6 +28,22 @@ export interface PaginationParams {
   last_heard_after?: Date;
 }
 
+/** Query params for GET `/api/dx/events/` (staff). */
+export interface DxEventsQueryParams extends PaginationParams {
+  state?: string;
+  reason_code?: string;
+  constellation?: number;
+  destination_node_id?: number;
+  last_observer_id?: string;
+  active_now?: boolean;
+  recent_only?: boolean;
+  recent_days?: number;
+  last_observed_after?: string;
+  last_observed_before?: string;
+  first_observed_after?: string;
+  first_observed_before?: string;
+}
+
 export interface ApiAuthConfig {
   type: 'none' | 'token' | 'basic' | 'oauth' | 'apiKey';
   token?: string;

--- a/src/pages/nodes/DxMonitoringPage.test.tsx
+++ b/src/pages/nodes/DxMonitoringPage.test.tsx
@@ -1,0 +1,61 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { render, screen } from '@testing-library/react';
+import { MemoryRouter } from 'react-router-dom';
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import type { DxEventListItem } from '@/lib/models';
+import DxMonitoringPage from './DxMonitoringPage';
+
+const getCurrentUser = vi.fn();
+
+vi.mock('@/lib/auth/authService', () => ({
+  authService: {
+    getCurrentUser: () => getCurrentUser(),
+  },
+}));
+
+const emptyPage = { count: 0, next: null, previous: null, results: [] as DxEventListItem[] };
+
+vi.mock('@/hooks/api/useDxMonitoring', () => ({
+  useDxEvents: vi.fn(() => ({
+    isLoading: false,
+    isSuccess: true,
+    isError: false,
+    error: null,
+    data: emptyPage,
+  })),
+  useDxActiveEventCount: vi.fn(() => ({ isLoading: false, data: 0 })),
+  useDxRecentEventCount: vi.fn(() => ({ isLoading: false, data: 0 })),
+  useDxEventDetail: vi.fn(() => ({ isLoading: false, isSuccess: false, data: undefined })),
+  useDxNodeExclusionMutation: vi.fn(() => ({ mutate: vi.fn(), isPending: false })),
+}));
+
+function renderPage() {
+  const client = new QueryClient({ defaultOptions: { queries: { retry: false } } });
+  return render(
+    <QueryClientProvider client={client}>
+      <MemoryRouter>
+        <DxMonitoringPage />
+      </MemoryRouter>
+    </QueryClientProvider>
+  );
+}
+
+describe('DxMonitoringPage', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    getCurrentUser.mockReturnValue({ id: 1, username: 'staff', is_staff: true });
+  });
+
+  it('shows staff-only message when user is not staff', () => {
+    getCurrentUser.mockReturnValue({ id: 2, username: 'user', is_staff: false });
+    renderPage();
+    expect(screen.getByText('DX monitoring')).toBeInTheDocument();
+    expect(screen.getByText(/staff only/i)).toBeInTheDocument();
+  });
+
+  it('renders dashboard heading for staff', () => {
+    renderPage();
+    expect(screen.getByRole('heading', { name: /DX monitoring/i })).toBeInTheDocument();
+    expect(screen.getByText(/Detection events and evidence/i)).toBeInTheDocument();
+  });
+});

--- a/src/pages/nodes/DxMonitoringPage.tsx
+++ b/src/pages/nodes/DxMonitoringPage.tsx
@@ -5,7 +5,7 @@ import { enGB } from 'date-fns/locale';
 import { toast } from 'sonner';
 import { ActivityIcon, RadioIcon } from 'lucide-react';
 import { authService } from '@/lib/auth/authService';
-import type { DxEventListItem, DxReasonCode } from '@/lib/models';
+import type { DxDestinationNode, DxEventListItem, DxManagedNodeMinimal, DxReasonCode } from '@/lib/models';
 import {
   useDxActiveEventCount,
   useDxEventDetail,
@@ -28,7 +28,6 @@ import {
 } from '@/components/ui/dialog';
 import { Label } from '@/components/ui/label';
 import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from '@/components/ui/select';
-import { Sheet, SheetContent, SheetDescription, SheetHeader, SheetTitle } from '@/components/ui/sheet';
 import { Table, TableBody, TableCell, TableHead, TableHeader, TableRow } from '@/components/ui/table';
 import { cn } from '@/lib/utils';
 
@@ -54,6 +53,45 @@ function httpStatus(err: unknown): number | undefined {
     return r?.status;
   }
   return undefined;
+}
+
+/** Primary line is short/long name; Meshtastic id is secondary when names exist, else sole label. */
+function formatDestinationLabel(dest: DxDestinationNode): { primary: string; idSecondary?: string } {
+  const long = dest.long_name?.trim();
+  const short = dest.short_name?.trim();
+  let primary = '';
+  if (long && short) {
+    primary = long === short ? long : `${long} (${short})`;
+  } else {
+    primary = long || short || '';
+  }
+  if (!primary) {
+    return { primary: dest.node_id_str };
+  }
+  return { primary, idSecondary: dest.node_id_str };
+}
+
+function formatObserverLabel(obs: DxManagedNodeMinimal): { primary: string; idSecondary?: string } {
+  const name = obs.name?.trim();
+  if (name) {
+    return { primary: name, idSecondary: obs.node_id_str };
+  }
+  return { primary: obs.node_id_str };
+}
+
+function NodeLinkLabel({ to, primary, idSecondary }: { to: string; primary: string; idSecondary?: string }) {
+  return (
+    <div className="flex flex-col gap-0.5 min-w-0">
+      <Link
+        to={to}
+        className="font-medium text-primary hover:underline truncate"
+        title={idSecondary ? `${primary} · ${idSecondary}` : primary}
+      >
+        {primary}
+      </Link>
+      {idSecondary ? <span className="text-xs text-muted-foreground tabular-nums">{idSecondary}</span> : null}
+    </div>
+  );
 }
 
 export default function DxMonitoringPage() {
@@ -108,7 +146,8 @@ export default function DxMonitoringPage() {
       },
       {
         onSuccess: () => {
-          toast.success(`Excluded ${excludeTarget.destination.node_id_str} from DX detection`);
+          const { primary } = formatDestinationLabel(excludeTarget.destination);
+          toast.success(`Excluded ${primary} from DX detection`);
           setExcludeTarget(null);
           setExcludeNotes('');
         },
@@ -135,6 +174,7 @@ export default function DxMonitoringPage() {
   }
 
   const listErr = listQuery.isError ? httpStatus(listQuery.error) : undefined;
+  const excludeDestLabel = excludeTarget ? formatDestinationLabel(excludeTarget.destination) : null;
 
   return (
     <div className="container mx-auto p-4 space-y-6">
@@ -299,16 +339,11 @@ export default function DxMonitoringPage() {
                         <Badge variant={row.state === 'active' ? 'default' : 'secondary'}>{row.state}</Badge>
                       </TableCell>
                       <TableCell>
-                        <div className="flex flex-col gap-1">
-                          <Link
+                        <div className="flex flex-col gap-1 max-w-[16rem]">
+                          <NodeLinkLabel
                             to={`/nodes/${row.destination.node_id}`}
-                            className="font-medium text-primary hover:underline"
-                          >
-                            {row.destination.node_id_str}
-                          </Link>
-                          <span className="text-xs text-muted-foreground truncate max-w-[12rem]">
-                            {row.destination.long_name || row.destination.short_name}
-                          </span>
+                            {...formatDestinationLabel(row.destination)}
+                          />
                           {row.destination.dx_metadata.exclude_from_detection && (
                             <Badge variant="outline" className="w-fit text-xs">
                               Excluded from DX
@@ -316,9 +351,12 @@ export default function DxMonitoringPage() {
                           )}
                         </div>
                       </TableCell>
-                      <TableCell className="text-sm">
+                      <TableCell className="text-sm max-w-[12rem]">
                         {row.last_observer ? (
-                          <span className="tabular-nums">{row.last_observer.node_id_str}</span>
+                          <NodeLinkLabel
+                            to={`/nodes/${row.last_observer.node_id}`}
+                            {...formatObserverLabel(row.last_observer)}
+                          />
                         ) : (
                           <span className="text-muted-foreground">—</span>
                         )}
@@ -373,36 +411,34 @@ export default function DxMonitoringPage() {
         </Card>
       )}
 
-      <Sheet open={Boolean(detailId)} onOpenChange={(o) => !o && closeDetail()}>
-        <SheetContent className="w-full sm:max-w-lg overflow-y-auto">
-          <SheetHeader>
-            <SheetTitle>DX event</SheetTitle>
-            <SheetDescription>Evidence rows and destination metadata.</SheetDescription>
-          </SheetHeader>
+      <Dialog open={Boolean(detailId)} onOpenChange={(o) => !o && closeDetail()}>
+        <DialogContent className="max-w-2xl max-h-[90vh] overflow-y-auto">
+          <DialogHeader>
+            <DialogTitle>DX event</DialogTitle>
+            <DialogDescription>Evidence rows and destination metadata.</DialogDescription>
+          </DialogHeader>
           {detailQuery.isLoading && (
             <div className="flex justify-center py-12">
               <div className="animate-spin rounded-full h-8 w-8 border-t-2 border-b-2 border-primary" />
             </div>
           )}
           {detailQuery.isSuccess && detailQuery.data && (
-            <div className="mt-6 space-y-4 text-sm">
+            <div className="mt-2 space-y-4 text-sm">
               <div>
                 <div className="text-muted-foreground">Reason</div>
                 <div className="font-medium">{formatReason(detailQuery.data.reason_code)}</div>
               </div>
               <div>
                 <div className="text-muted-foreground">Destination</div>
-                <Link
-                  to={`/nodes/${detailQuery.data.destination.node_id}`}
-                  className="font-medium text-primary hover:underline"
-                >
-                  {detailQuery.data.destination.node_id_str}
-                </Link>
-                {detailQuery.data.destination.dx_metadata.exclude_from_detection && (
-                  <Badge variant="outline" className="ml-2">
-                    Excluded from DX
-                  </Badge>
-                )}
+                <div className="flex flex-wrap items-center gap-2 mt-1">
+                  <NodeLinkLabel
+                    to={`/nodes/${detailQuery.data.destination.node_id}`}
+                    {...formatDestinationLabel(detailQuery.data.destination)}
+                  />
+                  {detailQuery.data.destination.dx_metadata.exclude_from_detection && (
+                    <Badge variant="outline">Excluded from DX</Badge>
+                  )}
+                </div>
               </div>
               {!detailQuery.data.destination.dx_metadata.exclude_from_detection && (
                 <Button type="button" variant="secondary" size="sm" onClick={() => setExcludeTarget(detailQuery.data)}>
@@ -428,33 +464,52 @@ export default function DxMonitoringPage() {
                         </TableCell>
                       </TableRow>
                     ) : (
-                      detailQuery.data.observations.map((o) => (
-                        <TableRow key={o.id}>
-                          <TableCell className="text-xs whitespace-nowrap">{formatWhen(o.observed_at)}</TableCell>
-                          <TableCell className="text-xs">{o.observer.node_id_str}</TableCell>
-                          <TableCell className="text-right tabular-nums">
-                            {o.distance_km != null ? o.distance_km.toFixed(1) : '—'}
-                          </TableCell>
-                          <TableCell className="font-mono text-xs break-all">{o.raw_packet}</TableCell>
-                        </TableRow>
-                      ))
+                      detailQuery.data.observations.map((o) => {
+                        const obsLabel = formatObserverLabel(o.observer);
+                        return (
+                          <TableRow key={o.id}>
+                            <TableCell className="text-xs whitespace-nowrap">{formatWhen(o.observed_at)}</TableCell>
+                            <TableCell className="text-xs max-w-[12rem]">
+                              <NodeLinkLabel
+                                to={`/nodes/${o.observer.node_id}`}
+                                primary={obsLabel.primary}
+                                idSecondary={obsLabel.idSecondary}
+                              />
+                            </TableCell>
+                            <TableCell className="text-right tabular-nums">
+                              {o.distance_km != null ? o.distance_km.toFixed(1) : '—'}
+                            </TableCell>
+                            <TableCell className="font-mono text-xs break-all">{o.raw_packet}</TableCell>
+                          </TableRow>
+                        );
+                      })
                     )}
                   </TableBody>
                 </Table>
               </div>
             </div>
           )}
-        </SheetContent>
-      </Sheet>
+        </DialogContent>
+      </Dialog>
 
       <Dialog open={Boolean(excludeTarget)} onOpenChange={(o) => !o && setExcludeTarget(null)}>
         <DialogContent>
           <DialogHeader>
             <DialogTitle>Exclude from DX detection?</DialogTitle>
             <DialogDescription>
-              Future DX candidate detection will ignore node{' '}
-              <span className="font-mono">{excludeTarget?.destination.node_id_str}</span>. Use for known mobile or noisy
-              stations.
+              Future DX candidate detection will ignore{' '}
+              {excludeDestLabel ? (
+                <>
+                  <span className="font-medium">{excludeDestLabel.primary}</span>
+                  {excludeDestLabel.idSecondary ? (
+                    <>
+                      {' '}
+                      (<span className="font-mono">{excludeDestLabel.idSecondary}</span>)
+                    </>
+                  ) : null}
+                </>
+              ) : null}
+              . Use for known mobile or noisy stations.
             </DialogDescription>
           </DialogHeader>
           <div className="space-y-2">

--- a/src/pages/nodes/DxMonitoringPage.tsx
+++ b/src/pages/nodes/DxMonitoringPage.tsx
@@ -1,0 +1,487 @@
+import { useMemo, useState } from 'react';
+import { Link } from 'react-router-dom';
+import { format } from 'date-fns';
+import { enGB } from 'date-fns/locale';
+import { toast } from 'sonner';
+import { ActivityIcon, RadioIcon } from 'lucide-react';
+import { authService } from '@/lib/auth/authService';
+import type { DxEventListItem, DxReasonCode } from '@/lib/models';
+import {
+  useDxActiveEventCount,
+  useDxEventDetail,
+  useDxEvents,
+  useDxNodeExclusionMutation,
+  useDxRecentEventCount,
+} from '@/hooks/api/useDxMonitoring';
+import type { DxEventsQueryParams } from '@/lib/types';
+import { Badge } from '@/components/ui/badge';
+import { Button } from '@/components/ui/button';
+import { Card, CardContent, CardDescription, CardHeader, CardTitle } from '@/components/ui/card';
+import { Checkbox } from '@/components/ui/checkbox';
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
+} from '@/components/ui/dialog';
+import { Label } from '@/components/ui/label';
+import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from '@/components/ui/select';
+import { Sheet, SheetContent, SheetDescription, SheetHeader, SheetTitle } from '@/components/ui/sheet';
+import { Table, TableBody, TableCell, TableHead, TableHeader, TableRow } from '@/components/ui/table';
+import { cn } from '@/lib/utils';
+
+const REASON_LABELS: Record<DxReasonCode, string> = {
+  new_distant_node: 'New distant node',
+  returned_dx_node: 'Returned DX node',
+  distant_observation: 'Distant observation',
+};
+
+function formatReason(code: string): string {
+  return REASON_LABELS[code as DxReasonCode] ?? code;
+}
+
+function formatWhen(iso: string): string {
+  const d = new Date(iso);
+  if (Number.isNaN(d.getTime())) return '—';
+  return format(d, 'PPp', { locale: enGB });
+}
+
+function httpStatus(err: unknown): number | undefined {
+  if (err && typeof err === 'object' && 'response' in err) {
+    const r = (err as { response?: { status?: number } }).response;
+    return r?.status;
+  }
+  return undefined;
+}
+
+export default function DxMonitoringPage() {
+  const user = authService.getCurrentUser();
+  const isStaff = Boolean(user?.is_staff);
+
+  const [stateFilter, setStateFilter] = useState<string>('');
+  const [reasonFilter, setReasonFilter] = useState<string>('');
+  const [recentOnly, setRecentOnly] = useState(true);
+  const [activeNow, setActiveNow] = useState(false);
+  const [page, setPage] = useState(1);
+  const pageSize = 50;
+
+  const listParams: DxEventsQueryParams = useMemo(() => {
+    const p: DxEventsQueryParams = { page, page_size: pageSize };
+    if (stateFilter) p.state = stateFilter;
+    if (reasonFilter) p.reason_code = reasonFilter;
+    if (recentOnly) {
+      p.recent_only = true;
+      p.recent_days = 7;
+    }
+    if (activeNow) p.active_now = true;
+    return p;
+  }, [stateFilter, reasonFilter, recentOnly, activeNow, page, pageSize]);
+
+  const listQuery = useDxEvents(listParams, isStaff);
+  const activeCountQuery = useDxActiveEventCount(isStaff);
+  const recentCountQuery = useDxRecentEventCount(isStaff, 7);
+
+  const [detailId, setDetailId] = useState<string | null>(null);
+  const detailQuery = useDxEventDetail(detailId, Boolean(detailId));
+
+  const [excludeTarget, setExcludeTarget] = useState<DxEventListItem | null>(null);
+  const [excludeNotes, setExcludeNotes] = useState('');
+  const exclusionMutation = useDxNodeExclusionMutation();
+
+  const openDetail = (row: DxEventListItem) => {
+    setDetailId(row.id);
+  };
+
+  const closeDetail = () => {
+    setDetailId(null);
+  };
+
+  const confirmExclude = () => {
+    if (!excludeTarget) return;
+    exclusionMutation.mutate(
+      {
+        node_id: excludeTarget.destination.node_id,
+        exclude_from_detection: true,
+        exclude_notes: excludeNotes.trim() || undefined,
+      },
+      {
+        onSuccess: () => {
+          toast.success(`Excluded ${excludeTarget.destination.node_id_str} from DX detection`);
+          setExcludeTarget(null);
+          setExcludeNotes('');
+        },
+        onError: () => {
+          toast.error('Could not update exclusion');
+        },
+      }
+    );
+  };
+
+  if (!isStaff) {
+    return (
+      <div className="container mx-auto max-w-lg p-6">
+        <Card>
+          <CardHeader>
+            <CardTitle>DX monitoring</CardTitle>
+            <CardDescription>
+              This dashboard is available to staff only. If you need access, contact a Meshflow administrator.
+            </CardDescription>
+          </CardHeader>
+        </Card>
+      </div>
+    );
+  }
+
+  const listErr = listQuery.isError ? httpStatus(listQuery.error) : undefined;
+
+  return (
+    <div className="container mx-auto p-4 space-y-6">
+      <div>
+        <h1 className="text-2xl font-bold flex items-center gap-2">
+          <RadioIcon className="h-7 w-7" aria-hidden />
+          DX monitoring
+        </h1>
+        <p className="text-sm text-muted-foreground mt-1">
+          Detection events and evidence (read-only). Exclude noisy or mobile destinations from future DX detection when
+          appropriate.
+        </p>
+      </div>
+
+      <div className="grid gap-4 md:grid-cols-3">
+        <Card>
+          <CardHeader className="pb-2">
+            <CardTitle className="text-base flex items-center gap-2">
+              <ActivityIcon className="h-4 w-4" />
+              Active now
+            </CardTitle>
+            <CardDescription>State active and within active_until</CardDescription>
+          </CardHeader>
+          <CardContent className="text-2xl font-semibold tabular-nums">
+            {activeCountQuery.isLoading ? '…' : (activeCountQuery.data ?? 0).toLocaleString()}
+          </CardContent>
+        </Card>
+        <Card>
+          <CardHeader className="pb-2">
+            <CardTitle className="text-base">Seen in last 7 days</CardTitle>
+            <CardDescription>Any event with activity in the rolling window</CardDescription>
+          </CardHeader>
+          <CardContent className="text-2xl font-semibold tabular-nums">
+            {recentCountQuery.isLoading ? '…' : (recentCountQuery.data ?? 0).toLocaleString()}
+          </CardContent>
+        </Card>
+        <Card>
+          <CardHeader className="pb-2">
+            <CardTitle className="text-base">Table page</CardTitle>
+            <CardDescription>Matches filters below (not global totals)</CardDescription>
+          </CardHeader>
+          <CardContent className="text-2xl font-semibold tabular-nums">
+            {listQuery.data?.count != null ? listQuery.data.count.toLocaleString() : '—'}
+          </CardContent>
+        </Card>
+      </div>
+
+      {listErr === 403 && (
+        <div className="rounded-lg border border-destructive/40 bg-destructive/5 px-4 py-3 text-sm text-destructive">
+          Your account does not have permission to load DX events (staff required).
+        </div>
+      )}
+
+      <Card>
+        <CardHeader>
+          <CardTitle className="text-lg">Filters</CardTitle>
+        </CardHeader>
+        <CardContent className="flex flex-wrap gap-6 items-end">
+          <div className="space-y-2 min-w-[140px]">
+            <Label>State</Label>
+            <Select
+              value={stateFilter || '__all__'}
+              onValueChange={(v) => {
+                setStateFilter(v === '__all__' ? '' : v);
+                setPage(1);
+              }}
+            >
+              <SelectTrigger>
+                <SelectValue placeholder="Any" />
+              </SelectTrigger>
+              <SelectContent>
+                <SelectItem value="__all__">Any</SelectItem>
+                <SelectItem value="active">Active</SelectItem>
+                <SelectItem value="closed">Closed</SelectItem>
+              </SelectContent>
+            </Select>
+          </div>
+          <div className="space-y-2 min-w-[200px]">
+            <Label>Reason</Label>
+            <Select
+              value={reasonFilter || '__all__'}
+              onValueChange={(v) => {
+                setReasonFilter(v === '__all__' ? '' : v);
+                setPage(1);
+              }}
+            >
+              <SelectTrigger>
+                <SelectValue placeholder="Any" />
+              </SelectTrigger>
+              <SelectContent>
+                <SelectItem value="__all__">Any</SelectItem>
+                <SelectItem value="new_distant_node">{REASON_LABELS.new_distant_node}</SelectItem>
+                <SelectItem value="returned_dx_node">{REASON_LABELS.returned_dx_node}</SelectItem>
+                <SelectItem value="distant_observation">{REASON_LABELS.distant_observation}</SelectItem>
+              </SelectContent>
+            </Select>
+          </div>
+          <label className="flex items-center gap-2 text-sm cursor-pointer">
+            <Checkbox
+              checked={recentOnly}
+              onCheckedChange={(v) => {
+                setRecentOnly(Boolean(v));
+                setPage(1);
+              }}
+            />
+            Last 7 days
+          </label>
+          <label className="flex items-center gap-2 text-sm cursor-pointer">
+            <Checkbox
+              checked={activeNow}
+              onCheckedChange={(v) => {
+                setActiveNow(Boolean(v));
+                setPage(1);
+              }}
+            />
+            Active now
+          </label>
+        </CardContent>
+      </Card>
+
+      {listQuery.isLoading && (
+        <div className="flex justify-center py-16">
+          <div className="animate-spin rounded-full h-8 w-8 border-t-2 border-b-2 border-primary" />
+        </div>
+      )}
+
+      {listQuery.isError && listErr !== 403 && (
+        <div className="text-center py-12 rounded-lg border border-destructive/50 text-destructive">
+          Could not load DX events.
+        </div>
+      )}
+
+      {listQuery.isSuccess && (
+        <Card>
+          <CardContent className="pt-6 overflow-x-auto">
+            <Table>
+              <TableHeader>
+                <TableRow>
+                  <TableHead>Reason</TableHead>
+                  <TableHead>State</TableHead>
+                  <TableHead>Destination</TableHead>
+                  <TableHead>Observer</TableHead>
+                  <TableHead>First seen</TableHead>
+                  <TableHead>Last seen</TableHead>
+                  <TableHead className="text-right">Evidence</TableHead>
+                  <TableHead className="text-right">Best km</TableHead>
+                  <TableHead />
+                </TableRow>
+              </TableHeader>
+              <TableBody>
+                {listQuery.data.results.length === 0 ? (
+                  <TableRow>
+                    <TableCell colSpan={9} className="text-center text-muted-foreground py-10">
+                      No events match these filters.
+                    </TableCell>
+                  </TableRow>
+                ) : (
+                  listQuery.data.results.map((row) => (
+                    <TableRow key={row.id}>
+                      <TableCell className="whitespace-nowrap">{formatReason(row.reason_code)}</TableCell>
+                      <TableCell>
+                        <Badge variant={row.state === 'active' ? 'default' : 'secondary'}>{row.state}</Badge>
+                      </TableCell>
+                      <TableCell>
+                        <div className="flex flex-col gap-1">
+                          <Link
+                            to={`/nodes/${row.destination.node_id}`}
+                            className="font-medium text-primary hover:underline"
+                          >
+                            {row.destination.node_id_str}
+                          </Link>
+                          <span className="text-xs text-muted-foreground truncate max-w-[12rem]">
+                            {row.destination.long_name || row.destination.short_name}
+                          </span>
+                          {row.destination.dx_metadata.exclude_from_detection && (
+                            <Badge variant="outline" className="w-fit text-xs">
+                              Excluded from DX
+                            </Badge>
+                          )}
+                        </div>
+                      </TableCell>
+                      <TableCell className="text-sm">
+                        {row.last_observer ? (
+                          <span className="tabular-nums">{row.last_observer.node_id_str}</span>
+                        ) : (
+                          <span className="text-muted-foreground">—</span>
+                        )}
+                      </TableCell>
+                      <TableCell className="text-xs whitespace-nowrap">{formatWhen(row.first_observed_at)}</TableCell>
+                      <TableCell className="text-xs whitespace-nowrap">{formatWhen(row.last_observed_at)}</TableCell>
+                      <TableCell className="text-right tabular-nums">{row.evidence_count}</TableCell>
+                      <TableCell className="text-right tabular-nums">
+                        {row.best_distance_km != null ? row.best_distance_km.toFixed(1) : '—'}
+                      </TableCell>
+                      <TableCell className="text-right space-x-2 whitespace-nowrap">
+                        <Button variant="outline" size="sm" type="button" onClick={() => openDetail(row)}>
+                          Detail
+                        </Button>
+                        {!row.destination.dx_metadata.exclude_from_detection && (
+                          <Button variant="secondary" size="sm" type="button" onClick={() => setExcludeTarget(row)}>
+                            Exclude
+                          </Button>
+                        )}
+                      </TableCell>
+                    </TableRow>
+                  ))
+                )}
+              </TableBody>
+            </Table>
+            <div className="flex justify-between items-center mt-4 text-sm text-muted-foreground">
+              <span>
+                Page {page} · {listQuery.data.results.length} rows
+              </span>
+              <div className="flex gap-2">
+                <Button
+                  type="button"
+                  variant="outline"
+                  size="sm"
+                  disabled={page <= 1}
+                  onClick={() => setPage((p) => Math.max(1, p - 1))}
+                >
+                  Previous
+                </Button>
+                <Button
+                  type="button"
+                  variant="outline"
+                  size="sm"
+                  disabled={!listQuery.data.next}
+                  onClick={() => setPage((p) => p + 1)}
+                >
+                  Next
+                </Button>
+              </div>
+            </div>
+          </CardContent>
+        </Card>
+      )}
+
+      <Sheet open={Boolean(detailId)} onOpenChange={(o) => !o && closeDetail()}>
+        <SheetContent className="w-full sm:max-w-lg overflow-y-auto">
+          <SheetHeader>
+            <SheetTitle>DX event</SheetTitle>
+            <SheetDescription>Evidence rows and destination metadata.</SheetDescription>
+          </SheetHeader>
+          {detailQuery.isLoading && (
+            <div className="flex justify-center py-12">
+              <div className="animate-spin rounded-full h-8 w-8 border-t-2 border-b-2 border-primary" />
+            </div>
+          )}
+          {detailQuery.isSuccess && detailQuery.data && (
+            <div className="mt-6 space-y-4 text-sm">
+              <div>
+                <div className="text-muted-foreground">Reason</div>
+                <div className="font-medium">{formatReason(detailQuery.data.reason_code)}</div>
+              </div>
+              <div>
+                <div className="text-muted-foreground">Destination</div>
+                <Link
+                  to={`/nodes/${detailQuery.data.destination.node_id}`}
+                  className="font-medium text-primary hover:underline"
+                >
+                  {detailQuery.data.destination.node_id_str}
+                </Link>
+                {detailQuery.data.destination.dx_metadata.exclude_from_detection && (
+                  <Badge variant="outline" className="ml-2">
+                    Excluded from DX
+                  </Badge>
+                )}
+              </div>
+              {!detailQuery.data.destination.dx_metadata.exclude_from_detection && (
+                <Button type="button" variant="secondary" size="sm" onClick={() => setExcludeTarget(detailQuery.data)}>
+                  Exclude destination from DX detection…
+                </Button>
+              )}
+              <div>
+                <div className="text-muted-foreground mb-2">Observations</div>
+                <Table>
+                  <TableHeader>
+                    <TableRow>
+                      <TableHead>Time</TableHead>
+                      <TableHead>Observer</TableHead>
+                      <TableHead className="text-right">km</TableHead>
+                      <TableHead>Raw packet</TableHead>
+                    </TableRow>
+                  </TableHeader>
+                  <TableBody>
+                    {detailQuery.data.observations.length === 0 ? (
+                      <TableRow>
+                        <TableCell colSpan={4} className="text-muted-foreground">
+                          No observations recorded.
+                        </TableCell>
+                      </TableRow>
+                    ) : (
+                      detailQuery.data.observations.map((o) => (
+                        <TableRow key={o.id}>
+                          <TableCell className="text-xs whitespace-nowrap">{formatWhen(o.observed_at)}</TableCell>
+                          <TableCell className="text-xs">{o.observer.node_id_str}</TableCell>
+                          <TableCell className="text-right tabular-nums">
+                            {o.distance_km != null ? o.distance_km.toFixed(1) : '—'}
+                          </TableCell>
+                          <TableCell className="font-mono text-xs break-all">{o.raw_packet}</TableCell>
+                        </TableRow>
+                      ))
+                    )}
+                  </TableBody>
+                </Table>
+              </div>
+            </div>
+          )}
+        </SheetContent>
+      </Sheet>
+
+      <Dialog open={Boolean(excludeTarget)} onOpenChange={(o) => !o && setExcludeTarget(null)}>
+        <DialogContent>
+          <DialogHeader>
+            <DialogTitle>Exclude from DX detection?</DialogTitle>
+            <DialogDescription>
+              Future DX candidate detection will ignore node{' '}
+              <span className="font-mono">{excludeTarget?.destination.node_id_str}</span>. Use for known mobile or noisy
+              stations.
+            </DialogDescription>
+          </DialogHeader>
+          <div className="space-y-2">
+            <Label htmlFor="dx-exclude-notes">Note (optional)</Label>
+            <textarea
+              id="dx-exclude-notes"
+              value={excludeNotes}
+              onChange={(e) => setExcludeNotes(e.target.value)}
+              placeholder="e.g. vehicle gateway"
+              rows={3}
+              className={cn(
+                'flex min-h-[80px] w-full rounded-md border border-input bg-transparent px-3 py-2 text-sm shadow-sm',
+                'placeholder:text-muted-foreground focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-ring',
+                'disabled:cursor-not-allowed disabled:opacity-50'
+              )}
+            />
+          </div>
+          <DialogFooter className="gap-2 sm:gap-0">
+            <Button type="button" variant="outline" onClick={() => setExcludeTarget(null)}>
+              Cancel
+            </Button>
+            <Button type="button" variant="destructive" disabled={exclusionMutation.isPending} onClick={confirmExclude}>
+              {exclusionMutation.isPending ? 'Saving…' : 'Exclude node'}
+            </Button>
+          </DialogFooter>
+        </DialogContent>
+      </Dialog>
+    </div>
+  );
+}


### PR DESCRIPTION
# Summary

Adds a staff-only **DX monitoring** page at `/nodes/dx-monitoring`: summary counts (active now, last 7 days), filterable event table with links to node detail, sheet with evidence rows and raw packet ids, and a confirmation dialog to exclude the destination node from DX detection via the API. Sidebar entry is shown only when `is_staff` is present on the cached user profile. TanStack Query polls DX endpoints on an interval.

Depends on meshflow API: https://github.com/pskillen/meshflow-api/pull/233

Tracks meshflow-api #222 and meshtastic-bot-ui #219; epic #217. Closes #219.

## Testing performed

- `npm run build`
- `npm run lint` (warnings only, pre-existing)
- `npx vitest run src/pages/nodes/DxMonitoringPage.test.tsx`