### PR TITLE
feat(nodes): node lifecycle removal UI (unclaim / unmanage)

### DIFF
--- a/src/components/nodes/MyNodeCard.test.tsx
+++ b/src/components/nodes/MyNodeCard.test.tsx
@@ -1,6 +1,7 @@
 import type { ComponentProps } from 'react';
 import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
 import { render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
 import { MemoryRouter } from 'react-router-dom';
 import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
 import type { ObservedNode } from '@/lib/models';
@@ -48,6 +49,8 @@ function renderCard(props: Partial<ComponentProps<typeof MyNodeCard>> = {}) {
           watchesQuery={props.watchesQuery ?? { isLoading: false, isError: false }}
           onConvert={props.onConvert ?? vi.fn()}
           onShowSetupInstructions={props.onShowSetupInstructions ?? vi.fn()}
+          onRequestUnclaim={props.onRequestUnclaim}
+          onRequestUnmanage={props.onRequestUnmanage}
         />
       </MemoryRouter>
     </QueryClientProvider>
@@ -108,6 +111,24 @@ describe('MyNodeCard', () => {
     });
     expect(screen.queryByText('Attention')).not.toBeInTheDocument();
     expect(screen.queryByText('Connectivity issue')).not.toBeInTheDocument();
+  });
+
+  it('offers Unclaim from the menu for claimed-only nodes when onRequestUnclaim is set', async () => {
+    const user = userEvent.setup();
+    const onRequestUnclaim = vi.fn();
+    renderCard({ isManaged: false, isClaimed: true, onRequestUnclaim });
+    await user.click(screen.getByRole('button', { name: /More actions/i }));
+    await user.click(screen.getByRole('menuitem', { name: /Unclaim node/i }));
+    expect(onRequestUnclaim).toHaveBeenCalledTimes(1);
+  });
+
+  it('offers Unmanage from the menu for managed nodes when onRequestUnmanage is set', async () => {
+    const user = userEvent.setup();
+    const onRequestUnmanage = vi.fn();
+    renderCard({ isManaged: true, isClaimed: true, onRequestUnmanage });
+    await user.click(screen.getByRole('button', { name: /More actions/i }));
+    await user.click(screen.getByRole('menuitem', { name: /Unmanage node/i }));
+    expect(onRequestUnmanage).toHaveBeenCalledTimes(1);
   });
 });
 

--- a/src/components/nodes/MyNodeCard.tsx
+++ b/src/components/nodes/MyNodeCard.tsx
@@ -1,5 +1,15 @@
 import { Link } from 'react-router-dom';
-import { MoreVertical, Radio, Settings, ChevronRight, FileText, AlertTriangle, AlertCircle } from 'lucide-react';
+import {
+  MoreVertical,
+  Radio,
+  Settings,
+  ChevronRight,
+  FileText,
+  AlertTriangle,
+  AlertCircle,
+  UserX,
+  Unplug,
+} from 'lucide-react';
 import { StaleReportedTime } from '@/components/nodes/StaleReportedTime';
 import type { UseQueryResult } from '@tanstack/react-query';
 
