### PR TITLE
feat(dx-monitoring): add DX Discord notification preference UI

### DIFF
--- a/src/hooks/api/dxNotificationSettingsQueryKey.ts
+++ b/src/hooks/api/dxNotificationSettingsQueryKey.ts
@@ -1,0 +1,1 @@
+export const dxNotificationSettingsQueryKey = ['dx', 'notifications', 'settings'] as const;

--- a/src/hooks/api/useDiscordNotifications.ts
+++ b/src/hooks/api/useDiscordNotifications.ts
@@ -1,4 +1,5 @@
 import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query';
+import { dxNotificationSettingsQueryKey } from '@/hooks/api/dxNotificationSettingsQueryKey';
 import { useMeshtasticApi } from '@/hooks/api/useApi';
 
 export const discordNotificationPrefsQueryKey = ['auth', 'discord-notifications'] as const;
@@ -18,6 +19,7 @@ export function usePatchDiscordNotificationPrefs() {
     mutationFn: () => api.patchDiscordNotificationPrefs(),
     onSuccess: () => {
       queryClient.invalidateQueries({ queryKey: discordNotificationPrefsQueryKey });
+      queryClient.invalidateQueries({ queryKey: dxNotificationSettingsQueryKey });
     },
   });
 }
@@ -29,6 +31,7 @@ export function usePostDiscordNotificationTest() {
     mutationFn: () => api.postDiscordNotificationTest(),
     onSuccess: () => {
       queryClient.invalidateQueries({ queryKey: discordNotificationPrefsQueryKey });
+      queryClient.invalidateQueries({ queryKey: dxNotificationSettingsQueryKey });
     },
   });
 }

--- a/src/hooks/api/useDxMonitoring.ts
+++ b/src/hooks/api/useDxMonitoring.ts
@@ -1,10 +1,15 @@
 import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query';
+import { AxiosError } from 'axios';
 import { useMeshtasticApi } from './useApi';
+import { dxNotificationSettingsQueryKey } from '@/hooks/api/dxNotificationSettingsQueryKey';
 import type { DxEventsQueryParams } from '@/lib/types';
+import type { DxNotificationSettingsWrite } from '@/lib/models';
 
 export const dxEventsQueryKey = (params: DxEventsQueryParams) => ['dx', 'events', params] as const;
 
 export const dxEventDetailQueryKey = (id: string | null) => ['dx', 'event', id ?? ''] as const;
+
+export { dxNotificationSettingsQueryKey } from '@/hooks/api/dxNotificationSettingsQueryKey';
 
 const DX_POLL_MS = 60_000;
 const DX_STALE_MS = 30_000;
@@ -71,4 +76,53 @@ export function useDxNodeExclusionMutation() {
       queryClient.invalidateQueries({ queryKey: ['dx'] });
     },
   });
+}
+
+const DX_SETTINGS_STALE_MS = 60_000;
+
+export function useDxNotificationSettings(enabled = true) {
+  const api = useMeshtasticApi();
+  return useQuery({
+    queryKey: dxNotificationSettingsQueryKey,
+    queryFn: () => api.getDxNotificationSettings(),
+    enabled,
+    staleTime: DX_SETTINGS_STALE_MS,
+  });
+}
+
+export function usePatchDxNotificationSettings() {
+  const api = useMeshtasticApi();
+  const queryClient = useQueryClient();
+  return useMutation({
+    mutationFn: (body: DxNotificationSettingsWrite) => api.patchDxNotificationSettings(body),
+    onSuccess: () => {
+      queryClient.invalidateQueries({ queryKey: dxNotificationSettingsQueryKey });
+    },
+  });
+}
+
+/** User-visible message for failed PATCH (Discord gate, validation, network). */
+export function getDxNotificationSettingsSaveErrorMessage(err: unknown): string {
+  if (err instanceof AxiosError && err.response?.data && typeof err.response.data === 'object') {
+    const d = err.response.data as {
+      code?: string;
+      detail?: string;
+      categories?: unknown;
+    };
+    if (d.code === 'NEEDS_DISCORD_VERIFICATION' && typeof d.detail === 'string') {
+      return d.detail;
+    }
+    if (typeof d.detail === 'string' && d.detail.trim()) {
+      return d.detail;
+    }
+    if (Array.isArray(d.categories) && d.categories.length && typeof d.categories[0] === 'string') {
+      return d.categories[0];
+    }
+    if (d.categories && typeof d.categories === 'object' && !Array.isArray(d.categories)) {
+      const first = Object.values(d.categories as Record<string, string[]>).flat()[0];
+      if (typeof first === 'string') return first;
+    }
+  }
+  if (err instanceof Error) return err.message;
+  return 'Could not save DX notification settings';
 }

