### PR TITLE
feat(dx-monitoring): traceroute distant hop reason label

### DIFF
--- a/src/lib/models.ts
+++ b/src/lib/models.ts
@@ -539,7 +539,7 @@ export interface NodeWatch {
 }
 
 /** DX monitoring (meshflow-api `/api/dx/`, staff-only). */
-export type DxReasonCode = 'new_distant_node' | 'returned_dx_node' | 'distant_observation';
+export type DxReasonCode = 'new_distant_node' | 'returned_dx_node' | 'distant_observation' | 'traceroute_distant_hop';
 export type DxEventState = 'active' | 'closed';
 
 export interface DxNodeMetadataPublic {

--- a/src/pages/nodes/DxMonitoringPage.tsx
+++ b/src/pages/nodes/DxMonitoringPage.tsx
@@ -35,6 +35,7 @@ const REASON_LABELS: Record<DxReasonCode, string> = {
   new_distant_node: 'New distant node',
   returned_dx_node: 'Returned DX node',
   distant_observation: 'Distant observation',
+  traceroute_distant_hop: 'Traceroute distant hop',
 };
 
 function formatReason(code: string): string {
@@ -269,6 +270,7 @@ export default function DxMonitoringPage() {
                 <SelectItem value="new_distant_node">{REASON_LABELS.new_distant_node}</SelectItem>
                 <SelectItem value="returned_dx_node">{REASON_LABELS.returned_dx_node}</SelectItem>
                 <SelectItem value="distant_observation">{REASON_LABELS.distant_observation}</SelectItem>
+                <SelectItem value="traceroute_distant_hop">{REASON_LABELS.traceroute_distant_hop}</SelectItem>
               </SelectContent>
             </Select>
           </div>


### PR DESCRIPTION
## Summary

- Extend `DxReasonCode` with `traceroute_distant_hop` (meshflow-api #231).
- Add staff DX monitoring page label and **Reason** filter option: **Traceroute distant hop**.

## Testing

- `npm test` (full suite via pre-commit)

Closes #219