@@ -43,6 +53,10 @@ export interface MyNodeCardProps {
   watchesQuery: Pick<UseQueryResult<PaginatedResponse<NodeWatch>>, 'isLoading' | 'isError'>;
   onConvert: () => void;
   onShowSetupInstructions: () => void;
+  /** When set, shows “Unclaim node” (claimed-only rows). */
+  onRequestUnclaim?: () => void;
+  /** When set, shows “Unmanage node” (managed rows). */
+  onRequestUnmanage?: () => void;
 }
 
 export function MyNodeCard({
@@ -55,6 +69,8 @@ export function MyNodeCard({
   watchesQuery,
   onConvert,
   onShowSetupInstructions,
+  onRequestUnclaim,
+  onRequestUnmanage,
 }: MyNodeCardProps) {
   const metrics = node.latest_device_metrics;
   const batteryLevel = metrics?.battery_level != null ? metrics.battery_level : null;
@@ -89,7 +105,7 @@ export function MyNodeCard({
                 <MoreVertical className="h-4 w-4" />
               </Button>
             </DropdownMenuTrigger>
-            <DropdownMenuContent align="end" className="w-48">
+            <DropdownMenuContent align="end" className="w-56">
               {!isManaged ? (
                 <DropdownMenuItem onSelect={() => onConvert()}>
                   <Radio className="mr-2 h-4 w-4" />
@@ -100,6 +116,24 @@ export function MyNodeCard({
                 <DropdownMenuItem onSelect={() => onShowSetupInstructions()}>
                   <FileText className="mr-2 h-4 w-4" />
                   Setup instructions
+                </DropdownMenuItem>
+              ) : null}
+              {onRequestUnmanage != null && isManaged ? (
+                <DropdownMenuItem
+                  className="text-destructive focus:text-destructive"
+                  onSelect={() => onRequestUnmanage()}
+                >
+                  <Unplug className="mr-2 h-4 w-4" />
+                  Unmanage node
+                </DropdownMenuItem>
+              ) : null}
+              {onRequestUnclaim != null && isClaimed && !isManaged ? (
+                <DropdownMenuItem
+                  className="text-destructive focus:text-destructive"
+                  onSelect={() => onRequestUnclaim()}
+                >
+                  <UserX className="mr-2 h-4 w-4" />
+                  Unclaim node
                 </DropdownMenuItem>
               ) : null}
             </DropdownMenuContent>

--- a/src/components/nodes/SetupManagedNode.tsx
+++ b/src/components/nodes/SetupManagedNode.tsx
@@ -1,3 +1,4 @@
+import axios from 'axios';
 import { useState, useEffect, useRef } from 'react';
 import { useNavigate } from 'react-router-dom';
 import { useMeshtasticApi } from '@/hooks/api/useApi';
@@ -31,6 +32,23 @@ interface SetupManagedNodeProps {
   node: ObservedNode;
   isOpen: boolean;
   onClose: () => void;
+}
+
+function formatManagedNodeCreateError(err: unknown): string {
+  if (axios.isAxiosError(err) && err.response?.data && typeof err.response.data === 'object') {
+    const data = err.response.data as Record<string, unknown>;
+    const nid = data.node_id;
+    if (Array.isArray(nid) && nid.length > 0) {
+      return String(nid[0]);
+    }
+    if (typeof nid === 'string') {
+      return nid;
+    }
+    if (data.detail != null) {
+      return String(data.detail);
+    }
+  }
+  return 'Failed to create managed node. Please try again.';
 }
 
 type SetupStep = 'constellation' | 'location' | 'channels' | 'api-key' | 'instructions';
@@ -301,7 +319,7 @@ export function SetupManagedNode({ node, isOpen, onClose }: SetupManagedNodeProp
       setCurrentStep('instructions');
     } catch (err) {
       console.error('Error creating managed node:', err);
-      setError('Failed to create managed node. Please try again.');
+      setError(formatManagedNodeCreateError(err));
     } finally {
       setIsLoading(false);
     }

--- a/src/hooks/api/useNodeClaims.ts
+++ b/src/hooks/api/useNodeClaims.ts
@@ -76,10 +76,33 @@ export function useCreateManagedNode() {
 
       return api.createManagedNode(data.nodeId, data.constellationId, data.name, currentUser.id, data.options);
     },
-    onSuccess: () => {
-      // Invalidate the managed nodes queries
+    onSuccess: (_data, variables) => {
       queryClient.invalidateQueries({ queryKey: ['managed-nodes'] });
       queryClient.invalidateQueries({ queryKey: ['managed-nodes', 'mine'] });
+      queryClient.invalidateQueries({ queryKey: ['observed-nodes', 'mine'] });
+      queryClient.invalidateQueries({ queryKey: ['nodes', variables.nodeId] });
+      queryClient.invalidateQueries({ queryKey: ['nodes', variables.nodeId, 'claim'] });
+      queryClient.invalidateQueries({ queryKey: ['api-keys'] });
+    },
+  });
+}
+
+/**
+ * Soft-delete a managed node (owner or staff); invalidates related queries.
+ */
+export function useDeleteManagedNode() {
+  const api = useMeshtasticApi();
+  const queryClient = useQueryClient();
+
+  return useMutation({
+    mutationFn: (nodeId: number) => api.deleteManagedNode(nodeId),
+    onSuccess: (_, nodeId) => {
+      queryClient.invalidateQueries({ queryKey: ['managed-nodes'] });
+      queryClient.invalidateQueries({ queryKey: ['managed-nodes', 'mine'] });
+      queryClient.invalidateQueries({ queryKey: ['nodes', nodeId] });
+      queryClient.invalidateQueries({ queryKey: ['nodes', nodeId, 'claim'] });
+      queryClient.invalidateQueries({ queryKey: ['api-keys'] });
+      queryClient.invalidateQueries({ queryKey: ['observed-nodes', 'mine'] });
     },
   });
 }
@@ -137,6 +160,9 @@ export function useCancelNodeClaim() {
       queryClient.invalidateQueries({ queryKey: ['nodes', nodeId, 'claim'] });
       queryClient.invalidateQueries({ queryKey: ['nodes', nodeId] });
       queryClient.invalidateQueries({ queryKey: ['observed-nodes', 'mine'] });
+      queryClient.invalidateQueries({ queryKey: ['managed-nodes'] });
+      queryClient.invalidateQueries({ queryKey: ['managed-nodes', 'mine'] });
+      queryClient.invalidateQueries({ queryKey: ['api-keys'] });
     },
   });
 }

--- a/src/lib/api/meshtastic-api.ts
+++ b/src/lib/api/meshtastic-api.ts
@@ -402,10 +402,16 @@ export class MeshtasticApi extends BaseApi {
   }
 
   /**
-   * Cancel / withdraw the current user's pending claim for a node
+   * Release the current user's claim on this observed node (`DELETE .../claim/`).
+   * Withdraws a pending claim or clears accepted ownership (`claimed_by`) when you own the claim.
    */
-  async cancelNodeClaim(nodeId: number): Promise<void> {
+  async releaseNodeClaim(nodeId: number): Promise<void> {
     await this.delete<void>(`/nodes/observed-nodes/${nodeId}/claim/`);
+  }
+
+  /** Same as {@link MeshtasticApi.releaseNodeClaim}. */
+  async cancelNodeClaim(nodeId: number): Promise<void> {
+    return this.releaseNodeClaim(nodeId);
   }
 
   /**
@@ -514,6 +520,14 @@ export class MeshtasticApi extends BaseApi {
     };
 
     return this.post<OwnedManagedNode>('/nodes/managed-nodes/', data);
+  }
+
+  /**
+   * Soft-delete (un-manage) a managed node: removes API-key links and hides the row from listings.
+   * Does not clear the observed-node claim.
+   */
+  async deleteManagedNode(nodeId: number): Promise<void> {
+    await this.delete<void>(`/nodes/managed-nodes/${nodeId}/`);
   }
 
   // ===== API Keys =====

--- a/src/pages/nodes/MyNodes.tsx
+++ b/src/pages/nodes/MyNodes.tsx
@@ -1,6 +1,7 @@
 import { useState, Suspense, useMemo } from 'react';
 import { useNavigate, Link } from 'react-router-dom';
 import { useMyClaimedNodesSuspense, useMyManagedNodesSuspense } from '@/hooks/api/useNodes';
+import { useCancelNodeClaim, useDeleteManagedNode } from '@/hooks/api/useNodeClaims';
 import { useNodeWatches } from '@/hooks/api/useNodeWatches';
 import { Card, CardHeader, CardTitle, CardContent, CardDescription } from '@/components/ui/card';
 import { Button } from '@/components/ui/button';
@@ -48,6 +49,10 @@ function MyNodesContent() {
   const api = useMeshtasticApi();
   const [showInstructionsNode, setShowInstructionsNode] = useState<ObservedNode | null>(null);
   const [instructionsModalOpen, setInstructionsModalOpen] = useState(false);
+  const [unclaimTarget, setUnclaimTarget] = useState<ObservedNode | null>(null);
+  const [unmanageTarget, setUnmanageTarget] = useState<{ nodeId: number; label: string } | null>(null);
+  const cancelClaimMutation = useCancelNodeClaim();
+  const deleteManagedMutation = useDeleteManagedNode();
   const { data: apiKeys } = useQuery({
     queryKey: ['api-keys'],
     queryFn: () => api.getApiKeys(),
@@ -190,6 +195,78 @@ function MyNodesContent() {
 
       {renderInstructionsModal()}
 
+      <Dialog open={unclaimTarget !== null} onOpenChange={(open) => !open && setUnclaimTarget(null)}>
+        <DialogContent>
+          <DialogHeader>
+            <DialogTitle>Unclaim this node?</DialogTitle>
+            <DialogDescription>
+              This releases your ownership claim. The node can stay visible as an observed node if the mesh still hears
+              it. You can claim it again later if it is unclaimed.
+            </DialogDescription>
+          </DialogHeader>
+          {cancelClaimMutation.isError ? (
+            <p className="text-sm text-destructive">Could not unclaim. Try again.</p>
+          ) : null}
+          <DialogFooter>
+            <Button type="button" variant="outline" onClick={() => setUnclaimTarget(null)}>
+              Cancel
+            </Button>
+            <Button
+              type="button"
+              variant="destructive"
+              disabled={cancelClaimMutation.isPending}
+              onClick={() => {
+                if (!unclaimTarget) return;
+                cancelClaimMutation.mutate(unclaimTarget.node_id, {
+                  onSuccess: () => setUnclaimTarget(null),
+                });
+              }}
+            >
+              {cancelClaimMutation.isPending ? 'Unclaiming…' : 'Unclaim node'}
+            </Button>
+          </DialogFooter>
+        </DialogContent>
+      </Dialog>
+
+      <Dialog open={unmanageTarget !== null} onOpenChange={(open) => !open && setUnmanageTarget(null)}>
+        <DialogContent>
+          <DialogHeader>
+            <DialogTitle>Unmanage this node?</DialogTitle>
+            <DialogDescription>
+              {unmanageTarget ? (
+                <>
+                  <span className="font-medium text-foreground">{unmanageTarget.label}</span>
+                  {' — '}
+                </>
+              ) : null}
+              Stops this radio from acting as a managed feeder and removes API-key associations for it. Your claim stays
+              active; use “Unclaim” separately if you want to release ownership too.
+            </DialogDescription>
+          </DialogHeader>
+          {deleteManagedMutation.isError ? (
+            <p className="text-sm text-destructive">Could not unmanage. Try again.</p>
+          ) : null}
+          <DialogFooter>
+            <Button type="button" variant="outline" onClick={() => setUnmanageTarget(null)}>
+              Cancel
+            </Button>
+            <Button
+              type="button"
+              variant="destructive"
+              disabled={deleteManagedMutation.isPending}
+              onClick={() => {
+                if (!unmanageTarget) return;
+                deleteManagedMutation.mutate(unmanageTarget.nodeId, {
+                  onSuccess: () => setUnmanageTarget(null),
+                });
+              }}
+            >
+              {deleteManagedMutation.isPending ? 'Removing…' : 'Unmanage node'}
+            </Button>
+          </DialogFooter>
+        </DialogContent>
+      </Dialog>
+
       {hasAnyNodes ? (
         <>
           {myManagedNodes.length > 0 ? (
@@ -222,6 +299,12 @@ function MyNodesContent() {
                           setShowInstructionsNode(node);
                           setInstructionsModalOpen(true);
                         }}
+                        onRequestUnmanage={() =>
+                          setUnmanageTarget({
+                            nodeId: managed.node_id,
+                            label: node.short_name || node.node_id_str,
+                          })
+                        }
                       />
                     );
                   })}
@@ -262,6 +345,7 @@ function MyNodesContent() {
                               setShowInstructionsNode(node);
                               setInstructionsModalOpen(true);
                             }}
+                            onRequestUnclaim={() => setUnclaimTarget(node)}
                           />
                         );
                       })}
@@ -295,6 +379,7 @@ function MyNodesContent() {
                               setShowInstructionsNode(node);
                               setInstructionsModalOpen(true);
                             }}