--- a/src/lib/api/meshtastic-api.ts
+++ b/src/lib/api/meshtastic-api.ts
@@ -27,6 +27,8 @@ import {
   DxEventListItem,
   DxEventDetail,
   DxNodeExclusionResponse,
+  DxNotificationSettings,
+  DxNotificationSettingsWrite,
 } from '../models';
 import {
   ApiConfig,
@@ -1010,6 +1012,16 @@ export class MeshtasticApi extends BaseApi {
   /** POST /api/auth/discord/notifications/test/ */
   async postDiscordNotificationTest(): Promise<{ detail: string }> {
     return this.post<{ detail: string }>('/auth/discord/notifications/test/', {});
+  }
+
+  /** GET /api/dx/notifications/settings/ */
+  async getDxNotificationSettings(): Promise<DxNotificationSettings> {
+    return this.get<DxNotificationSettings>('/dx/notifications/settings/');
+  }
+
+  /** PATCH /api/dx/notifications/settings/ */
+  async patchDxNotificationSettings(body: DxNotificationSettingsWrite): Promise<DxNotificationSettings> {
+    return this.patch<DxNotificationSettings>('/dx/notifications/settings/', body);
   }
 
   // ===== Mesh monitoring watches (Phase 04) =====

--- a/src/lib/models.ts
+++ b/src/lib/models.ts
@@ -520,6 +520,80 @@ export interface DiscordNotificationPrefs {
   discord_notify_verified: boolean;
 }
 
+/** GET/PATCH `/api/dx/notifications/settings/` (DX Discord DM preferences). */
+export type DxNotificationCategoryValue =
+  | 'new_distant_node'
+  | 'returned_dx_node'
+  | 'distant_observation'
+  | 'traceroute_distant_hop'
+  | 'confirmed_event'
+  | 'event_closed_summary';
+
+export type DxDiscordReadinessStatus = 'verified' | 'not_linked' | 'needs_relink';
+
+export interface DxDiscordReadiness {
+  status: DxDiscordReadinessStatus;
+  can_receive_dms: boolean;
+}
+
+export interface DxNotificationSettings {
+  enabled: boolean;
+  all_categories: boolean;
+  categories: DxNotificationCategoryValue[];
+  discord: DxDiscordReadiness;
+}
+
+export interface DxNotificationSettingsWrite {
+  enabled?: boolean;
+  all_categories?: boolean;
+  categories?: DxNotificationCategoryValue[];
+}
+
+/** Error body when enabling DX DMs without verified Discord (`HTTP 400`). */
+export interface DxNotificationSettingsErrorResponse {
+  code: 'NEEDS_DISCORD_VERIFICATION';
+  detail: string;
+}
+
+export const DX_NOTIFICATION_CATEGORY_ORDER: readonly DxNotificationCategoryValue[] = [
+  'new_distant_node',
+  'returned_dx_node',
+  'distant_observation',
+  'traceroute_distant_hop',
+  'confirmed_event',
+  'event_closed_summary',
+] as const;
+
+export const DX_NOTIFICATION_CATEGORY_META: Record<
+  DxNotificationCategoryValue,
+  { label: string; description: string }
+> = {
+  new_distant_node: {
+    label: 'New distant node',
+    description: 'A node is first seen as distant from its constellation footprint.',
+  },
+  returned_dx_node: {
+    label: 'Returned DX node',
+    description: 'A distant node reappears after a quiet period.',
+  },
+  distant_observation: {
+    label: 'Distant observation',
+    description: 'Direct or near-direct mesh observation across distance.',
+  },
+  traceroute_distant_hop: {
+    label: 'Traceroute distant hop',
+    description: 'Traceroute evidence shows a distant hop toward the destination.',
+  },
+  confirmed_event: {
+    label: 'Event confirmed',
+    description: 'A DX event reaches the evidence threshold.',
+  },
+  event_closed_summary: {
+    label: 'Event closed',
+    description: 'Summary when a DX event is closed.',
+  },
+};
+
 /**
  * Observed node embedded on NodeWatch responses: same shape as ObservedNode (list/detail API)
  * plus mesh monitoring hints (`GET /api/monitoring/watches/`).

--- a/src/pages/nodes/DxMonitoringPage.test.tsx
+++ b/src/pages/nodes/DxMonitoringPage.test.tsx
@@ -4,7 +4,7 @@ import userEvent from '@testing-library/user-event';
 import { MemoryRouter } from 'react-router-dom';
 import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
 import type { DxEventDetail, DxEventListItem } from '@/lib/models';
-import { useDxEventDetail, useDxEvents } from '@/hooks/api/useDxMonitoring';
+import { useDxEventDetail, useDxEvents, useDxNotificationSettings } from '@/hooks/api/useDxMonitoring';
 import DxMonitoringPage from './DxMonitoringPage';
 
 const getCurrentUser = vi.fn();
@@ -23,10 +23,12 @@ vi.mock('@/hooks/api/useDxMonitoring', () => ({
   useDxRecentEventCount: vi.fn(() => ({ isLoading: false, data: 0 })),
   useDxEventDetail: vi.fn(),
   useDxNodeExclusionMutation: vi.fn(() => ({ mutate: vi.fn(), isPending: false })),
+  useDxNotificationSettings: vi.fn(),
 }));
 
 const useDxEventsMock = vi.mocked(useDxEvents);
 const useDxEventDetailMock = vi.mocked(useDxEventDetail);
+const useDxNotificationSettingsMock = vi.mocked(useDxNotificationSettings);
 
 function renderPage() {
   const client = new QueryClient({ defaultOptions: { queries: { retry: false } } });
@@ -70,6 +72,25 @@ describe('DxMonitoringPage', () => {
         } as ReturnType<typeof useDxEventDetail>;
       }) as typeof useDxEventDetail
     );
+    useDxNotificationSettingsMock.mockReturnValue({
+      isLoading: false,
+      isError: false,
+      error: null,
+      data: {
+        enabled: true,
+        all_categories: true,
+        categories: [
+          'new_distant_node',
+          'returned_dx_node',
+          'distant_observation',
+          'traceroute_distant_hop',
+          'confirmed_event',
+          'event_closed_summary',
+        ],
+        discord: { status: 'verified', can_receive_dms: true },
+      },
+      refetch: vi.fn(),
+    } as unknown as ReturnType<typeof useDxNotificationSettings>);
   });
 
   it('shows staff-only message when user is not staff', () => {
@@ -83,6 +104,17 @@ describe('DxMonitoringPage', () => {
     renderPage();
     expect(screen.getByRole('heading', { name: /DX monitoring/i })).toBeInTheDocument();
     expect(screen.getByText(/Detection events and evidence/i)).toBeInTheDocument();
+  });
+
+  it('shows profile link and DX notification status for staff', () => {
+    renderPage();
+    expect(screen.getByRole('link', { name: /Profile: DX notifications/i })).toHaveAttribute(
+      'href',
+      '/user#dx-notifications'
+    );
+    const bar = screen.getByRole('link', { name: /Profile: DX notifications/i }).closest('.flex');
+    expect(bar?.textContent).toMatch(/Your DX DMs:/);
+    expect(bar?.textContent).toMatch(/DX DMs:\s*On/);
   });
 
   it('shows exploration attempt counts on the list', () => {

--- a/src/pages/nodes/DxMonitoringPage.tsx
+++ b/src/pages/nodes/DxMonitoringPage.tsx
@@ -20,6 +20,7 @@ import {
   useDxEventDetail,
   useDxEvents,
   useDxNodeExclusionMutation,
+  useDxNotificationSettings,
   useDxRecentEventCount,
 } from '@/hooks/api/useDxMonitoring';
 import type { DxEventsQueryParams } from '@/lib/types';
@@ -167,6 +168,7 @@ function NodeLinkLabel({ to, primary, idSecondary }: { to: string; primary: stri
 export default function DxMonitoringPage() {
   const user = authService.getCurrentUser();
   const isStaff = Boolean(user?.is_staff);
+  const dxNotifSettings = useDxNotificationSettings(isStaff);
 
   const [stateFilter, setStateFilter] = useState<string>('');
   const [reasonFilter, setReasonFilter] = useState<string>('');
@@ -258,6 +260,31 @@ export default function DxMonitoringPage() {
           Detection events and evidence (read-only). Exclude noisy or mobile destinations from future DX detection when
           appropriate.
         </p>
+      </div>
+
+      <div className="rounded-md border bg-muted/40 px-4 py-3 flex flex-col gap-2 sm:flex-row sm:items-center sm:justify-between text-sm">
+        <p className="text-muted-foreground">
+          {dxNotifSettings.isLoading ? (
+            <>Loading your DX Discord notification status…</>
+          ) : dxNotifSettings.data ? (
+            <>
+              <span className="font-medium text-foreground">Your DX DMs:</span>{' '}
+              {dxNotifSettings.data.enabled ? 'On' : 'Off'}
+              {dxNotifSettings.data.discord.status === 'verified'
+                ? ''
+                : dxNotifSettings.data.discord.status === 'needs_relink'
+                  ? ' (Discord needs refresh — see profile)'
+                  : ' (link Discord on your profile)'}
+            </>
+          ) : dxNotifSettings.isError ? (
+            <>Could not load notification status. You can still open settings from your profile.</>
+          ) : (
+            <>Optional DX alerts go to Discord DMs configured on your profile.</>
+          )}
+        </p>
+        <Button asChild variant="outline" size="sm" className="shrink-0 w-fit">
+          <Link to="/user#dx-notifications">Profile: DX notifications</Link>
+        </Button>
       </div>
 
       <div className="grid gap-4 md:grid-cols-3">

--- a/src/pages/user/DxNotificationsPanel.test.tsx
+++ b/src/pages/user/DxNotificationsPanel.test.tsx
@@ -1,0 +1,207 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import { AxiosError } from 'axios';
+import { DxNotificationsPanel } from '@/pages/user/DxNotificationsPanel';
+import {
+  getDxNotificationSettingsSaveErrorMessage,
+  useDxNotificationSettings,
+  usePatchDxNotificationSettings,
+} from '@/hooks/api/useDxMonitoring';
+import {
+  DX_NOTIFICATION_CATEGORY_ORDER,
+  type DxNotificationCategoryValue,
+  type DxNotificationSettings,
+} from '@/lib/models';
+
+const toastError = vi.fn();
+
+vi.mock('sonner', () => ({
+  toast: {
+    error: (...args: unknown[]) => toastError(...args),
+    success: vi.fn(),
+  },
+}));
+
+const { useDxNotificationSettingsMock, usePatchDxNotificationSettingsMock } = vi.hoisted(() => ({
+  useDxNotificationSettingsMock: vi.fn(),
+  usePatchDxNotificationSettingsMock: vi.fn(),
+}));
+
+vi.mock('@/hooks/api/useDxMonitoring', async () => {
+  const actual = await vi.importActual<typeof import('@/hooks/api/useDxMonitoring')>('@/hooks/api/useDxMonitoring');
+  return {
+    ...actual,
+    useDxNotificationSettings: useDxNotificationSettingsMock,
+    usePatchDxNotificationSettings: usePatchDxNotificationSettingsMock,
+  };
+});
+
+function baseSettings(
+  overrides: Partial<{
+    enabled: boolean;
+    all_categories: boolean;
+    categories: DxNotificationCategoryValue[];
+    discord: { status: 'verified' | 'not_linked' | 'needs_relink'; can_receive_dms: boolean };
+  }> = {}
+): DxNotificationSettings {
+  return {
+    enabled: false,
+    all_categories: true,
+    categories: [...DX_NOTIFICATION_CATEGORY_ORDER],
+    discord: { status: 'verified' as const, can_receive_dms: true },
+    ...overrides,
+  };
+}
+
+function renderPanel() {
+  const client = new QueryClient({ defaultOptions: { queries: { retry: false } } });
+  return render(
+    <QueryClientProvider client={client}>
+      <DxNotificationsPanel />
+    </QueryClientProvider>
+  );
+}
+
+describe('getDxNotificationSettingsSaveErrorMessage', () => {
+  it('returns API detail for NEEDS_DISCORD_VERIFICATION', () => {
+    const err = new AxiosError('Request failed');
+    err.response = {
+      status: 400,
+      data: { code: 'NEEDS_DISCORD_VERIFICATION', detail: 'Connect Discord in your profile.' },
+    } as AxiosError['response'];
+    expect(getDxNotificationSettingsSaveErrorMessage(err)).toBe('Connect Discord in your profile.');
+  });
+});
+
+describe('DxNotificationsPanel', () => {
+  const mutate = vi.fn();
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    usePatchDxNotificationSettingsMock.mockReturnValue({
+      mutate,
+      isPending: false,
+    } as unknown as ReturnType<typeof usePatchDxNotificationSettings>);
+  });
+
+  it('shows verified Discord readiness and allows the main toggle', () => {
+    useDxNotificationSettingsMock.mockReturnValue({
+      isLoading: false,
+      error: null,
+      data: baseSettings({ enabled: false, discord: { status: 'verified', can_receive_dms: true } }),
+      refetch: vi.fn(),
+    } as unknown as ReturnType<typeof useDxNotificationSettings>);
+    renderPanel();
+    expect(screen.getByText('Verified')).toBeInTheDocument();
+    const mainSwitch = screen.getByRole('switch', { name: /DX direct messages/i });
+    expect(mainSwitch).not.toBeDisabled();
+  });
+
+  it('shows not_linked guidance and disables opt-in', () => {
+    useDxNotificationSettingsMock.mockReturnValue({
+      isLoading: false,
+      error: null,
+      data: baseSettings({ discord: { status: 'not_linked', can_receive_dms: false } }),
+      refetch: vi.fn(),
+    } as unknown as ReturnType<typeof useDxNotificationSettings>);
+    renderPanel();
+    expect(screen.getByText(/Link Discord first/i)).toBeInTheDocument();
+    expect(screen.getByRole('switch', { name: /DX direct messages/i })).toBeDisabled();
+  });
+
+  it('shows needs_relink alert', () => {
+    useDxNotificationSettingsMock.mockReturnValue({
+      isLoading: false,
+      error: null,
+      data: baseSettings({ discord: { status: 'needs_relink', can_receive_dms: false } }),
+      refetch: vi.fn(),
+    } as unknown as ReturnType<typeof useDxNotificationSettings>);
+    renderPanel();
+    expect(screen.getByText(/Discord needs a refresh/i)).toBeInTheDocument();
+  });
+
+  it('sends all_categories true when turning on the all-types switch', async () => {
+    const user = userEvent.setup();
+    useDxNotificationSettingsMock.mockReturnValue({
+      isLoading: false,
+      error: null,
+      data: baseSettings({
+        enabled: true,
+        all_categories: false,
+        categories: ['new_distant_node', 'returned_dx_node'],
+      }),
+      refetch: vi.fn(),
+    } as unknown as ReturnType<typeof useDxNotificationSettings>);
+    renderPanel();
+    const allSwitch = screen.getByRole('switch', { name: /All notification types/i });
+    await user.click(allSwitch);
+    expect(mutate).toHaveBeenCalledWith({ all_categories: true }, expect.any(Object));
+  });
+
+  it('sends explicit categories when turning off all-types', async () => {
+    const user = userEvent.setup();
+    useDxNotificationSettingsMock.mockReturnValue({
+      isLoading: false,
+      error: null,
+      data: baseSettings({
+        enabled: true,
+        all_categories: true,
+        categories: [...DX_NOTIFICATION_CATEGORY_ORDER],
+      }),
+      refetch: vi.fn(),
+    } as unknown as ReturnType<typeof useDxNotificationSettings>);
+    renderPanel();
+    const allSwitch = screen.getByRole('switch', { name: /All notification types/i });
+    await user.click(allSwitch);
+    expect(mutate).toHaveBeenCalledWith(
+      { all_categories: false, categories: [...DX_NOTIFICATION_CATEGORY_ORDER] },
+      expect.any(Object)
+    );
+  });
+
+  it('sends category list when toggling a checkbox off', async () => {
+    const user = userEvent.setup();
+    useDxNotificationSettingsMock.mockReturnValue({
+      isLoading: false,
+      error: null,
+      data: baseSettings({
+        enabled: true,
+        all_categories: false,
+        categories: ['new_distant_node', 'returned_dx_node', 'distant_observation'],
+      }),
+      refetch: vi.fn(),
+    } as unknown as ReturnType<typeof useDxNotificationSettings>);
+    renderPanel();
+    await user.click(screen.getByLabelText(/Returned DX node/i));
+    expect(mutate).toHaveBeenCalledWith(
+      { all_categories: false, categories: ['new_distant_node', 'distant_observation'] },
+      expect.any(Object)
+    );
+  });
+
+  it('shows NEEDS_DISCORD_VERIFICATION message when the mutation fails', async () => {
+    const user = userEvent.setup();
+    const err = new AxiosError('bad');
+    err.response = {
+      status: 400,
+      data: { code: 'NEEDS_DISCORD_VERIFICATION', detail: 'Verify Discord first.' },
+    } as AxiosError['response'];
+    mutate.mockImplementation((_body, opts) => {
+      (opts as { onError?: (e: unknown) => void })?.onError?.(err);
+    });
+    useDxNotificationSettingsMock.mockReturnValue({
+      isLoading: false,
+      error: null,
+      data: baseSettings({
+        enabled: false,
+        discord: { status: 'verified', can_receive_dms: true },
+      }),
+      refetch: vi.fn(),
+    } as unknown as ReturnType<typeof useDxNotificationSettings>);
+    renderPanel();
+    await user.click(screen.getByRole('switch', { name: /DX direct messages/i }));
+    expect(toastError).toHaveBeenCalledWith('Verify Discord first.');
+  });
+});

--- a/src/pages/user/DxNotificationsPanel.tsx
+++ b/src/pages/user/DxNotificationsPanel.tsx
@@ -1,0 +1,207 @@
+import { Card, CardContent, CardHeader, CardTitle, CardDescription } from '@/components/ui/card';
+import { Alert, AlertDescription, AlertTitle } from '@/components/ui/alert';
+import { Button } from '@/components/ui/button';
+import { Badge } from '@/components/ui/badge';
+import { Checkbox } from '@/components/ui/checkbox';
+import { Label } from '@/components/ui/label';
+import { Switch } from '@/components/ui/switch';
+import { Loader2, AlertCircle, Info, Radio } from 'lucide-react';
+import { toast } from 'sonner';
+import {
+  getDxNotificationSettingsSaveErrorMessage,
+  useDxNotificationSettings,
+  usePatchDxNotificationSettings,
+} from '@/hooks/api/useDxMonitoring';
+import {
+  DX_NOTIFICATION_CATEGORY_META,
+  DX_NOTIFICATION_CATEGORY_ORDER,
+  type DxNotificationCategoryValue,
+} from '@/lib/models';
+
+function readinessBadgeVariant(
+  status: 'verified' | 'not_linked' | 'needs_relink'
+): 'default' | 'secondary' | 'destructive' {
+  if (status === 'verified') return 'default';
+  if (status === 'needs_relink') return 'destructive';
+  return 'secondary';
+}
+
+function readinessLabel(status: 'verified' | 'not_linked' | 'needs_relink'): string {
+  if (status === 'verified') return 'Verified';
+  if (status === 'needs_relink') return 'Needs refresh';
+  return 'Not linked';
+}
+
+export function DxNotificationsPanel() {
+  const { data, isLoading, error, refetch } = useDxNotificationSettings();
+  const patch = usePatchDxNotificationSettings();
+
+  const discordVerified = data?.discord.status === 'verified';
+  const busy = patch.isPending;
+
+  const save = (body: Parameters<typeof patch.mutate>[0]) => {
+    patch.mutate(body, {
+      onError: (e) => toast.error(getDxNotificationSettingsSaveErrorMessage(e)),
+    });
+  };
+
+  const onEnabledChange = (checked: boolean) => {
+    save({ enabled: checked });
+  };
+
+  const onAllCategoriesChange = (checked: boolean) => {
+    if (!data) return;
+    if (checked) {
+      save({ all_categories: true });
+      return;
+    }
+    const fallback = [...DX_NOTIFICATION_CATEGORY_ORDER];
+    const categories = data.categories.length > 0 ? (data.categories as DxNotificationCategoryValue[]) : fallback;
+    save({ all_categories: false, categories: categories.length ? categories : fallback });
+  };
+
+  const onCategoryToggle = (cat: DxNotificationCategoryValue, checked: boolean) => {
+    if (!data || data.all_categories) return;
+    const set = new Set(data.categories);
+    if (checked) {
+      set.add(cat);
+    } else {
+      if (set.size <= 1) {
+        toast.error('Choose at least one notification type, or turn “All types” back on.');
+        return;
+      }
+      set.delete(cat);
+    }
+    const categories = DX_NOTIFICATION_CATEGORY_ORDER.filter((c) => set.has(c));
+    save({ all_categories: false, categories });
+  };
+
+  return (
+    <Card id="dx-notifications">
+      <CardHeader>
+        <CardTitle className="flex items-center gap-2">
+          <Radio className="h-5 w-5" />
+          DX Discord notifications
+        </CardTitle>
+        <CardDescription>
+          Optional direct messages when Meshflow detects interesting DX-related activity. Uses the same linked Discord
+          account as the test notification above.
+        </CardDescription>
+      </CardHeader>
+      <CardContent className="space-y-4">
+        {isLoading ? (
+          <div className="flex justify-center py-8">
+            <Loader2 className="h-8 w-8 animate-spin text-slate-500 dark:text-slate-400" />
+          </div>
+        ) : error ? (
+          <Alert variant="destructive">
+            <AlertCircle className="h-4 w-4" />
+            <AlertTitle>Could not load DX notification settings</AlertTitle>
+            <AlertDescription className="flex flex-col gap-2 sm:flex-row sm:items-center">
+              <span>{error instanceof Error ? error.message : 'Unknown error'}</span>
+              <Button type="button" variant="outline" size="sm" onClick={() => refetch()}>
+                Retry
+              </Button>
+            </AlertDescription>
+          </Alert>
+        ) : data ? (
+          <>
+            <div className="grid gap-2 text-sm">
+              <div className="flex flex-wrap items-center gap-2">
+                <span className="text-muted-foreground">Discord for DMs</span>
+                <Badge variant={readinessBadgeVariant(data.discord.status)}>
+                  {readinessLabel(data.discord.status)}
+                </Badge>
+              </div>
+            </div>
+
+            {data.discord.status === 'not_linked' && (
+              <Alert>
+                <Info className="h-4 w-4" />
+                <AlertTitle>Link Discord first</AlertTitle>
+                <AlertDescription className="text-xs leading-relaxed">
+                  Connect your Discord account using the panel above, then send a test notification to verify DMs. DX
+                  alerts stay off until Discord shows as verified.
+                </AlertDescription>
+              </Alert>
+            )}
+
+            {data.discord.status === 'needs_relink' && (
+              <Alert variant="destructive">
+                <AlertCircle className="h-4 w-4" />
+                <AlertTitle>Discord needs a refresh</AlertTitle>
+                <AlertDescription className="text-xs leading-relaxed">
+                  Your Discord link is out of date. Use &quot;Refresh status&quot; or &quot;Link Discord&quot; in the
+                  Discord panel above, then try again.
+                </AlertDescription>
+              </Alert>
+            )}
+
+            <div className="flex flex-row items-center justify-between gap-4 rounded-lg border p-4">
+              <div className="space-y-0.5">
+                <Label htmlFor="dx-notif-enabled">DX direct messages</Label>
+                <p className="text-xs text-muted-foreground">
+                  {discordVerified
+                    ? 'Send DX-related alerts to your verified Discord DM channel.'
+                    : 'Verify Discord above before you can turn this on.'}
+                </p>
+              </div>
+              <Switch
+                id="dx-notif-enabled"
+                checked={data.enabled}
+                disabled={busy || !discordVerified}
+                onCheckedChange={onEnabledChange}
+              />
+            </div>
+
+            <div
+              className={`flex flex-col gap-4 rounded-lg border p-4 ${!data.enabled ? 'opacity-60 pointer-events-none' : ''}`}
+            >
+              <div className="flex flex-row items-center justify-between gap-4">
+                <div className="space-y-0.5">
+                  <Label htmlFor="dx-notif-all-cat">All notification types</Label>
+                  <p className="text-xs text-muted-foreground">
+                    When on, you receive every category. When off, pick the types you want.
+                  </p>
+                </div>
+                <Switch
+                  id="dx-notif-all-cat"
+                  checked={data.all_categories}
+                  disabled={busy || !data.enabled}
+                  onCheckedChange={onAllCategoriesChange}
+                />
+              </div>
+
+              <div className="space-y-3">
+                <p className="text-sm font-medium">Categories</p>
+                <ul className="space-y-3">
+                  {DX_NOTIFICATION_CATEGORY_ORDER.map((cat) => {
+                    const meta = DX_NOTIFICATION_CATEGORY_META[cat];
+                    const checked = data.categories.includes(cat);
+                    return (
+                      <li key={cat} className="flex flex-row items-start gap-3">
+                        <Checkbox
+                          id={`dx-cat-${cat}`}
+                          checked={checked}
+                          disabled={busy || !data.enabled || data.all_categories}
+                          onCheckedChange={(v) => onCategoryToggle(cat, v === true)}
+                          className="mt-1"
+                        />
+                        <div className="space-y-0.5 min-w-0">
+                          <Label htmlFor={`dx-cat-${cat}`} className="font-normal cursor-pointer">
+                            {meta.label}
+                          </Label>
+                          <p className="text-xs text-muted-foreground leading-relaxed">{meta.description}</p>
+                        </div>
+                      </li>
+                    );
+                  })}
+                </ul>
+              </div>
+            </div>
+          </>
+        ) : null}
+      </CardContent>
+    </Card>
+  );
+}

--- a/src/pages/user/UserPage.test.tsx
+++ b/src/pages/user/UserPage.test.tsx
@@ -1,0 +1,80 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { render, screen, waitFor } from '@testing-library/react';
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import { UserPage } from '@/pages/user/UserPage';
+import { DX_NOTIFICATION_CATEGORY_ORDER } from '@/lib/models';
+
+vi.mock('@/providers/ConfigProvider', () => ({
+  useConfig: () => ({ apis: { meshBot: { baseUrl: 'https://api.example' } } }),
+}));
+
+vi.mock('@/hooks/use-toast', () => ({
+  useToast: () => ({ toast: vi.fn() }),
+}));
+
+vi.mock('@/lib/auth/authService', () => ({
+  authService: {
+    getUserDetails: vi.fn().mockResolvedValue({
+      username: 'tester',
+      email: 'tester@example.com',
+      display_name: 'Tester',
+      first_name: '',
+    }),
+    updateUserDetails: vi.fn(),
+    changePassword: vi.fn(),
+  },
+}));
+
+vi.mock('@/hooks/api/useDiscordNotifications', () => ({
+  useDiscordNotificationPrefs: () => ({
+    isLoading: false,
+    error: null,
+    data: { discord_linked: true, discord_notify_verified: true },
+    refetch: vi.fn(),
+  }),
+  usePatchDiscordNotificationPrefs: () => ({ mutate: vi.fn(), isPending: false }),
+  usePostDiscordNotificationTest: () => ({ mutate: vi.fn(), isPending: false }),
+}));
+
+vi.mock('@/hooks/api/useDxMonitoring', async () => {
+  const actual = await vi.importActual<typeof import('@/hooks/api/useDxMonitoring')>('@/hooks/api/useDxMonitoring');
+  return {
+    ...actual,
+    useDxNotificationSettings: () => ({
+      isLoading: false,
+      error: null,
+      refetch: vi.fn(),
+      data: {
+        enabled: false,
+        all_categories: true,
+        categories: [...DX_NOTIFICATION_CATEGORY_ORDER],
+        discord: { status: 'verified', can_receive_dms: true },
+      },
+    }),
+    usePatchDxNotificationSettings: () => ({ mutate: vi.fn(), isPending: false }),
+  };
+});
+
+function renderUserPage() {
+  const client = new QueryClient({ defaultOptions: { queries: { retry: false } } });
+  return render(
+    <QueryClientProvider client={client}>
+      <UserPage />
+    </QueryClientProvider>
+  );
+}
+
+describe('UserPage', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('renders Discord setup and DX Discord notification panels', async () => {
+    renderUserPage();
+    await waitFor(() => {
+      expect(screen.getByRole('heading', { name: 'User Profile' })).toBeInTheDocument();
+    });
+    expect(screen.getByText('Discord')).toBeInTheDocument();
+    expect(screen.getByText('DX Discord notifications')).toBeInTheDocument();
+  });
+});

--- a/src/pages/user/UserPage.tsx
+++ b/src/pages/user/UserPage.tsx
@@ -7,6 +7,7 @@ import { useToast } from '@/hooks/use-toast';
 import { authService } from '@/lib/auth/authService';
 import { useConfig } from '@/providers/ConfigProvider';
 import { DiscordNotificationsPanel } from '@/pages/user/DiscordNotificationsPanel';
+import { DxNotificationsPanel } from '@/pages/user/DxNotificationsPanel';
 
 export function UserPage() {
   const { toast } = useToast();
@@ -151,8 +152,9 @@ export function UserPage() {
         </CardContent>
       </Card>
 
-      <div className="mb-6">
+      <div className="mb-6 space-y-6">
         <DiscordNotificationsPanel />
+        <DxNotificationsPanel />
       </div>
 
       <Card>


### PR DESCRIPTION
## Summary

Implements DX Phase 6c notification preference UI for the merged `/api/dx/notifications/settings/` contract (GET/PATCH).

- **Types & API**: `DxNotificationSettings`, category union/meta, `MeshtasticApi.getDxNotificationSettings` / `patchDxNotificationSettings`.
- **Data layer**: `dxNotificationSettingsQueryKey`, `useDxNotificationSettings`, `usePatchDxNotificationSettings`, `getDxNotificationSettingsSaveErrorMessage` (including `NEEDS_DISCORD_VERIFICATION`). Discord resync/test mutations invalidate DX settings so readiness updates after the profile Discord panel.
- **Profile UI**: `DxNotificationsPanel` on `/user` (anchor `#dx-notifications`) with Discord readiness (`verified` / `not_linked` / `needs_relink`), opt-in switch, all-categories vs per-category checkboxes, loading/error/retry.
- **Staff DX dashboard**: Compact status strip + link to profile notification settings.
- **Tests**: Vitest for readiness, payloads, API error toast, dashboard link, and UserPage showing both Discord and DX panels.

Parent epic: https://github.com/pskillen/meshflow-api/issues/217

## Testing performed

- `npm run build` and `npm run lint`
- `npm run test` (full Vitest suite)
- `npm run format` (via pre-commit)