### PR TITLE
Fix misc UI bugs and RF propagation map behavior

### DIFF
--- a/src/components/nodes/InfrastructureNodeCard.test.tsx
+++ b/src/components/nodes/InfrastructureNodeCard.test.tsx
@@ -2,7 +2,7 @@ import { describe, it, expect, vi } from 'vitest';
 import { render, screen } from '@testing-library/react';
 import { MemoryRouter } from 'react-router-dom';
 import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
-import type { ObservedNode } from '@/lib/models';
+import type { ManagedNode, ObservedNode } from '@/lib/models';
 
 import { InfrastructureNodeCard } from './InfrastructureNodeCard';
 
@@ -13,12 +13,25 @@ vi.mock('@/hooks/api/useRfPropagation', () => ({
   useRecomputeRfPropagation: () => ({ mutateAsync: vi.fn(), isPending: false }),
 }));
 
-function renderCard(node: ObservedNode) {
+function minimalManaged(nodeId: number): ManagedNode {
+  return {
+    node_id: nodeId,
+    long_name: null,
+    short_name: null,
+    last_heard: null,
+    node_id_str: '!0',
+    owner: { id: 1, username: 'u' },
+    constellation: { id: 1 },
+    position: { latitude: null, longitude: null },
+  } as ManagedNode;
+}
+
+function renderCard(node: ObservedNode, opts?: { managedNode?: ManagedNode | null }) {
   const client = new QueryClient();
   return render(
     <QueryClientProvider client={client}>
       <MemoryRouter>
-        <InfrastructureNodeCard node={node} />
+        <InfrastructureNodeCard node={node} managedNode={opts?.managedNode ?? null} />
       </MemoryRouter>
     </QueryClientProvider>
   );
@@ -42,11 +55,15 @@ function makeNode(overrides: Partial<ObservedNode> = {}): ObservedNode {
 }
 
 describe('InfrastructureNodeCard', () => {
-  it('renders a deep-linked Coverage map link to /traceroutes/map/coverage?feeder=<node_id>', () => {
-    renderCard(makeNode({ node_id: 4242 }));
+  it('renders Coverage map link only when the infra node is a managed feeder', () => {
+    renderCard(makeNode({ node_id: 4242 }), { managedNode: minimalManaged(4242) });
     const link = screen.getByTestId('infra-coverage-link-4242');
-    expect(link).toBeInTheDocument();
     expect(link.getAttribute('href')).toBe('/traceroutes/map/coverage?feeder=4242');
+  });
+
+  it('does not render Coverage map link for unmanaged infrastructure nodes', () => {
+    renderCard(makeNode({ node_id: 4242 }));
+    expect(screen.queryByTestId('infra-coverage-link-4242')).not.toBeInTheDocument();
   });
 
   it('also renders the Open node details link to /nodes/<node_id>', () => {

--- a/src/components/nodes/InfrastructureNodeCard.tsx
+++ b/src/components/nodes/InfrastructureNodeCard.tsx
@@ -154,13 +154,15 @@ function InfrastructureNodeCardInner({
         )}
       </div>
       <div className="mt-auto flex justify-end gap-3 pt-3">
-        <Link
-          to={`/traceroutes/map/coverage?feeder=${node.node_id}`}
-          className="text-sm text-muted-foreground underline-offset-4 hover:text-primary hover:underline"
-          data-testid={`infra-coverage-link-${node.node_id}`}
-        >
-          Coverage map
-        </Link>
+        {managedNode != null && (
+          <Link
+            to={`/traceroutes/map/coverage?feeder=${node.node_id}`}
+            className="text-sm text-muted-foreground underline-offset-4 hover:text-primary hover:underline"
+            data-testid={`infra-coverage-link-${node.node_id}`}
+          >
+            Coverage map
+          </Link>
+        )}
         {node.has_ready_rf_render === true && (
           <>
             <button

--- a/src/components/nodes/MapMarkerLegend.tsx
+++ b/src/components/nodes/MapMarkerLegend.tsx
@@ -46,7 +46,8 @@ export function MapMarkerLegend({
   return (
     <div
       className={cn(
-        'absolute top-2 right-2 z-[1000] max-h-[40%] overflow-y-auto max-w-[min(100%,20rem)] rounded-md border bg-background/95 p-2 text-xs shadow-sm backdrop-blur-sm',
+        // Below sheet/dialog overlays (z-50); above Leaflet panes inside the map container.
+        'absolute top-2 right-2 z-10 max-h-[40%] overflow-y-auto max-w-[min(100%,20rem)] rounded-md border bg-background/95 p-2 text-xs shadow-sm backdrop-blur-sm',
         className
       )}
       role="region"

--- a/src/components/nodes/NodeOutgoingTraceroutesSection.tsx
+++ b/src/components/nodes/NodeOutgoingTraceroutesSection.tsx
@@ -11,6 +11,7 @@ import { TracerouteQueueDispatchCell } from '@/components/traceroutes/Traceroute
 import { TracerouteStatusBadge } from '@/components/traceroutes/TracerouteStatusBadge';
 import { useTracerouteTriggerableNodesSuspense, useTriggerTraceroute } from '@/hooks/api/useTraceroutes';
 import { useTraceroutesWithWebSocket } from '@/hooks/useTraceroutesWithWebSocket';
+import { TracerouteElapsedCell } from '@/components/traceroutes/TracerouteElapsedCell';
 import { TracerouteDetailModal } from '@/pages/traceroutes/TracerouteDetailModal';
 import { getTracerouteErrorMessage } from '@/pages/traceroutes/tracerouteErrors';
 import type { AutoTraceRoute, ManagedNode } from '@/lib/models';
@@ -109,7 +110,7 @@ export function NodeOutgoingTraceroutesSection({ nodeId, managed }: NodeOutgoing
                       <TableHead>Queue / dispatch</TableHead>
                       <TableHead>Route</TableHead>
                       <TableHead>Triggered</TableHead>
-                      <TableHead>Completed</TableHead>
+                      <TableHead title="Time from triggered to completion (successful runs only)">Elapsed</TableHead>
                       {canTrigger ? <TableHead className="w-12" /> : null}
                     </TableRow>
                   </TableHeader>
@@ -135,7 +136,9 @@ export function NodeOutgoingTraceroutesSection({ nodeId, managed }: NodeOutgoing
                             {routeSummary(tr)}
                           </TableCell>
                           <TableCell>{tr.triggered_at ? format(new Date(tr.triggered_at), 'PPp') : '—'}</TableCell>
-                          <TableCell>{tr.completed_at ? format(new Date(tr.completed_at), 'PPp') : '—'}</TableCell>
+                          <TableCell>
+                            <TracerouteElapsedCell tr={tr} />
+                          </TableCell>
                           {canTrigger ? (
                             <TableCell onClick={(e) => e.stopPropagation()}>
                               {canRepeat ? (

--- a/src/components/nodes/NodeTracerouteHistorySection.tsx
+++ b/src/components/nodes/NodeTracerouteHistorySection.tsx
@@ -10,6 +10,7 @@ import { TracerouteQueueDispatchCell } from '@/components/traceroutes/Traceroute
 import { TracerouteStatusBadge } from '@/components/traceroutes/TracerouteStatusBadge';
 import { useTracerouteTriggerableNodesSuspense, useTriggerTraceroute } from '@/hooks/api/useTraceroutes';
 import { useTraceroutesWithWebSocket } from '@/hooks/useTraceroutesWithWebSocket';
+import { TracerouteElapsedCell } from '@/components/traceroutes/TracerouteElapsedCell';
 import { TracerouteDetailModal } from '@/pages/traceroutes/TracerouteDetailModal';
 import { TriggerTracerouteModal } from '@/pages/traceroutes/TriggerTracerouteModal';
 import { getTracerouteErrorMessage } from '@/pages/traceroutes/tracerouteErrors';
@@ -129,7 +130,7 @@ export function NodeTracerouteHistorySection({ nodeId, observedNode }: NodeTrace
                     <TableHead>Queue / dispatch</TableHead>
                     <TableHead>Route</TableHead>
                     <TableHead>Triggered</TableHead>
-                    <TableHead>Completed</TableHead>
+                    <TableHead title="Time from triggered to completion (successful runs only)">Elapsed</TableHead>
                     {canTrigger && <TableHead className="w-12"></TableHead>}
                   </TableRow>
                 </TableHeader>
@@ -155,7 +156,9 @@ export function NodeTracerouteHistorySection({ nodeId, observedNode }: NodeTrace
                           {routeSummary(tr)}
                         </TableCell>
                         <TableCell>{tr.triggered_at ? format(new Date(tr.triggered_at), 'PPp') : '—'}</TableCell>
-                        <TableCell>{tr.completed_at ? format(new Date(tr.completed_at), 'PPp') : '—'}</TableCell>
+                        <TableCell>
+                          <TracerouteElapsedCell tr={tr} />
+                        </TableCell>
                         {canTrigger && (
                           <TableCell onClick={(e) => e.stopPropagation()}>
                             {canRepeat ? (

--- a/src/components/nodes/RfProfileModal.tsx
+++ b/src/components/nodes/RfProfileModal.tsx
@@ -269,9 +269,9 @@ export function RfProfileModal({ open, onOpenChange, node }: RfProfileModalProps
 
   const handleSave = async () => {
     try {
+      const needsRerender = coordsChangedVsSnapshot();
       await updateMutation.mutateAsync(buildBody());
       toast.success('RF profile saved');
-      const needsRerender = coordsChangedVsSnapshot();
       onOpenChange(false);
       if (needsRerender) setConfirmRerenderOpen(true);
     } catch {

--- a/src/components/nodes/RfPropagationMap.tsx
+++ b/src/components/nodes/RfPropagationMap.tsx
@@ -7,6 +7,44 @@ import L from 'leaflet';
 import { useEffect, useRef } from 'react';
 import 'leaflet/dist/leaflet.css';
 
+/** Approximate km per degree latitude */
+const KM_PER_DEG_LAT = 111;
+
+/** Target on-screen diameter when API bounds span more than this (local coverage UX; see issue #191). */
+const VIEWPORT_MAX_DIAMETER_KM = 200;
+
+function approxBoundsSpanKm(bounds: { west: number; south: number; east: number; north: number }): number {
+  const midLat = (bounds.south + bounds.north) / 2;
+  const nsKm = Math.abs(bounds.north - bounds.south) * KM_PER_DEG_LAT;
+  const ewKm = Math.abs(bounds.east - bounds.west) * KM_PER_DEG_LAT * Math.cos((midLat * Math.PI) / 180);
+  return Math.max(nsKm, ewKm);
+}
+
+/** Axis-aligned bounds ~`radiusKm` from center (used when raw render bounds are continent-scale). */
+function latLngBoundsRadiusKm(centerLat: number, centerLng: number, radiusKm: number): L.LatLngBounds {
+  const latDelta = radiusKm / KM_PER_DEG_LAT;
+  const cosLat = Math.cos((centerLat * Math.PI) / 180);
+  const lngDelta = cosLat > 1e-6 ? radiusKm / (KM_PER_DEG_LAT * cosLat) : latDelta;
+  return L.latLngBounds([centerLat - latDelta, centerLng - lngDelta], [centerLat + latDelta, centerLng + lngDelta]);
+}
+
+function fitBoundsForPropagation(
+  map: L.Map,
+  bounds: { west: number; south: number; east: number; north: number },
+  overlaySw: L.LatLngTuple,
+  overlayNe: L.LatLngTuple
+): void {
+  const spanKm = approxBoundsSpanKm(bounds);
+  if (spanKm <= VIEWPORT_MAX_DIAMETER_KM) {
+    map.fitBounds(L.latLngBounds(overlaySw, overlayNe), { padding: [24, 24], maxZoom: 14 });
+    return;
+  }
+  const centerLat = (bounds.south + bounds.north) / 2;
+  const centerLng = (bounds.west + bounds.east) / 2;
+  const capped = latLngBoundsRadiusKm(centerLat, centerLng, VIEWPORT_MAX_DIAMETER_KM / 2);
+  map.fitBounds(capped, { padding: [24, 24], maxZoom: 14 });
+}
+
 export interface RfPropagationMapProps {
   assetUrl: string | null | undefined;
   bounds: { west: number; south: number; east: number; north: number } | null | undefined;
@@ -25,10 +63,9 @@ export function RfPropagationMap({ assetUrl, bounds, minHeight = 280, className 
     const el = mapRef.current;
     if (!el || !assetUrl || !bounds) return;
 
-    const map = L.map(el, { zoomControl: true }).setView(
-      [(bounds.south + bounds.north) / 2, (bounds.west + bounds.east) / 2],
-      10
-    );
+    const centerLat = (bounds.south + bounds.north) / 2;
+    const centerLng = (bounds.west + bounds.east) / 2;
+    const map = L.map(el, { zoomControl: true }).setView([centerLat, centerLng], 11);
     mapInstanceRef.current = map;
     L.tileLayer(tileUrl, { attribution }).addTo(map);
 
@@ -37,7 +74,7 @@ export function RfPropagationMap({ assetUrl, bounds, minHeight = 280, className 
     const overlay = L.imageOverlay(assetUrl, [sw, ne], { opacity: 0.85 }).addTo(map);
     layersRef.current.push(overlay);
 
-    map.fitBounds(L.latLngBounds(sw, ne), { padding: [24, 24], maxZoom: 14 });
+    fitBoundsForPropagation(map, bounds, sw, ne);
     const t = setTimeout(() => map.invalidateSize(), 50);
 
     return () => {

--- a/src/components/nodes/RfPropagationMap.tsx
+++ b/src/components/nodes/RfPropagationMap.tsx
@@ -75,10 +75,30 @@ export function RfPropagationMap({ assetUrl, bounds, minHeight = 280, className 
     layersRef.current.push(overlay);
 
     fitBoundsForPropagation(map, bounds, sw, ne);
-    const t = setTimeout(() => map.invalidateSize(), 50);
+
+    /** Tabs (e.g. node Map) and dialogs mount the map at 0×0; refit once the container is measurable. */
+    let prevTooSmall = true;
+    const refitIfNeeded = () => {
+      const w = el.clientWidth;
+      const h = el.clientHeight;
+      const tooSmall = w < 32 || h < 32;
+      if (tooSmall) {
+        prevTooSmall = true;
+        return;
+      }
+      map.invalidateSize();
+      if (prevTooSmall) {
+        fitBoundsForPropagation(map, bounds, sw, ne);
+      }
+      prevTooSmall = false;
+    };
+    const ro = new ResizeObserver(() => refitIfNeeded());
+    ro.observe(el);
+    const t = window.setTimeout(() => refitIfNeeded(), 50);
 
     return () => {
-      clearTimeout(t);
+      window.clearTimeout(t);
+      ro.disconnect();
       layersRef.current.forEach((layer) => {
         try {
           map.removeLayer(layer);

--- a/src/components/traceroutes/TracerouteElapsedCell.tsx
+++ b/src/components/traceroutes/TracerouteElapsedCell.tsx
@@ -1,0 +1,23 @@
+import type { AutoTraceRoute } from '@/lib/models';
+import { formatElapsedBetween } from '@/lib/utils';
+import { TRIGGER_TYPE_EXTERNAL } from '@/lib/traceroute-trigger-type';
+
+/**
+ * Elapsed duration from triggered to completion, matching {@link TracerouteHistory}.
+ */
+export function TracerouteElapsedCell({ tr }: { tr: AutoTraceRoute }) {
+  if (tr.status === 'failed') return '—';
+  /** Only completion time is reliable for externally ingested traceroutes */
+  if (tr.trigger_type === TRIGGER_TYPE_EXTERNAL) {
+    return (
+      <span
+        className="text-muted-foreground"
+        title="External traceroutes do not record when the probe started; elapsed time cannot be computed."
+      >
+        Unknown
+      </span>
+    );
+  }
+  if (!tr.triggered_at || !tr.completed_at) return '—';
+  return formatElapsedBetween(new Date(tr.triggered_at), new Date(tr.completed_at));
+}

--- a/src/pages/nodes/MeshInfrastructure.tsx
+++ b/src/pages/nodes/MeshInfrastructure.tsx
@@ -252,6 +252,7 @@ function MeshInfrastructureContent() {
                     !node.last_heard ||
                     (node.last_heard instanceof Date ? node.last_heard : new Date(node.last_heard)) < cutoff;
                   const watch = watchesByNodeIdStr.get(node.node_id_str);
+                  const managed = managedByMeshId.get(node.node_id);
                   return (
                     <TableRow key={node.internal_id}>
                       <TableCell>
@@ -317,13 +318,15 @@ function MeshInfrastructureContent() {
                           <Link to={`/nodes/${node.node_id}`} className="text-primary text-sm hover:underline">
                             View details
                           </Link>
-                          <Link
-                            to={`/traceroutes/map/coverage?feeder=${node.node_id}`}
-                            className="text-muted-foreground text-sm underline-offset-4 hover:text-primary hover:underline"
-                            data-testid={`infra-no-loc-coverage-link-${node.node_id}`}
-                          >
-                            Coverage map
-                          </Link>
+                          {managed != null && (
+                            <Link
+                              to={`/traceroutes/map/coverage?feeder=${node.node_id}`}
+                              className="text-muted-foreground text-sm underline-offset-4 hover:text-primary hover:underline"
+                              data-testid={`infra-no-loc-coverage-link-${node.node_id}`}
+                            >
+                              Coverage map
+                            </Link>
+                          )}
                         </div>
                       </TableCell>
                     </TableRow>

--- a/src/pages/traceroutes/TracerouteHistory.tsx
+++ b/src/pages/traceroutes/TracerouteHistory.tsx
@@ -26,7 +26,7 @@ import { StrategyBadge } from '@/components/traceroutes/StrategyBadge';
 import { TracerouteQueueDispatchCell } from '@/components/traceroutes/TracerouteQueueDispatchCell';
 import { TracerouteStatusBadge } from '@/components/traceroutes/TracerouteStatusBadge';
 import { AutoTraceRoute, ObservedNode } from '@/lib/models';
-import { formatElapsedBetween } from '@/lib/utils';
+import { TracerouteElapsedCell } from '@/components/traceroutes/TracerouteElapsedCell';
 import { TRACEROUTE_STRATEGIES, type TracerouteStrategyValue } from '@/lib/traceroute-strategy';
 import {
   TRIGGER_TYPE_EXTERNAL,
@@ -85,23 +85,6 @@ function parseNumberParam(raw: string | null): number | null {
   if (!raw) return null;
   const n = parseInt(raw, 10);
   return Number.isFinite(n) ? n : null;
-}
-
-function TracerouteElapsedCell({ tr }: { tr: AutoTraceRoute }) {
-  if (tr.status === 'failed') return '—';
-  /** Only completion time is reliable for externally ingested traceroutes */
-  if (tr.trigger_type === TRIGGER_TYPE_EXTERNAL) {
-    return (
-      <span
-        className="text-muted-foreground"
-        title="External traceroutes do not record when the probe started; elapsed time cannot be computed."
-      >
-        Unknown
-      </span>
-    );
-  }
-  if (!tr.triggered_at || !tr.completed_at) return '—';
-  return formatElapsedBetween(new Date(tr.triggered_at), new Date(tr.completed_at));
 }
 
 function triggerTypeMultiLabel(values: TriggerTypeFilterToken[]): string {


### PR DESCRIPTION
# Summary

Fixes a batch of UI bugs and RF propagation map issues:

* Rename Node Details traceroute table `Completed` columns to `Elapsed` and reuse the Traceroutes page elapsed formatting.
* Tighten RF propagation map framing to a ~200 km context when render bounds are very large, and refit after hidden tabs/dialogs become visible.
* Ensure RF profile coordinate changes reliably prompt for a re-render after save.
* Hide Mesh Infrastructure `Coverage map` links unless the infra node is managed.
* Keep the in-map marker key below the mobile drawer overlay.

Closes #198
Closes #191
Closes #190
Closes #226

## Testing performed

* `npm run format`
* `npm test` (45 files, 216 tests passed)
* Commit hooks ran `eslint`, Prettier check, and Vitest on each commit; ESLint reports existing warnings only (0 errors).