+                            onRequestUnclaim={() => setUnclaimTarget(node)}
                           />
                         );
                       })}
@@ -324,6 +409,7 @@ function MyNodesContent() {
                               setShowInstructionsNode(node);
                               setInstructionsModalOpen(true);
                             }}
+                            onRequestUnclaim={() => setUnclaimTarget(node)}
                           />
                         );
                       })}

--- a/src/pages/user/NodeSettings.tsx
+++ b/src/pages/user/NodeSettings.tsx
@@ -1,7 +1,7 @@
 import { useState, useEffect, useMemo, Suspense } from 'react';
 import { Link, useSearchParams } from 'react-router-dom';
 import { Card, CardContent, CardHeader, CardTitle, CardDescription } from '@/components/ui/card';
-import { useCancelNodeClaim, useUserClaims } from '@/hooks/api/useNodeClaims';
+import { useCancelNodeClaim, useDeleteManagedNode, useUserClaims } from '@/hooks/api/useNodeClaims';
 import { useConstellationChannels } from '@/hooks/api/useConstellations';
 import { useMyManagedNodesSuspense, useMyClaimedNodesSuspense } from '@/hooks/api/useNodes';
 import { Badge } from '@/components/ui/badge';
@@ -44,7 +44,10 @@ function NodeSettingsContent() {
     botDefaults?: { ignorePortnums?: string | null; hopLimit?: number | null };
   } | null>(null);
   const [cancelClaimForNodeId, setCancelClaimForNodeId] = useState<number | null>(null);
