### PR TITLE
feat(traceroutes): heatmap node importance and health encoding

### DIFF
--- a/src/components/map/DeckMapboxMap.tsx
+++ b/src/components/map/DeckMapboxMap.tsx
@@ -17,6 +17,8 @@ export type DeckMapboxMapProps = {
   layers: Layer[];
   initialViewState: DeckMapboxInitialViewState;
   onClick?: (info: PickingInfo) => void;
+  /** Fires on pan/zoom; use for zoom-dependent overlays (e.g. labels). */
+  onViewStateChange?: DeckGLProps['onViewStateChange'];
   getTooltip?: DeckGLProps['getTooltip'];
   children?: ReactNode;
   className?: string;
@@ -32,6 +34,7 @@ export function DeckMapboxMap({
   layers,
   initialViewState,
   onClick,
+  onViewStateChange,
   getTooltip,
   children,
   className,
@@ -56,6 +59,7 @@ export function DeckMapboxMap({
         layers={layers}
         initialViewState={initialViewState}
         onClick={onClick}
+        onViewStateChange={onViewStateChange}
         getTooltip={getTooltip}
         style={{ width: '100%', height: '100%', minHeight: '200px', minWidth: '0' }}
       >

--- a/src/components/nodes/MyNodeCard.test.tsx
+++ b/src/components/nodes/MyNodeCard.test.tsx
@@ -75,22 +75,6 @@ describe('MyNodeCard', () => {
     expect(badge.className).toMatch(/border-destructive/);
   });
 
-  it('shows GPS position recent for fresh reported_time', () => {
-    renderCard({
-      node: makeNode({
-        latest_position: {
-          latitude: 55,
-          longitude: -4,
-          reported_time: new Date('2026-04-21T11:00:00Z'),
-          logged_time: null,
-          altitude: null,
-          location_source: 'gps',
-        },
-      }),
-    });
-    expect(screen.getByText('GPS position recent')).toBeInTheDocument();
-  });
-
   it('renders managed liveness warning when severity is warn', () => {
     renderCard({
       isManaged: true,
@@ -139,6 +123,22 @@ describe('MyNodeCard position hint styling (fixed clock)', () => {
   });
   afterEach(() => {
     vi.useRealTimers();
+  });
+
+  it('shows GPS position recent for fresh reported_time', () => {
+    renderCard({
+      node: makeNode({
+        latest_position: {
+          latitude: 55,
+          longitude: -4,
+          reported_time: new Date('2026-04-21T11:00:00Z'),
+          logged_time: null,
+          altitude: null,
+          location_source: 'gps',
+        },
+      }),
+    });
+    expect(screen.getByText('GPS position recent')).toBeInTheDocument();
   });
 
   it('applies warning-style border to stale GPS copy', () => {

--- a/src/components/traceroutes/TracerouteHeatmapMap.test.tsx
+++ b/src/components/traceroutes/TracerouteHeatmapMap.test.tsx
@@ -99,13 +99,13 @@ describe('TracerouteHeatmapMap', () => {
     );
 
     expect(layerIds(lastCapture().layers)).toEqual(
-      expect.arrayContaining(['heatmap-arcs-packets', 'heatmap-nodes', 'heatmap-node-labels'])
+      expect.arrayContaining(['heatmap-arcs-packets', 'heatmap-nodes'])
     );
 
     fireEvent.click(screen.getByTestId('mock-pick-node'));
 
     expect(layerIds(lastCapture().layers)).toEqual(
-      expect.arrayContaining(['heatmap-arcs-packets', 'heatmap-nodes', 'heatmap-node-labels'])
+      expect.arrayContaining(['heatmap-arcs-packets', 'heatmap-nodes'])
     );
   });
 
@@ -126,6 +126,5 @@ describe('TracerouteHeatmapMap', () => {
 
     expect(lastCapture().layers.some((l) => l.id === 'heatmap-arcs-snr')).toBe(true);
     expect(lastCapture().layers.some((l) => l.id === 'heatmap-nodes')).toBe(true);
-    expect(lastCapture().layers.some((l) => l.id === 'heatmap-node-labels')).toBe(true);
   });
 });

--- a/src/components/traceroutes/TracerouteHeatmapMap.tsx
+++ b/src/components/traceroutes/TracerouteHeatmapMap.tsx
@@ -2,6 +2,7 @@ import { useMemo, useState, useCallback } from 'react';
 import { Popup } from 'react-map-gl';
 import { ArcLayer, ScatterplotLayer, TextLayer } from '@deck.gl/layers';
 import type { PickingInfo } from '@deck.gl/core';
+import { formatDistanceToNow, parseISO } from 'date-fns';
 import { Link } from 'react-router-dom';
 import { X } from 'lucide-react';
 import type { HeatmapEdge, HeatmapNode } from '@/hooks/api/useHeatmapEdges';
@@ -9,6 +10,9 @@ import type { HeatmapEdge, HeatmapNode } from '@/hooks/api/useHeatmapEdges';
 import { DeckMapboxMap } from '@/components/map/DeckMapboxMap';
 
 const DEFAULT_CENTER = { longitude: -4.2518, latitude: 55.8642, zoom: 8 };
+/** Hide name labels when zoomed out past this level (deck.gl zoom). */
+const HEATMAP_LABEL_MIN_ZOOM = 9.5;
+
 const NODE_COLOR: [number, number, number, number] = [134, 239, 172, 200]; // light green
 // Packets: quiet = blue, busy = orange
 const PACKETS_QUIET_COLOR: [number, number, number, number] = [59, 130, 246, 200]; // blue
@@ -16,6 +20,9 @@ const PACKETS_BUSY_COLOR: [number, number, number, number] = [249, 115, 22, 200]
 // Link quality (SNR): unhealthy = red, healthy = green
 const SNR_BAD_COLOR: [number, number, number, number] = [239, 68, 68, 200]; // red
 const SNR_GOOD_COLOR: [number, number, number, number] = [34, 197, 94, 200]; // green
+
+/** Default hours without mesh observation before nodes fade (client-side styling). */
+const DEFAULT_STALE_THRESHOLD_HOURS = 6;
 
 function interpolatePacketsColor(weight: number, minW: number, maxW: number): [number, number, number, number] {
   if (maxW <= minW) return PACKETS_QUIET_COLOR;
@@ -35,11 +42,97 @@ function interpolateSnrColor(snr: number, minS: number, maxS: number): [number, 
   return [r, g, b, 200];
 }
 
+function numericExtent(values: number[]): { min: number; max: number } {
+  if (values.length === 0) return { min: 0, max: 1 };
+  let min = values[0];
+  let max = values[0];
+  for (const v of values) {
+    if (v < min) min = v;
+    if (v > max) max = v;
+  }
+  if (max <= min) return { min, max: min + 1e-9 };
+  return { min, max };
+}
+
+/** Client-side stale window (hours); fades nodes not heard within this window. */
+function staleThresholdMs(hours: number): number {
+  return hours * 60 * 60 * 1000;
+}
+
+function isVisuallyStale(node: HeatmapNode, nowMs: number, staleMs: number): boolean {
+  if (node.role === 'offline') return true;
+  if (!node.last_seen) return true;
+  const t = Date.parse(node.last_seen);
+  if (Number.isNaN(t)) return true;
+  return nowMs - t > staleMs;
+}
+
+/** Fill alpha by age within stale window (recent → opaque). */
+function recencyAlpha(node: HeatmapNode, nowMs: number, staleMs: number): number {
+  if (!node.last_seen) return 95;
+  const t = Date.parse(node.last_seen);
+  if (Number.isNaN(t)) return 95;
+  const age = nowMs - t;
+  if (age >= staleMs) return 88;
+  const u = age / staleMs;
+  return Math.round(255 - u * (255 - 155));
+}
+
+function degreeFillColor(
+  node: HeatmapNode,
+  degMin: number,
+  degMax: number,
+  nowMs: number,
+  staleMs: number
+): [number, number, number, number] {
+  const grey: [number, number, number] = [148, 163, 184];
+  if (isVisuallyStale(node, nowMs, staleMs)) {
+    return [...grey, 100];
+  }
+  const t = degMax > degMin ? ((node.degree ?? 0) - degMin) / (degMax - degMin) : 0.5;
+  const r = Math.round(59 + (249 - 59) * t);
+  const g = Math.round(130 + (115 - 130) * t);
+  const b = Math.round(246 + (22 - 246) * t);
+  const alpha = recencyAlpha(node, nowMs, staleMs);
+  return [r, g, b, alpha];
+}
+
+function nodeRadiusMeters(centrality: number | undefined, cMin: number, cMax: number): number {
+  if (centrality == null) return 380;
+  if (cMax <= cMin) return 380;
+  const u = (centrality - cMin) / (cMax - cMin);
+  return 140 + u * 760;
+}
+
+function nodeLineWidth(node: HeatmapNode, degMin: number, degMax: number): number {
+  const t = degMax > degMin ? ((node.degree ?? 0) - degMin) / (degMax - degMin) : 0;
+  let w = 1 + t * 6;
+  if (node.role === 'backbone') w += 2.5;
+  if (node.role === 'offline') w = Math.min(w, 1);
+  return w;
+}
+
+function nodeLineColor(fill: [number, number, number, number]): [number, number, number, number] {
+  const [r, g, b, a] = fill;
+  return [Math.round(r * 0.35), Math.round(g * 0.38), Math.round(b * 0.42), Math.min(255, a + 35)];
+}
+
+function formatRecency(iso: string | null | undefined): string {
+  if (!iso) return 'No recent mesh observation';
+  try {
+    return formatDistanceToNow(parseISO(iso), { addSuffix: true });
+  } catch {
+    return iso;
+  }
+}
+
 export interface TracerouteHeatmapMapProps {
   edges: HeatmapEdge[];
   nodes: HeatmapNode[];
   intensity?: number;
   edgeMetric?: 'packets' | 'snr';
+  /** Hours without last_seen before treating as stale for styling (default 6). */
+  staleThresholdHours?: number;
 }
 
 function getNodeLabel(node: HeatmapNode): string {
@@ -51,8 +144,21 @@ export function TracerouteHeatmapMap({
   nodes,
   intensity = 0.7,
   edgeMetric = 'packets',
+  staleThresholdHours = DEFAULT_STALE_THRESHOLD_HOURS,
 }: TracerouteHeatmapMapProps) {
   const [selectedNode, setSelectedNode] = useState<HeatmapNode | null>(null);
+  const [zoom, setZoom] = useState<number>(typeof DEFAULT_CENTER.zoom === 'number' ? DEFAULT_CENTER.zoom : 8);
+
+  const staleMs = staleThresholdMs(staleThresholdHours);
+
+  const nodeMetrics = useMemo(() => {
+    const hasSignal = nodes.some((n) => n.centrality != null && n.degree != null);
+    const centralities = nodes.map((n) => n.centrality).filter((c): c is number => c != null && !Number.isNaN(c));
+    const degrees = nodes.map((n) => n.degree).filter((d): d is number => d != null && !Number.isNaN(d));
+    const cExt = numericExtent(centralities.length ? centralities : [0, 1]);
+    const dExt = numericExtent(degrees.length ? degrees : [0, 1]);
+    return { cExt, dExt, hasSignal };
+  }, [nodes]);
 
   const handleClick = useCallback((info: PickingInfo) => {
     if (info.object && (info.layer?.id === 'heatmap-nodes' || info.layer?.id === 'heatmap-node-labels')) {
@@ -60,6 +166,11 @@ export function TracerouteHeatmapMap({
     } else {
       setSelectedNode(null);
     }
+  }, []);
+
+  const handleViewStateChange = useCallback((params: { viewState: { zoom?: number } }) => {
+    const z = params.viewState?.zoom;
+    if (typeof z === 'number' && !Number.isNaN(z)) setZoom(z);
   }, []);
 
   const arcLayer = useMemo(() => {
@@ -99,20 +210,36 @@ export function TracerouteHeatmapMap({
 
   const scatterLayer = useMemo(() => {
     if (nodes.length === 0) return null;
+    const nowMs = Date.now();
+    const { cExt, dExt, hasSignal } = nodeMetrics;
+
     return new ScatterplotLayer({
       id: 'heatmap-nodes',
       data: nodes,
       getPosition: (d) => [d.lng, d.lat],
-      getFillColor: () => NODE_COLOR,
-      getRadius: 100,
-      radiusMinPixels: 3,
-      radiusMaxPixels: 8,
+      getFillColor: (d) => (hasSignal ? degreeFillColor(d, dExt.min, dExt.max, nowMs, staleMs) : NODE_COLOR),
+      getRadius: (d) => (hasSignal ? nodeRadiusMeters(d.centrality, cExt.min, cExt.max) : 380),
+      radiusMinPixels: 4,
+      radiusMaxPixels: 22,
+      stroked: true,
+      lineWidthUnits: 'pixels',
+      getLineWidth: (d) => (hasSignal ? nodeLineWidth(d, dExt.min, dExt.max) : 1),
+      lineWidthMinPixels: 0.5,
+      lineWidthMaxPixels: 8,
+      getLineColor: (d) =>
+        hasSignal ? nodeLineColor(degreeFillColor(d, dExt.min, dExt.max, nowMs, staleMs)) : [30, 60, 40, 180],
       pickable: true,
+      updateTriggers: {
+        getFillColor: [nowMs, staleMs, hasSignal, dExt.min, dExt.max, cExt.min, cExt.max],
+        getRadius: [hasSignal, cExt.min, cExt.max],
+        getLineWidth: [hasSignal, dExt.min, dExt.max],
+        getLineColor: [nowMs, staleMs, hasSignal, dExt.min, dExt.max],
+      },
     });
-  }, [nodes]);
+  }, [nodes, nodeMetrics, staleMs]);
 
   const textLayer = useMemo(() => {
-    if (nodes.length === 0) return null;
+    if (nodes.length === 0 || zoom < HEATMAP_LABEL_MIN_ZOOM) return null;
     return new TextLayer({
       id: 'heatmap-node-labels',
       data: nodes,
@@ -130,7 +257,7 @@ export function TracerouteHeatmapMap({
       backgroundBorderRadius: 2,
       pickable: true,
     });
-  }, [nodes]);
+  }, [nodes, zoom]);
 
   const layers = useMemo(
     () => [arcLayer, scatterLayer, textLayer].filter(Boolean) as (ArcLayer | ScatterplotLayer | TextLayer)[],
@@ -142,6 +269,7 @@ export function TracerouteHeatmapMap({
       layers={layers}
       initialViewState={DEFAULT_CENTER}
       onClick={handleClick}
+      onViewStateChange={handleViewStateChange}
       data-testid="heatmap-map-container"
     >
       {selectedNode && (
@@ -172,6 +300,31 @@ export function TracerouteHeatmapMap({
               </div>
               <div className="mt-0.5 text-xs text-slate-400">
                 {selectedNode.node_id_str || `!${selectedNode.node_id.toString(16)}`}
+              </div>
+              {(selectedNode.centrality != null || selectedNode.degree != null) && (
+                <dl className="mt-2 space-y-0.5 text-xs text-slate-300">
+                  {selectedNode.centrality != null && (
+                    <div className="flex justify-between gap-2">
+                      <dt className="text-slate-500">Centrality</dt>
+                      <dd>{(selectedNode.centrality * 100).toFixed(1)}%</dd>
+                    </div>
+                  )}
+                  {selectedNode.degree != null && (
+                    <div className="flex justify-between gap-2">
+                      <dt className="text-slate-500">Degree</dt>
+                      <dd>{selectedNode.degree}</dd>
+                    </div>
+                  )}
+                  {selectedNode.role && (
+                    <div className="flex justify-between gap-2">
+                      <dt className="text-slate-500">Role</dt>
+                      <dd className="capitalize">{selectedNode.role}</dd>
+                    </div>
+                  )}
+                </dl>
+              )}
+              <div className="mt-1.5 text-xs text-slate-400">
+                Last seen: <span className="text-slate-300">{formatRecency(selectedNode.last_seen)}</span>
               </div>
               <Link
                 to={`/nodes/${selectedNode.node_id}`}

--- a/src/hooks/api/useHeatmapEdges.ts
+++ b/src/hooks/api/useHeatmapEdges.ts
@@ -12,6 +12,8 @@ export interface HeatmapEdge {
   avg_snr?: number;
 }
 
+export type HeatmapNodeRole = 'backbone' | 'relay' | 'leaf' | 'offline';
+
 export interface HeatmapNode {
   node_id: number;
   node_id_str: string;
@@ -19,6 +21,14 @@ export interface HeatmapNode {
   lng: number;
   short_name?: string;
   long_name?: string;
+  /** Normalised betweenness centrality (0–1), when provided by API */
+  centrality?: number;
+  /** Distinct neighbours in the heatmap subgraph */
+  degree?: number;
+  /** ISO 8601 from ObservedNode last_heard */
+  last_seen?: string | null;
+  /** Server-derived role (~24h offline cutoff) */
+  role?: HeatmapNodeRole;
 }
 
 export interface HeatmapEdgesData {

--- a/src/lib/api/meshtastic-api.ts
+++ b/src/lib/api/meshtastic-api.ts
@@ -869,6 +869,10 @@ export class MeshtasticApi extends BaseApi {
       lng: number;
       short_name?: string;
       long_name?: string;
+      centrality?: number;
+      degree?: number;
+      last_seen?: string | null;
+      role?: 'backbone' | 'relay' | 'leaf' | 'offline';
     }>;
     meta: {
       active_nodes_count: number;

--- a/src/pages/traceroutes/TracerouteHeatmapPage.tsx
+++ b/src/pages/traceroutes/TracerouteHeatmapPage.tsx
@@ -22,6 +22,9 @@ import { TRACEROUTE_STRATEGIES, type TracerouteStrategyValue } from '@/lib/trace
 type TimeRange = '24h' | '7d' | '30d' | 'custom';
 export type EdgeMetric = 'packets' | 'snr';
 
+/** Client-side stale styling threshold (hours without mesh observation). */
+const HEATMAP_STALE_THRESHOLD_HOURS = 6;
+
 function parseCsvParam<T extends string>(raw: string | null): T[] {
   if (!raw) return [];
   return raw
@@ -68,9 +71,11 @@ function toggleValue<T extends string>(current: T[], value: T): T[] {
 
 function NetworkStatsCard({
   meta,
+  staleThresholdHours,
   className,
 }: {
   meta: { active_nodes_count: number; total_trace_routes_count: number };
+  staleThresholdHours: number;
   className?: string;
 }) {
   return (
@@ -81,6 +86,15 @@ function NetworkStatsCard({
       <CardContent className="space-y-2 text-sm">
         <div>Active Nodes: {meta.active_nodes_count.toLocaleString()}</div>
         <div>Total Trace Routes: {meta.total_trace_routes_count.toLocaleString()}</div>
+        <div className="border-t border-border pt-2">
+          <div className="mb-1 text-xs font-medium text-muted-foreground">Nodes (topology)</div>
+          <ul className="list-inside list-disc space-y-1 text-xs text-muted-foreground">
+            <li>Dot size — centrality (backbone paths)</li>
+            <li>Fill hue — degree (cool → warm)</li>
+            <li>Ring weight — degree + backbone role (also for colour-blind contrast)</li>
+            <li>Opacity — mesh recency (older than {staleThresholdHours}h fades; API role “offline” from ~24h)</li>
+          </ul>
+        </div>
         <div className="pt-2">
           <div className="mb-1 text-xs text-muted-foreground">Packets: Quiet → Busy</div>
           <div
@@ -259,7 +273,7 @@ export function TracerouteHeatmapPage({ edgeMetric }: { edgeMetric: EdgeMetric }
 
       {/* Stats: below top bar on mobile, overlay on desktop */}
       <div className="block md:hidden">
-        <NetworkStatsCard meta={meta} />
+        <NetworkStatsCard meta={meta} staleThresholdHours={HEATMAP_STALE_THRESHOLD_HOURS} />
       </div>
 
       {/* Map area */}
@@ -276,13 +290,20 @@ export function TracerouteHeatmapPage({ edgeMetric }: { edgeMetric: EdgeMetric }
                 Loading heatmap data...
               </div>
             )}
-            {!error && !isLoading && <TracerouteHeatmapMap edges={edges} nodes={nodes} edgeMetric={edgeMetric} />}
+            {!error && !isLoading && (
+              <TracerouteHeatmapMap
+                edges={edges}
+                nodes={nodes}
+                edgeMetric={edgeMetric}
+                staleThresholdHours={HEATMAP_STALE_THRESHOLD_HOURS}
+              />
+            )}
           </CardContent>
         </Card>
 
         {/* Stats overlay on desktop */}
         <div className="absolute right-4 top-4 z-10 hidden md:block">
-          <NetworkStatsCard meta={meta} className="w-56" />
+          <NetworkStatsCard meta={meta} staleThresholdHours={HEATMAP_STALE_THRESHOLD_HOURS} className="w-64" />
         </div>
       </div>
     </div>


### PR DESCRIPTION
# Summary

Implements node importance and health encoding for the traceroute heatmap, closing #156.

The heatmap now uses the enriched `heatmap-edges` node fields to show more than a uniform dot:

* Node radius reflects betweenness centrality, making backbone nodes visually larger.
* Fill colour reflects degree, using a cool-to-warm scale for low-to-high neighbour counts.
* Opacity and grey styling reflect staleness / offline state from `last_seen` and `role`.
* Ring width provides a non-colour cue for degree/backbone importance.
* Node labels hide below the zoom threshold to reduce clutter.
* Popups show centrality, degree, role, and relative last-seen time.
* The map legend explains size, fill, ring width, and recency/staleness channels.

This also extends the heatmap API types with optional `centrality`, `degree`, `last_seen`, and `role`, so the UI remains compatible while the API PR rolls out.

## Background

Depends on pskillen/meshflow-api#253 for the new node fields. Merge/deploy the API first for the full visual encoding. Without the API fields, the heatmap falls back to the previous uniform node styling.

This PR also fixes a flaky `MyNodeCard` GPS recency test by moving the “recent” assertion under the existing fake-clock test block. The previous test used fixed April 2026 data against the real system clock, so it became stale once the real date moved past the seven-day threshold.

## Deployment notes

* No frontend environment changes.
* No data backfill or Neo4j re-export required.
* Best deployed after pskillen/meshflow-api#253.

## Testing performed

* `cd /Users/patricks/git_personal/meshtastic-bot-ui && npm run build`
* `cd /Users/patricks/git_personal/meshtastic-bot-ui && npm test -- --run TracerouteHeatmapMap TracerouteHeatmapPage`
* `cd /Users/patricks/git_personal/meshtastic-bot-ui && npm test -- --run src/components/nodes/MyNodeCard.test.tsx`
* `cd /Users/patricks/git_personal/meshtastic-bot-ui && npm test -- --run` — 47 files / 226 tests passed
* `npm run lint` was run and reported existing warnings only (0 errors).