+  const [unclaimMyNodesTarget, setUnclaimMyNodesTarget] = useState<ObservedNode | null>(null);
+  const [unmanageManagedTarget, setUnmanageManagedTarget] = useState<OwnedManagedNode | null>(null);
   const cancelClaimMutation = useCancelNodeClaim();
+  const deleteManagedMutation = useDeleteManagedNode();
   const [searchParams, setSearchParams] = useSearchParams();
   const tabParam = searchParams.get('tab');
   const activeTab = ['nodes', 'pending-claims', 'managed'].includes(tabParam ?? '') ? tabParam! : 'nodes';
@@ -135,6 +138,14 @@ function NodeSettingsContent() {
                             Convert to Managed Node
                           </Button>
                         )}
+                        <Button
+                          onClick={() => setUnclaimMyNodesTarget(node)}
+                          size="sm"
+                          variant="outline"
+                          className="text-xs text-destructive border-destructive/40 hover:bg-destructive/10"
+                        >
+                          Unclaim node
+                        </Button>
                       </div>
                     </div>
                   ))}
@@ -285,6 +296,7 @@ function NodeSettingsContent() {
                             isLoadingApiKeys={isLoadingApiKeys}
                             handleCopyToClipboard={handleCopyToClipboard}
                             onShowSetupInstructions={setSetupInstructionsKey}
+                            onRequestUnmanage={() => setUnmanageManagedTarget(node)}
                           />
                         </AccordionContent>
                       </AccordionItem>
@@ -321,12 +333,79 @@ function NodeSettingsContent() {
         </TabsContent>
       </Tabs>
 
+      <Dialog open={unclaimMyNodesTarget !== null} onOpenChange={(open) => !open && setUnclaimMyNodesTarget(null)}>
+        <DialogContent>
+          <DialogHeader>
+            <DialogTitle>Unclaim this node?</DialogTitle>
+            <DialogDescription>
+              Releases your ownership claim. The node may still appear as observed if the mesh hears it. You can claim
+              again later if it is unclaimed.
+            </DialogDescription>
+          </DialogHeader>
+          {cancelClaimMutation.isError ? (
+            <p className="text-sm text-destructive">Could not unclaim. Try again.</p>
+          ) : null}
+          <DialogFooter>
+            <Button type="button" variant="outline" onClick={() => setUnclaimMyNodesTarget(null)}>
+              Cancel
+            </Button>
+            <Button
+              type="button"
+              variant="destructive"
+              disabled={cancelClaimMutation.isPending}
+              onClick={() => {
+                if (!unclaimMyNodesTarget) return;
+                cancelClaimMutation.mutate(unclaimMyNodesTarget.node_id, {
+                  onSuccess: () => setUnclaimMyNodesTarget(null),
+                });
+              }}
+            >
+              {cancelClaimMutation.isPending ? 'Unclaiming…' : 'Unclaim node'}
+            </Button>
+          </DialogFooter>
+        </DialogContent>
+      </Dialog>
+
+      <Dialog open={unmanageManagedTarget !== null} onOpenChange={(open) => !open && setUnmanageManagedTarget(null)}>
+        <DialogContent>
+          <DialogHeader>
+            <DialogTitle>Unmanage this node?</DialogTitle>
+            <DialogDescription>
+              Stops this radio from acting as a managed feeder and removes API-key associations. Your claim stays
+              active; use “Unclaim” on the My Nodes tab if you also want to release ownership.
+            </DialogDescription>
+          </DialogHeader>
+          {deleteManagedMutation.isError ? (
+            <p className="text-sm text-destructive">Could not unmanage. Try again.</p>
+          ) : null}
+          <DialogFooter>
+            <Button type="button" variant="outline" onClick={() => setUnmanageManagedTarget(null)}>
+              Cancel
+            </Button>
+            <Button
+              type="button"
+              variant="destructive"
+              disabled={deleteManagedMutation.isPending}
+              onClick={() => {
+                if (!unmanageManagedTarget) return;
+                deleteManagedMutation.mutate(unmanageManagedTarget.node_id, {
+                  onSuccess: () => setUnmanageManagedTarget(null),
+                });
+              }}
+            >
+              {deleteManagedMutation.isPending ? 'Removing…' : 'Unmanage node'}
+            </Button>
+          </DialogFooter>
+        </DialogContent>
+      </Dialog>
+
       <Dialog open={cancelClaimForNodeId !== null} onOpenChange={(open) => !open && setCancelClaimForNodeId(null)}>
         <DialogContent>
           <DialogHeader>
             <DialogTitle>Cancel this claim?</DialogTitle>
             <DialogDescription>
-              This withdraws your pending claim. You can start again later from the node page if you change your mind.
+              This withdraws your pending claim before it is accepted. You can start again later from the node page if
+              you change your mind.
             </DialogDescription>
           </DialogHeader>
           {cancelClaimMutation.isError && (
@@ -391,6 +470,7 @@ function ManagedNodeSettings({
   isLoadingApiKeys,
   handleCopyToClipboard,
   onShowSetupInstructions,
+  onRequestUnmanage,
 }: {
   node: OwnedManagedNode;
   nodeApiKeys: NodeApiKey[];
@@ -404,6 +484,7 @@ function ManagedNodeSettings({
       botDefaults?: { ignorePortnums?: string | null; hopLimit?: number | null };
     } | null
   ) => void;
+  onRequestUnmanage?: () => void;
 }) {
   const api = useMeshtasticApi();
   const queryClient = useQueryClient();
@@ -445,12 +526,23 @@ function ManagedNodeSettings({
 
   return (
     <div className="space-y-4 pt-2">
-      <div className="flex gap-2">
+      <div className="flex flex-wrap gap-2">
         <Link to={`/nodes/${node.node_id}`}>
           <Button variant="outline" size="sm">
             View Node Details
           </Button>
         </Link>
+        {onRequestUnmanage != null ? (
+          <Button
+            type="button"
+            variant="outline"
+            size="sm"
+            className="text-destructive border-destructive/40 hover:bg-destructive/10"
+            onClick={() => onRequestUnmanage()}
+          >
+            Unmanage node
+          </Button>
+        ) : null}
       </div>
 
       <div className="border rounded-md bg-slate-50/50 dark:bg-slate-900/30 overflow-hidden">


### PR DESCRIPTION
Implements [meshtastic-bot-ui#213](https://github.com/pskillen/meshtastic-bot-ui/issues/213).

## Summary

- **API client**: `releaseNodeClaim` / `cancelNodeClaim`, `deleteManagedNode`.
- **Hooks**: `useDeleteManagedNode`; broader invalidation for `useCancelNodeClaim` and `useCreateManagedNode` (managed nodes, observed mine, node detail, claims, API keys).
- **My Nodes**: Confirmation dialogs for unclaim and unmanage; card menu actions.
- **Node Settings**: Unclaim on My Nodes tab; unmanage on Managed tab; clarified pending cancel copy.
- **Convert to managed**: Surfaces API `node_id` validation errors (e.g. previously removed).

## API PR

- https://github.com/pskillen/meshflow-api/pull/238
