### PR TITLE
feat(traceroutes): topology view and heatmap role exploration (#159)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -8,6 +8,7 @@
       "name": "meshtastic-bot-ui",
       "version": "0.0.0",
       "dependencies": {
+        "@deck.gl/extensions": "~9.2.0",
         "@deck.gl/geo-layers": "~9.2.0",
         "@deck.gl/layers": "^9.0.0",
         "@dnd-kit/core": "^6.3.1",

--- a/package.json
+++ b/package.json
@@ -21,6 +21,7 @@
     "prepare": "husky"
   },
   "dependencies": {
+    "@deck.gl/extensions": "~9.2.0",
     "@deck.gl/geo-layers": "~9.2.0",
     "@deck.gl/layers": "^9.0.0",
     "@dnd-kit/core": "^6.3.1",

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,6 +1,7 @@
 import { Suspense, lazy } from 'react';
 import { TracerouteHistory } from '@/pages/traceroutes/TracerouteHistory';
 import { TracerouteHeatmapPage } from '@/pages/traceroutes/TracerouteHeatmapPage';
+import { TracerouteTopologyPage } from '@/pages/traceroutes/TracerouteTopologyPage';
 import { FeederCoveragePage } from '@/pages/traceroutes/FeederCoveragePage';
 import { ConstellationCoveragePage } from '@/pages/traceroutes/ConstellationCoveragePage';
 import { BrowserRouter as Router, Routes, Route, Navigate } from 'react-router-dom';
@@ -72,8 +73,17 @@ function App() {
                   <Route path="/messages" element={<MessageHistory />} />
                   <Route path="/traceroutes" element={<TracerouteHistory />} />
                   <Route path="/traceroutes/heatmap" element={<Navigate to="/traceroutes/map/heat" replace />} />
+                  <Route
+                    path="/traceroutes/topology"
+                    element={<Navigate to="/traceroutes/map/topology/heat" replace />}
+                  />
                   <Route path="/traceroutes/map/heat" element={<TracerouteHeatmapPage edgeMetric="packets" />} />
                   <Route path="/traceroutes/map/snr" element={<TracerouteHeatmapPage edgeMetric="snr" />} />
+                  <Route
+                    path="/traceroutes/map/topology/heat"
+                    element={<TracerouteTopologyPage edgeMetric="packets" />}
+                  />
+                  <Route path="/traceroutes/map/topology/snr" element={<TracerouteTopologyPage edgeMetric="snr" />} />
                   <Route path="/traceroutes/map/coverage" element={<FeederCoveragePage />} />
                   <Route
                     path="/traceroutes/map/coverage/constellation/:constellationId"

--- a/src/components/map/DeckMapboxMap.tsx
+++ b/src/components/map/DeckMapboxMap.tsx
@@ -1,4 +1,5 @@
 import type { ReactNode } from 'react';
+import { useLayoutEffect, useRef } from 'react';
 
 import type { Layer, PickingInfo } from '@deck.gl/core';
 import { DeckGL } from 'deck.gl';
@@ -9,6 +10,19 @@ import { Map } from 'react-map-gl';
 import { useConfig } from '@/providers/ConfigProvider';
 import { useMapboxStyle } from '@/hooks/useMapboxStyle';
 import { cn } from '@/lib/utils';
+
+/** Move Mapbox popups to the deck.gl wrapper so they stack above the WebGL canvas (@deck.gl/react forces Map to z-index -1). */
+function reparentMapboxPopupsIntoDeckWrapper(root: HTMLElement) {
+  const deckWrap =
+    root.querySelector<HTMLElement>('#deckgl-wrapper') ?? root.querySelector<HTMLElement>('[id$="deckgl-wrapper"]');
+  if (!deckWrap) return;
+  const popups = root.querySelectorAll<HTMLElement>('.mapboxgl-popup');
+  popups.forEach((popup) => {
+    if (popup.parentElement !== deckWrap) {
+      deckWrap.appendChild(popup);
+    }
+  });
+}
 
 /** DeckGL `initialViewState` (longitude, latitude, zoom, etc.). */
 export type DeckMapboxInitialViewState = NonNullable<DeckGLProps['initialViewState']>;
@@ -23,6 +37,11 @@ export type DeckMapboxMapProps = {
   children?: ReactNode;
   className?: string;
   'data-testid'?: string;
+  /**
+   * Reparent `.mapboxgl-popup` nodes into the deck.gl root so popups render above deck layers.
+   * Disable only if you hit positioning issues with a custom Mapbox integration.
+   */
+  elevateMapboxPopups?: boolean;
 };
 
 /**
@@ -39,10 +58,26 @@ export function DeckMapboxMap({
   children,
   className,
   'data-testid': testId,
+  elevateMapboxPopups = true,
 }: DeckMapboxMapProps) {
+  const rootRef = useRef<HTMLDivElement>(null);
   const config = useConfig();
   const mapboxToken = config.mapboxToken ?? (import.meta.env.VITE_MAPBOX_TOKEN as string | undefined);
   const mapStyle = useMapboxStyle();
+
+  useLayoutEffect(() => {
+    if (!mapboxToken || !elevateMapboxPopups) return;
+    const root = rootRef.current;
+    if (!root) return;
+    const run = () => reparentMapboxPopupsIntoDeckWrapper(root);
+    run();
+    const raf = requestAnimationFrame(run);
+    const t = window.setTimeout(run, 0);
+    return () => {
+      cancelAnimationFrame(raf);
+      window.clearTimeout(t);
+    };
+  }, [mapboxToken, elevateMapboxPopups, children]);
 
   if (!mapboxToken) {
     return (
@@ -53,7 +88,7 @@ export function DeckMapboxMap({
   }
 
   return (
-    <div className={cn('relative h-full w-full', className)} data-testid={testId}>
+    <div ref={rootRef} className={cn('relative h-full w-full', className)} data-testid={testId}>
       <DeckGL
         controller
         layers={layers}

--- a/src/components/nav-main.tsx
+++ b/src/components/nav-main.tsx
@@ -11,7 +11,7 @@ import {
   RouteIcon,
   ScanSearchIcon,
   ServerIcon,
-  SignalIcon,
+  Share2,
   type LucideIcon,
 } from 'lucide-react';
 import { Link, useLocation, useNavigate } from 'react-router-dom';
@@ -50,6 +50,21 @@ function isPathActive(pathname: string, url: string, exact: boolean) {
   return pathname === url || pathname.startsWith(`${url}/`);
 }
 
+function navSubItemActive(pathname: string, childUrl: string): boolean {
+  switch (childUrl) {
+    case '/traceroutes/map/heat':
+      return pathname === '/traceroutes/map/heat' || pathname === '/traceroutes/map/snr';
+    case '/traceroutes/map/topology/heat':
+      return pathname.startsWith('/traceroutes/map/topology');
+    case '/traceroutes/map/coverage':
+      return pathname === '/traceroutes/map/coverage';
+    case '/traceroutes/map/coverage/constellation':
+      return pathname.startsWith('/traceroutes/map/coverage/constellation');
+    default:
+      return pathname === childUrl || pathname.startsWith(`${childUrl}/`);
+  }
+}
+
 export function NavMain() {
   const { hasUnreadMessages, unreadMessages, markAllAsRead } = useWebSocket();
   const navigate = useNavigate();
@@ -84,8 +99,7 @@ export function NavMain() {
       icon: RouteIcon,
       children: [
         { title: 'Heatmap', url: '/traceroutes/map/heat', icon: MapIcon },
-        { title: 'Topology', url: '/traceroutes/map/topology/heat', icon: NetworkIcon },
-        { title: 'Link quality', url: '/traceroutes/map/snr', icon: SignalIcon },
+        { title: 'Topology', url: '/traceroutes/map/topology/heat', icon: Share2 },
         { title: 'Coverage by node', url: '/traceroutes/map/coverage', icon: CircleDashedIcon },
         {
           title: 'Constellation coverage',
@@ -130,7 +144,7 @@ export function NavMain() {
                   <SidebarMenuSub>
                     {item.children.map((child) => {
                       const ChildIcon = child.icon;
-                      const childIsActive = isPathActive(pathname, child.url, true);
+                      const childIsActive = navSubItemActive(pathname, child.url);
                       return (
                         <SidebarMenuSubItem key={child.title}>
                           <SidebarMenuSubButton asChild isActive={childIsActive}>

--- a/src/components/nav-main.tsx
+++ b/src/components/nav-main.tsx
@@ -84,6 +84,7 @@ export function NavMain() {
       icon: RouteIcon,
       children: [
         { title: 'Heatmap', url: '/traceroutes/map/heat', icon: MapIcon },
+        { title: 'Topology', url: '/traceroutes/map/topology/heat', icon: NetworkIcon },
         { title: 'Link quality', url: '/traceroutes/map/snr', icon: SignalIcon },
         { title: 'Coverage by node', url: '/traceroutes/map/coverage', icon: CircleDashedIcon },
         {

--- a/src/components/nav-main.tsx
+++ b/src/components/nav-main.tsx
@@ -98,7 +98,7 @@ export function NavMain() {
       url: '/traceroutes',
       icon: RouteIcon,
       children: [
-        { title: 'Heatmap', url: '/traceroutes/map/heat', icon: MapIcon },
+        { title: 'Geographic', url: '/traceroutes/map/heat', icon: MapIcon },
         { title: 'Topology', url: '/traceroutes/map/topology/heat', icon: Share2 },
         { title: 'Coverage by node', url: '/traceroutes/map/coverage', icon: CircleDashedIcon },
         {

--- a/src/components/traceroutes/TracerouteHeatmapBackboneRelayTable.tsx
+++ b/src/components/traceroutes/TracerouteHeatmapBackboneRelayTable.tsx
@@ -5,19 +5,55 @@ import { Table, TableBody, TableCell, TableHead, TableHeader, TableRow } from '@
 import type { HeatmapNode } from '@/hooks/api/useHeatmapEdges';
 import { getHeatmapNodeLabel } from '@/components/traceroutes/heatmapEncoding';
 
-function roleSort(a: HeatmapNode, b: HeatmapNode): number {
-  const rank = (r: string | undefined) => (r === 'backbone' ? 0 : r === 'relay' ? 1 : 2);
-  const dr = rank(a.role) - rank(b.role);
-  if (dr !== 0) return dr;
-  const ca = a.centrality ?? 0;
-  const cb = b.centrality ?? 0;
-  return cb - ca;
+function byCentralityDesc(a: HeatmapNode, b: HeatmapNode): number {
+  return (b.centrality ?? 0) - (a.centrality ?? 0);
+}
+
+const SCROLL_AREA_HEIGHT = 'h-56'; /* 14rem; fixed so both panels align */
+
+function RoleNodeTable({ nodes }: { nodes: HeatmapNode[] }) {
+  if (nodes.length === 0) {
+    return (
+      <div className="text-muted-foreground flex h-full min-h-[4rem] items-center justify-center px-3 text-sm">
+        None for these filters.
+      </div>
+    );
+  }
+
+  return (
+    <Table>
+      <TableHeader className="bg-card sticky top-0 z-[1] shadow-[0_1px_0_0_hsl(var(--border))]">
+        <TableRow>
+          <TableHead className="w-[48%]">Node</TableHead>
+          <TableHead className="text-right">Centrality</TableHead>
+          <TableHead className="text-right">Degree</TableHead>
+        </TableRow>
+      </TableHeader>
+      <TableBody>
+        {nodes.map((n) => (
+          <TableRow key={n.node_id}>
+            <TableCell>
+              <Link to={`/nodes/${n.node_id}`} className="font-medium text-primary hover:underline">
+                {getHeatmapNodeLabel(n)}
+              </Link>
+              <div className="text-muted-foreground text-xs">{n.node_id_str ?? `!${n.node_id.toString(16)}`}</div>
+            </TableCell>
+            <TableCell className="text-right tabular-nums">
+              {n.centrality != null ? `${(n.centrality * 100).toFixed(1)}%` : '—'}
+            </TableCell>
+            <TableCell className="text-right tabular-nums">{n.degree ?? '—'}</TableCell>
+          </TableRow>
+        ))}
+      </TableBody>
+    </Table>
+  );
 }
 
 export function TracerouteHeatmapBackboneRelayTable({ nodes }: { nodes: HeatmapNode[] }) {
-  const rows = useMemo(() => nodes.filter((n) => n.role === 'backbone' || n.role === 'relay').sort(roleSort), [nodes]);
+  const backbone = useMemo(() => nodes.filter((n) => n.role === 'backbone').sort(byCentralityDesc), [nodes]);
+  const relay = useMemo(() => nodes.filter((n) => n.role === 'relay').sort(byCentralityDesc), [nodes]);
 
-  if (rows.length === 0) {
+  if (backbone.length === 0 && relay.length === 0) {
     return (
       <Card data-testid="heatmap-backbone-relay-table">
         <CardHeader className="pb-2">
@@ -36,34 +72,25 @@ export function TracerouteHeatmapBackboneRelayTable({ nodes }: { nodes: HeatmapN
           Nodes classified from mesh topology (betweenness and degree). Same roles as on the map.
         </CardDescription>
       </CardHeader>
-      <CardContent className="overflow-x-auto px-2 pb-4 pt-0 sm:px-6">
-        <Table>
-          <TableHeader>
-            <TableRow>
-              <TableHead className="w-[40%]">Node</TableHead>
-              <TableHead>Role</TableHead>
-              <TableHead className="text-right">Centrality</TableHead>
-              <TableHead className="text-right">Degree</TableHead>
-            </TableRow>
-          </TableHeader>
-          <TableBody>
-            {rows.map((n) => (
-              <TableRow key={n.node_id}>
-                <TableCell>
-                  <Link to={`/nodes/${n.node_id}`} className="font-medium text-primary hover:underline">
-                    {getHeatmapNodeLabel(n)}
-                  </Link>
-                  <div className="text-xs text-muted-foreground">{n.node_id_str ?? `!${n.node_id.toString(16)}`}</div>
-                </TableCell>
-                <TableCell className="capitalize">{n.role}</TableCell>
-                <TableCell className="text-right tabular-nums">
-                  {n.centrality != null ? `${(n.centrality * 100).toFixed(1)}%` : '—'}
-                </TableCell>
-                <TableCell className="text-right tabular-nums">{n.degree ?? '—'}</TableCell>
-              </TableRow>
-            ))}
-          </TableBody>
-        </Table>
+      <CardContent className="px-2 pb-4 pt-0 sm:px-6">
+        <div className="grid gap-6 md:grid-cols-2">
+          <section data-testid="heatmap-backbone-list">
+            <h3 className="text-foreground mb-2 text-sm font-semibold tracking-tight">Backbone</h3>
+            <div
+              className={`border-border bg-card overflow-x-auto overflow-y-auto rounded-md border ${SCROLL_AREA_HEIGHT}`}
+            >
+              <RoleNodeTable nodes={backbone} />
+            </div>
+          </section>
+          <section data-testid="heatmap-relay-list">
+            <h3 className="text-foreground mb-2 text-sm font-semibold tracking-tight">Relay</h3>
+            <div
+              className={`border-border bg-card overflow-x-auto overflow-y-auto rounded-md border ${SCROLL_AREA_HEIGHT}`}
+            >
+              <RoleNodeTable nodes={relay} />
+            </div>
+          </section>
+        </div>
       </CardContent>
     </Card>
   );

--- a/src/components/traceroutes/TracerouteHeatmapBackboneRelayTable.tsx
+++ b/src/components/traceroutes/TracerouteHeatmapBackboneRelayTable.tsx
@@ -11,6 +11,22 @@ function byCentralityDesc(a: HeatmapNode, b: HeatmapNode): number {
 
 const SCROLL_AREA_HEIGHT = 'h-56'; /* 14rem; fixed so both panels align */
 
+function MetricsColumnDescriptions() {
+  return (
+    <div className="text-muted-foreground mb-4 space-y-1.5 text-sm leading-snug">
+      <p>
+        <span className="text-foreground font-medium">Centrality</span> — Normalised betweenness for this filtered
+        graph, shown as 0–100%. Higher values mean more shortest traceroute paths between other nodes pass through this
+        node.
+      </p>
+      <p>
+        <span className="text-foreground font-medium">Degree</span> — Number of distinct neighbours (other nodes linked
+        by at least one edge) in this filtered graph.
+      </p>
+    </div>
+  );
+}
+
 function RoleNodeTable({ nodes }: { nodes: HeatmapNode[] }) {
   if (nodes.length === 0) {
     return (
@@ -58,8 +74,16 @@ export function TracerouteHeatmapBackboneRelayTable({ nodes }: { nodes: HeatmapN
       <Card data-testid="heatmap-backbone-relay-table">
         <CardHeader className="pb-2">
           <CardTitle className="text-base">Backbone and relay nodes</CardTitle>
-          <CardDescription>No backbone or relay nodes in this graph for the current filters.</CardDescription>
+          <CardDescription>
+            Nodes classified from mesh topology (betweenness and degree). Same roles as on the map and topology views.
+          </CardDescription>
         </CardHeader>
+        <CardContent className="px-2 pb-4 pt-0 sm:px-6">
+          <MetricsColumnDescriptions />
+          <p className="text-muted-foreground text-sm">
+            No backbone or relay nodes in this graph for the current filters.
+          </p>
+        </CardContent>
       </Card>
     );
   }
@@ -69,10 +93,11 @@ export function TracerouteHeatmapBackboneRelayTable({ nodes }: { nodes: HeatmapN
       <CardHeader className="pb-2">
         <CardTitle className="text-base">Backbone and relay nodes</CardTitle>
         <CardDescription>
-          Nodes classified from mesh topology (betweenness and degree). Same roles as on the map.
+          Nodes classified from mesh topology (betweenness and degree). Same roles as on the map and topology views.
         </CardDescription>
       </CardHeader>
       <CardContent className="px-2 pb-4 pt-0 sm:px-6">
+        <MetricsColumnDescriptions />
         <div className="grid gap-6 md:grid-cols-2">
           <section data-testid="heatmap-backbone-list">
             <h3 className="text-foreground mb-2 text-sm font-semibold tracking-tight">Backbone</h3>

--- a/src/components/traceroutes/TracerouteHeatmapBackboneRelayTable.tsx
+++ b/src/components/traceroutes/TracerouteHeatmapBackboneRelayTable.tsx
@@ -1,0 +1,70 @@
+import { useMemo } from 'react';
+import { Link } from 'react-router-dom';
+import { Card, CardContent, CardDescription, CardHeader, CardTitle } from '@/components/ui/card';
+import { Table, TableBody, TableCell, TableHead, TableHeader, TableRow } from '@/components/ui/table';
+import type { HeatmapNode } from '@/hooks/api/useHeatmapEdges';
+import { getHeatmapNodeLabel } from '@/components/traceroutes/heatmapEncoding';
+
+function roleSort(a: HeatmapNode, b: HeatmapNode): number {
+  const rank = (r: string | undefined) => (r === 'backbone' ? 0 : r === 'relay' ? 1 : 2);
+  const dr = rank(a.role) - rank(b.role);
+  if (dr !== 0) return dr;
+  const ca = a.centrality ?? 0;
+  const cb = b.centrality ?? 0;
+  return cb - ca;
+}
+
+export function TracerouteHeatmapBackboneRelayTable({ nodes }: { nodes: HeatmapNode[] }) {
+  const rows = useMemo(() => nodes.filter((n) => n.role === 'backbone' || n.role === 'relay').sort(roleSort), [nodes]);
+
+  if (rows.length === 0) {
+    return (
+      <Card data-testid="heatmap-backbone-relay-table">
+        <CardHeader className="pb-2">
+          <CardTitle className="text-base">Backbone and relay nodes</CardTitle>
+          <CardDescription>No backbone or relay nodes in this graph for the current filters.</CardDescription>
+        </CardHeader>
+      </Card>
+    );
+  }
+
+  return (
+    <Card data-testid="heatmap-backbone-relay-table">
+      <CardHeader className="pb-2">
+        <CardTitle className="text-base">Backbone and relay nodes</CardTitle>
+        <CardDescription>
+          Nodes classified from mesh topology (betweenness and degree). Same roles as on the map.
+        </CardDescription>
+      </CardHeader>
+      <CardContent className="overflow-x-auto px-2 pb-4 pt-0 sm:px-6">
+        <Table>
+          <TableHeader>
+            <TableRow>
+              <TableHead className="w-[40%]">Node</TableHead>
+              <TableHead>Role</TableHead>
+              <TableHead className="text-right">Centrality</TableHead>
+              <TableHead className="text-right">Degree</TableHead>
+            </TableRow>
+          </TableHeader>
+          <TableBody>
+            {rows.map((n) => (
+              <TableRow key={n.node_id}>
+                <TableCell>
+                  <Link to={`/nodes/${n.node_id}`} className="font-medium text-primary hover:underline">
+                    {getHeatmapNodeLabel(n)}
+                  </Link>
+                  <div className="text-xs text-muted-foreground">{n.node_id_str ?? `!${n.node_id.toString(16)}`}</div>
+                </TableCell>
+                <TableCell className="capitalize">{n.role}</TableCell>
+                <TableCell className="text-right tabular-nums">
+                  {n.centrality != null ? `${(n.centrality * 100).toFixed(1)}%` : '—'}
+                </TableCell>
+                <TableCell className="text-right tabular-nums">{n.degree ?? '—'}</TableCell>
+              </TableRow>
+            ))}
+          </TableBody>
+        </Table>
+      </CardContent>
+    </Card>
+  );
+}

--- a/src/components/traceroutes/TracerouteHeatmapChrome.tsx
+++ b/src/components/traceroutes/TracerouteHeatmapChrome.tsx
@@ -1,0 +1,270 @@
+import { Link } from 'react-router-dom';
+import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card';
+import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from '@/components/ui/select';
+import { Button } from '@/components/ui/button';
+import {
+  DropdownMenu,
+  DropdownMenuCheckboxItem,
+  DropdownMenuContent,
+  DropdownMenuLabel,
+  DropdownMenuSeparator,
+  DropdownMenuTrigger,
+} from '@/components/ui/dropdown-menu';
+import type { ManagedNode } from '@/lib/models';
+import { RouteIcon, ChevronDown, X } from 'lucide-react';
+import { cn } from '@/lib/utils';
+import { TRACEROUTE_STRATEGIES, type TracerouteStrategyValue } from '@/lib/traceroute-strategy';
+
+export type HeatmapViewMode = 'map' | 'topology';
+
+const HEATMAP_STRATEGY_OPTIONS: Array<{ value: TracerouteStrategyValue; label: string }> = TRACEROUTE_STRATEGIES.filter(
+  (v) => v !== 'legacy'
+).map((value) => ({
+  value,
+  label:
+    value === 'intra_zone'
+      ? 'Intra-zone'
+      : value === 'dx_across'
+        ? 'DX across'
+        : value === 'dx_same_side'
+          ? 'DX same side'
+          : value,
+}));
+
+function multiSelectLabel<T extends string>(
+  values: T[],
+  options: Array<{ value: T; label: string }>,
+  fallback: string
+): string {
+  if (values.length === 0) return fallback;
+  if (values.length === 1) {
+    return options.find((o) => o.value === values[0])?.label ?? values[0];
+  }
+  return `${fallback} (${values.length})`;
+}
+
+export function NetworkStatsCard({
+  meta,
+  staleThresholdHours,
+  className,
+}: {
+  meta: { active_nodes_count: number; total_trace_routes_count: number };
+  staleThresholdHours: number;
+  className?: string;
+}) {
+  return (
+    <Card className={className}>
+      <CardHeader className="pb-2">
+        <CardTitle className="text-sm">Network Stats</CardTitle>
+      </CardHeader>
+      <CardContent className="space-y-2 text-sm">
+        <div>Active Nodes: {meta.active_nodes_count.toLocaleString()}</div>
+        <div>Total Trace Routes: {meta.total_trace_routes_count.toLocaleString()}</div>
+        <div className="border-t border-border pt-2">
+          <div className="mb-1 text-xs font-medium text-muted-foreground">Nodes (topology)</div>
+          <ul className="list-inside list-disc space-y-1 text-xs text-muted-foreground">
+            <li>Dot size — centrality (backbone paths)</li>
+            <li>Fill hue — degree (cool → warm)</li>
+            <li>Ring weight — degree + backbone role (also for colour-blind contrast)</li>
+            <li>Opacity — mesh recency (older than {staleThresholdHours}h fades; API role “offline” from ~24h)</li>
+          </ul>
+        </div>
+        <div className="pt-2">
+          <div className="mb-1 text-xs text-muted-foreground">Packets: Quiet → Busy</div>
+          <div
+            className="h-2 w-full rounded"
+            style={{
+              background: 'linear-gradient(to right, #3b82f6, #f97316)',
+            }}
+          />
+          <div className="mt-1 flex justify-between text-xs text-muted-foreground">
+            <span>Quiet (blue)</span>
+            <span>Busy (orange)</span>
+          </div>
+          <div className="mb-1 mt-2 text-xs text-muted-foreground">Link quality: Unhealthy → Healthy</div>
+          <div
+            className="h-2 w-full rounded"
+            style={{
+              background: 'linear-gradient(to right, #ef4444, #22c55e)',
+            }}
+          />
+          <div className="mt-1 flex justify-between text-xs text-muted-foreground">
+            <span>Unhealthy (red)</span>
+            <span>Healthy (green)</span>
+          </div>
+        </div>
+      </CardContent>
+    </Card>
+  );
+}
+
+export type EdgeMetric = 'packets' | 'snr';
+
+export interface TracerouteHeatmapChromeProps {
+  viewMode: HeatmapViewMode;
+  edgeMetric: EdgeMetric;
+  searchSuffix: string;
+  timeRange: '24h' | '7d' | '30d' | 'custom';
+  onTimeRangeChange: (v: '24h' | '7d' | '30d' | 'custom') => void;
+  strategyTokens: TracerouteStrategyValue[];
+  sourceMeshId: number | null;
+  managedNodes: ManagedNode[];
+  hasGeoFilters: boolean;
+  onUpdateParams: (patch: Record<string, string | null>) => void;
+}
+
+function toggleValue<T extends string>(current: T[], value: T): T[] {
+  return current.includes(value) ? current.filter((v) => v !== value) : [...current, value];
+}
+
+export function TracerouteHeatmapChrome({
+  viewMode,
+  edgeMetric,
+  searchSuffix,
+  timeRange,
+  onTimeRangeChange,
+  strategyTokens,
+  sourceMeshId,
+  managedNodes,
+  hasGeoFilters,
+  onUpdateParams,
+}: TracerouteHeatmapChromeProps) {
+  const mapPacketsPath = '/traceroutes/map/heat';
+  const mapSnrPath = '/traceroutes/map/snr';
+  const topoPacketsPath = '/traceroutes/map/topology/heat';
+  const topoSnrPath = '/traceroutes/map/topology/snr';
+  const mapPathForMetric = edgeMetric === 'packets' ? mapPacketsPath : mapSnrPath;
+  const topoPathForMetric = edgeMetric === 'packets' ? topoPacketsPath : topoSnrPath;
+
+  return (
+    <div className="flex flex-col gap-4 sm:flex-row sm:items-center sm:justify-between">
+      <div className="flex items-center gap-2">
+        <RouteIcon className="h-6 w-6" />
+        <h1 className="text-xl font-semibold sm:text-2xl">Traceroute Heatmap</h1>
+      </div>
+      <div className="flex flex-wrap items-center gap-4" data-testid="heatmap-filters">
+        <div className="flex flex-wrap gap-2 rounded-md border border-input bg-muted/50 p-0.5">
+          <Link
+            to={`${mapPathForMetric}${searchSuffix}`}
+            className={cn(
+              'rounded px-3 py-1.5 text-sm font-medium transition-colors',
+              viewMode === 'map'
+                ? 'bg-background text-foreground shadow-sm'
+                : 'text-muted-foreground hover:text-foreground'
+            )}
+          >
+            Map
+          </Link>
+          <Link
+            to={`${topoPathForMetric}${searchSuffix}`}
+            className={cn(
+              'rounded px-3 py-1.5 text-sm font-medium transition-colors',
+              viewMode === 'topology'
+                ? 'bg-background text-foreground shadow-sm'
+                : 'text-muted-foreground hover:text-foreground'
+            )}
+          >
+            Topology
+          </Link>
+        </div>
+
+        <div className="flex rounded-md border border-input bg-muted/50 p-0.5">
+          <Link
+            to={`${viewMode === 'topology' ? topoPacketsPath : mapPacketsPath}${searchSuffix}`}
+            className={cn(
+              'rounded px-3 py-1.5 text-sm font-medium transition-colors',
+              edgeMetric === 'packets'
+                ? 'bg-background text-foreground shadow-sm'
+                : 'text-muted-foreground hover:text-foreground'
+            )}
+          >
+            Packets
+          </Link>
+          <Link
+            to={`${viewMode === 'topology' ? topoSnrPath : mapSnrPath}${searchSuffix}`}
+            className={cn(
+              'rounded px-3 py-1.5 text-sm font-medium transition-colors',
+              edgeMetric === 'snr'
+                ? 'bg-background text-foreground shadow-sm'
+                : 'text-muted-foreground hover:text-foreground'
+            )}
+          >
+            Link quality (SNR)
+          </Link>
+        </div>
+
+        <div className="w-full sm:w-auto sm:min-w-[180px]">
+          <Select value={timeRange} onValueChange={(v) => onTimeRangeChange(v as '24h' | '7d' | '30d' | 'custom')}>
+            <SelectTrigger>
+              <SelectValue />
+            </SelectTrigger>
+            <SelectContent>
+              <SelectItem value="24h">Last 24 Hours</SelectItem>
+              <SelectItem value="7d">Last 7 Days</SelectItem>
+              <SelectItem value="30d">Last 30 Days</SelectItem>
+              <SelectItem value="custom">Custom</SelectItem>
+            </SelectContent>
+          </Select>
+        </div>
+
+        <Select
+          value={sourceMeshId != null ? String(sourceMeshId) : 'all'}
+          onValueChange={(v) => onUpdateParams({ source: v === 'all' ? null : v })}
+        >
+          <SelectTrigger className="w-full sm:w-[200px]" data-testid="heatmap-source-select">
+            <SelectValue placeholder="Source feeder" />
+          </SelectTrigger>
+          <SelectContent>
+            <SelectItem value="all">All sources</SelectItem>
+            {managedNodes.map((n) => (
+              <SelectItem key={n.node_id} value={String(n.node_id)}>
+                {n.short_name ?? n.node_id_str ?? String(n.node_id)}
+              </SelectItem>
+            ))}
+          </SelectContent>
+        </Select>
+
+        <DropdownMenu>
+          <DropdownMenuTrigger asChild>
+            <Button variant="outline" size="sm" className="w-full sm:w-[180px] justify-between" type="button">
+              {multiSelectLabel(strategyTokens, HEATMAP_STRATEGY_OPTIONS, 'Strategy')}
+              <ChevronDown className="h-4 w-4 opacity-50" />
+            </Button>
+          </DropdownMenuTrigger>
+          <DropdownMenuContent align="start">
+            <DropdownMenuLabel>Strategy</DropdownMenuLabel>
+            <DropdownMenuSeparator />
+            {HEATMAP_STRATEGY_OPTIONS.map((opt) => (
+              <DropdownMenuCheckboxItem
+                key={opt.value}
+                checked={strategyTokens.includes(opt.value)}
+                onCheckedChange={() => {
+                  const next = toggleValue(strategyTokens, opt.value);
+                  onUpdateParams({
+                    strategy: next.join(',') || null,
+                  });
+                }}
+                onSelect={(e) => e.preventDefault()}
+              >
+                {opt.label}
+              </DropdownMenuCheckboxItem>
+            ))}
+          </DropdownMenuContent>
+        </DropdownMenu>
+
+        {hasGeoFilters && (
+          <Button
+            variant="ghost"
+            size="sm"
+            type="button"
+            onClick={() => onUpdateParams({ strategy: null, source: null })}
+            data-testid="heatmap-clear-geo-filters"
+          >
+            <X className="mr-1 h-4 w-4" />
+            Clear geo filters
+          </Button>
+        )}
+      </div>
+    </div>
+  );
+}

--- a/src/components/traceroutes/TracerouteHeatmapChrome.tsx
+++ b/src/components/traceroutes/TracerouteHeatmapChrome.tsx
@@ -1,4 +1,4 @@
-import { Link } from 'react-router-dom';
+import { useNavigate } from 'react-router-dom';
 import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card';
 import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from '@/components/ui/select';
 import { Button } from '@/components/ui/button';
@@ -12,8 +12,14 @@ import {
 } from '@/components/ui/dropdown-menu';
 import type { ManagedNode } from '@/lib/models';
 import { RouteIcon, ChevronDown, X } from 'lucide-react';
-import { cn } from '@/lib/utils';
 import { TRACEROUTE_STRATEGIES, type TracerouteStrategyValue } from '@/lib/traceroute-strategy';
+
+const MESH_VIEW_OPTIONS = [
+  { value: 'map-packets', label: 'Heatmap · Packet volume', path: '/traceroutes/map/heat' },
+  { value: 'map-snr', label: 'Heatmap · Link quality (SNR)', path: '/traceroutes/map/snr' },
+  { value: 'topology-packets', label: 'Topology · Packet volume', path: '/traceroutes/map/topology/heat' },
+  { value: 'topology-snr', label: 'Topology · Link quality (SNR)', path: '/traceroutes/map/topology/snr' },
+] as const;
 
 export type HeatmapViewMode = 'map' | 'topology';
 
@@ -129,68 +135,35 @@ export function TracerouteHeatmapChrome({
   hasGeoFilters,
   onUpdateParams,
 }: TracerouteHeatmapChromeProps) {
-  const mapPacketsPath = '/traceroutes/map/heat';
-  const mapSnrPath = '/traceroutes/map/snr';
-  const topoPacketsPath = '/traceroutes/map/topology/heat';
-  const topoSnrPath = '/traceroutes/map/topology/snr';
-  const mapPathForMetric = edgeMetric === 'packets' ? mapPacketsPath : mapSnrPath;
-  const topoPathForMetric = edgeMetric === 'packets' ? topoPacketsPath : topoSnrPath;
+  const navigate = useNavigate();
+  const meshViewValue = `${viewMode}-${edgeMetric}`;
 
   return (
     <div className="flex flex-col gap-4 sm:flex-row sm:items-center sm:justify-between">
       <div className="flex items-center gap-2">
         <RouteIcon className="h-6 w-6" />
-        <h1 className="text-xl font-semibold sm:text-2xl">Traceroute Heatmap</h1>
+        <h1 className="text-xl font-semibold sm:text-2xl">Traceroute mesh</h1>
       </div>
       <div className="flex flex-wrap items-center gap-4" data-testid="heatmap-filters">
-        <div className="flex flex-wrap gap-2 rounded-md border border-input bg-muted/50 p-0.5">
-          <Link
-            to={`${mapPathForMetric}${searchSuffix}`}
-            className={cn(
-              'rounded px-3 py-1.5 text-sm font-medium transition-colors',
-              viewMode === 'map'
-                ? 'bg-background text-foreground shadow-sm'
-                : 'text-muted-foreground hover:text-foreground'
-            )}
+        <div className="w-full min-w-[min(100%,280px)] sm:w-auto sm:min-w-[280px]">
+          <Select
+            value={meshViewValue}
+            onValueChange={(v) => {
+              const opt = MESH_VIEW_OPTIONS.find((o) => o.value === v);
+              if (opt) navigate(`${opt.path}${searchSuffix}`);
+            }}
           >
-            Map
-          </Link>
-          <Link
-            to={`${topoPathForMetric}${searchSuffix}`}
-            className={cn(
-              'rounded px-3 py-1.5 text-sm font-medium transition-colors',
-              viewMode === 'topology'
-                ? 'bg-background text-foreground shadow-sm'
-                : 'text-muted-foreground hover:text-foreground'
-            )}
-          >
-            Topology
-          </Link>
-        </div>
-
-        <div className="flex rounded-md border border-input bg-muted/50 p-0.5">
-          <Link
-            to={`${viewMode === 'topology' ? topoPacketsPath : mapPacketsPath}${searchSuffix}`}
-            className={cn(
-              'rounded px-3 py-1.5 text-sm font-medium transition-colors',
-              edgeMetric === 'packets'
-                ? 'bg-background text-foreground shadow-sm'
-                : 'text-muted-foreground hover:text-foreground'
-            )}
-          >
-            Packets
-          </Link>
-          <Link
-            to={`${viewMode === 'topology' ? topoSnrPath : mapSnrPath}${searchSuffix}`}
-            className={cn(
-              'rounded px-3 py-1.5 text-sm font-medium transition-colors',
-              edgeMetric === 'snr'
-                ? 'bg-background text-foreground shadow-sm'
-                : 'text-muted-foreground hover:text-foreground'
-            )}
-          >
-            Link quality (SNR)
-          </Link>
+            <SelectTrigger data-testid="heatmap-mesh-view-select" aria-label="Mesh visualization">
+              <SelectValue />
+            </SelectTrigger>
+            <SelectContent>
+              {MESH_VIEW_OPTIONS.map((o) => (
+                <SelectItem key={o.value} value={o.value}>
+                  {o.label}
+                </SelectItem>
+              ))}
+            </SelectContent>
+          </Select>
         </div>
 
         <div className="w-full sm:w-auto sm:min-w-[180px]">

--- a/src/components/traceroutes/TracerouteHeatmapMap.test.tsx
+++ b/src/components/traceroutes/TracerouteHeatmapMap.test.tsx
@@ -1,5 +1,6 @@
 import { MemoryRouter } from 'react-router-dom';
 import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { useState, type ComponentProps } from 'react';
 import { fireEvent, render, screen } from '@testing-library/react';
 
 import type { HeatmapEdge, HeatmapNode } from '@/hooks/api/useHeatmapEdges';
@@ -86,6 +87,13 @@ function lastCapture() {
   return mapboxCaptures[mapboxCaptures.length - 1];
 }
 
+function Harness(
+  props: Omit<ComponentProps<typeof TracerouteHeatmapMap>, 'selectedNode' | 'onSelectedNodeChange'>
+) {
+  const [selected, setSelected] = useState<HeatmapNode | null>(null);
+  return <TracerouteHeatmapMap {...props} selectedNode={selected} onSelectedNodeChange={setSelected} />;
+}
+
 describe('TracerouteHeatmapMap', () => {
   beforeEach(() => {
     mapboxCaptures.length = 0;
@@ -94,7 +102,7 @@ describe('TracerouteHeatmapMap', () => {
   it('keeps arc layers after popup selection state (mock click / onClick)', () => {
     render(
       <MemoryRouter>
-        <TracerouteHeatmapMap edges={[edge]} nodes={[nodeA, nodeB]} edgeMetric="packets" />
+        <Harness edges={[edge]} nodes={[nodeA, nodeB]} edgeMetric="packets" />
       </MemoryRouter>
     );
 
@@ -112,7 +120,7 @@ describe('TracerouteHeatmapMap', () => {
   it('swaps arc layer id when edgeMetric changes but keeps node layers', () => {
     const { rerender } = render(
       <MemoryRouter>
-        <TracerouteHeatmapMap edges={[edge]} nodes={[nodeA, nodeB]} edgeMetric="packets" />
+        <Harness edges={[edge]} nodes={[nodeA, nodeB]} edgeMetric="packets" />
       </MemoryRouter>
     );
 
@@ -120,7 +128,7 @@ describe('TracerouteHeatmapMap', () => {
 
     rerender(
       <MemoryRouter>
-        <TracerouteHeatmapMap edges={[edge]} nodes={[nodeA, nodeB]} edgeMetric="snr" />
+        <Harness edges={[edge]} nodes={[nodeA, nodeB]} edgeMetric="snr" />
       </MemoryRouter>
     );
 

--- a/src/components/traceroutes/TracerouteHeatmapMap.test.tsx
+++ b/src/components/traceroutes/TracerouteHeatmapMap.test.tsx
@@ -79,6 +79,64 @@ const edge: HeatmapEdge = {
   avg_snr: 4,
 };
 
+const hub: HeatmapNode = {
+  node_id: 0x11c,
+  node_id_str: '!0000011c',
+  short_name: 'Hub',
+  long_name: 'Hub',
+  lat: 55.92,
+  lng: -4.18,
+  role: 'backbone',
+  degree: 3,
+  centrality: 0.4,
+};
+
+const spoke: HeatmapNode = {
+  node_id: 0x11d,
+  node_id_str: '!0000011d',
+  short_name: 'Spoke',
+  long_name: 'Spoke',
+  lat: 55.91,
+  lng: -4.19,
+  role: 'leaf',
+  degree: 1,
+  centrality: 0,
+};
+
+const peer: HeatmapNode = {
+  node_id: 0x11e,
+  node_id_str: '!0000011e',
+  short_name: 'Peer',
+  long_name: 'Peer',
+  lat: 55.93,
+  lng: -4.17,
+  role: 'backbone',
+  degree: 3,
+  centrality: 0.35,
+};
+
+const edgeHubSpoke: HeatmapEdge = {
+  from_node_id: hub.node_id,
+  to_node_id: spoke.node_id,
+  from_lng: hub.lng,
+  from_lat: hub.lat,
+  to_lng: spoke.lng,
+  to_lat: spoke.lat,
+  weight: 3,
+  avg_snr: 5,
+};
+
+const edgeHubPeer: HeatmapEdge = {
+  from_node_id: hub.node_id,
+  to_node_id: peer.node_id,
+  from_lng: hub.lng,
+  from_lat: hub.lat,
+  to_lng: peer.lng,
+  to_lat: peer.lat,
+  weight: 8,
+  avg_snr: 6,
+};
+
 function layerIds(layers: { id: string }[]) {
   return layers.map((l) => l.id);
 }
@@ -134,5 +192,31 @@ describe('TracerouteHeatmapMap', () => {
 
     expect(lastCapture().layers.some((l) => l.id === 'heatmap-arcs-snr')).toBe(true);
     expect(lastCapture().layers.some((l) => l.id === 'heatmap-nodes')).toBe(true);
+  });
+
+  it('omits leaf path layer when no edge touches a leaf node', () => {
+    render(
+      <MemoryRouter>
+        <Harness edges={[edgeHubPeer]} nodes={[hub, peer]} edgeMetric="packets" />
+      </MemoryRouter>
+    );
+    expect(layerIds(lastCapture().layers)).toEqual(
+      expect.arrayContaining(['heatmap-arcs-packets', 'heatmap-nodes'])
+    );
+    expect(lastCapture().layers.some((l) => l.id === 'heatmap-leaf-edges-packets')).toBe(false);
+  });
+
+  it('uses grey dashed path layer for edges touching a leaf, plus arcs for remaining edges', () => {
+    render(
+      <MemoryRouter>
+        <Harness
+          edges={[edgeHubSpoke, edgeHubPeer]}
+          nodes={[hub, spoke, peer]}
+          edgeMetric="packets"
+        />
+      </MemoryRouter>
+    );
+    const ids = layerIds(lastCapture().layers);
+    expect(ids).toEqual(expect.arrayContaining(['heatmap-leaf-edges-packets', 'heatmap-arcs-packets', 'heatmap-nodes']));
   });
 });

--- a/src/components/traceroutes/TracerouteHeatmapMap.tsx
+++ b/src/components/traceroutes/TracerouteHeatmapMap.tsx
@@ -1,130 +1,31 @@
-import { useMemo, useState, useCallback } from 'react';
+import { useMemo, useCallback, useState } from 'react';
 import { Popup } from 'react-map-gl';
 import { ArcLayer, ScatterplotLayer, TextLayer } from '@deck.gl/layers';
 import type { PickingInfo } from '@deck.gl/core';
-import { formatDistanceToNow, parseISO } from 'date-fns';
-import { Link } from 'react-router-dom';
-import { X } from 'lucide-react';
 import type { HeatmapEdge, HeatmapNode } from '@/hooks/api/useHeatmapEdges';
 
 import { DeckMapboxMap } from '@/components/map/DeckMapboxMap';
+import {
+  HEATMAP_NODE_COLOR_FALLBACK,
+  computeHeatmapArcEncoding,
+  computeHeatmapNodeExtents,
+  degreeFillColor,
+  edgeArcColor,
+  edgeArcWidth,
+  getHeatmapNodeLabel,
+  nodeLineColor,
+  nodeLineWidth,
+  nodeRadiusMeters,
+  staleThresholdMs,
+} from '@/components/traceroutes/heatmapEncoding';
+import { TracerouteHeatmapNodePanel } from '@/components/traceroutes/TracerouteHeatmapNodePanel';
 
 const DEFAULT_CENTER = { longitude: -4.2518, latitude: 55.8642, zoom: 8 };
 /** Hide name labels when zoomed out past this level (deck.gl zoom). */
 const HEATMAP_LABEL_MIN_ZOOM = 9.5;
 
-const NODE_COLOR: [number, number, number, number] = [134, 239, 172, 200]; // light green
-// Packets: quiet = blue, busy = orange
-const PACKETS_QUIET_COLOR: [number, number, number, number] = [59, 130, 246, 200]; // blue
-const PACKETS_BUSY_COLOR: [number, number, number, number] = [249, 115, 22, 200]; // orange
-// Link quality (SNR): unhealthy = red, healthy = green
-const SNR_BAD_COLOR: [number, number, number, number] = [239, 68, 68, 200]; // red
-const SNR_GOOD_COLOR: [number, number, number, number] = [34, 197, 94, 200]; // green
-
 /** Default hours without mesh observation before nodes fade (client-side styling). */
 const DEFAULT_STALE_THRESHOLD_HOURS = 6;
-
-function interpolatePacketsColor(weight: number, minW: number, maxW: number): [number, number, number, number] {
-  if (maxW <= minW) return PACKETS_QUIET_COLOR;
-  const t = (weight - minW) / (maxW - minW);
-  const r = Math.round(PACKETS_QUIET_COLOR[0] + (PACKETS_BUSY_COLOR[0] - PACKETS_QUIET_COLOR[0]) * t);
-  const g = Math.round(PACKETS_QUIET_COLOR[1] + (PACKETS_BUSY_COLOR[1] - PACKETS_QUIET_COLOR[1]) * t);
-  const b = Math.round(PACKETS_QUIET_COLOR[2] + (PACKETS_BUSY_COLOR[2] - PACKETS_QUIET_COLOR[2]) * t);
-  return [r, g, b, 200];
-}
-
-function interpolateSnrColor(snr: number, minS: number, maxS: number): [number, number, number, number] {
-  if (maxS <= minS) return SNR_GOOD_COLOR;
-  const t = (snr - minS) / (maxS - minS);
-  const r = Math.round(SNR_BAD_COLOR[0] + (SNR_GOOD_COLOR[0] - SNR_BAD_COLOR[0]) * t);
-  const g = Math.round(SNR_BAD_COLOR[1] + (SNR_GOOD_COLOR[1] - SNR_BAD_COLOR[1]) * t);
-  const b = Math.round(SNR_BAD_COLOR[2] + (SNR_GOOD_COLOR[2] - SNR_BAD_COLOR[2]) * t);
-  return [r, g, b, 200];
-}
-
-function numericExtent(values: number[]): { min: number; max: number } {
-  if (values.length === 0) return { min: 0, max: 1 };
-  let min = values[0];
-  let max = values[0];
-  for (const v of values) {
-    if (v < min) min = v;
-    if (v > max) max = v;
-  }
-  if (max <= min) return { min, max: min + 1e-9 };
-  return { min, max };
-}
-
-/** Client-side stale window (hours); fades nodes not heard within this window. */
-function staleThresholdMs(hours: number): number {
-  return hours * 60 * 60 * 1000;
-}
-
-function isVisuallyStale(node: HeatmapNode, nowMs: number, staleMs: number): boolean {
-  if (node.role === 'offline') return true;
-  if (!node.last_seen) return true;
-  const t = Date.parse(node.last_seen);
-  if (Number.isNaN(t)) return true;
-  return nowMs - t > staleMs;
-}
-
-/** Fill alpha by age within stale window (recent → opaque). */
-function recencyAlpha(node: HeatmapNode, nowMs: number, staleMs: number): number {
-  if (!node.last_seen) return 95;
-  const t = Date.parse(node.last_seen);
-  if (Number.isNaN(t)) return 95;
-  const age = nowMs - t;
-  if (age >= staleMs) return 88;
-  const u = age / staleMs;
-  return Math.round(255 - u * (255 - 155));
-}
-
-function degreeFillColor(
-  node: HeatmapNode,
-  degMin: number,
-  degMax: number,
-  nowMs: number,
-  staleMs: number
-): [number, number, number, number] {
-  const grey: [number, number, number] = [148, 163, 184];
-  if (isVisuallyStale(node, nowMs, staleMs)) {
-    return [...grey, 100];
-  }
-  const t = degMax > degMin ? ((node.degree ?? 0) - degMin) / (degMax - degMin) : 0.5;
-  const r = Math.round(59 + (249 - 59) * t);
-  const g = Math.round(130 + (115 - 130) * t);
-  const b = Math.round(246 + (22 - 246) * t);
-  const alpha = recencyAlpha(node, nowMs, staleMs);
-  return [r, g, b, alpha];
-}
-
-function nodeRadiusMeters(centrality: number | undefined, cMin: number, cMax: number): number {
-  if (centrality == null) return 380;
-  if (cMax <= cMin) return 380;
-  const u = (centrality - cMin) / (cMax - cMin);
-  return 140 + u * 760;
-}
-
-function nodeLineWidth(node: HeatmapNode, degMin: number, degMax: number): number {
-  const t = degMax > degMin ? ((node.degree ?? 0) - degMin) / (degMax - degMin) : 0;
-  let w = 1 + t * 6;
-  if (node.role === 'backbone') w += 2.5;
-  if (node.role === 'offline') w = Math.min(w, 1);
-  return w;
-}
-
-function nodeLineColor(fill: [number, number, number, number]): [number, number, number, number] {
-  const [r, g, b, a] = fill;
-  return [Math.round(r * 0.35), Math.round(g * 0.38), Math.round(b * 0.42), Math.min(255, a + 35)];
-}
-
-function formatRecency(iso: string | null | undefined): string {
-  if (!iso) return 'No recent mesh observation';
-  try {
-    return formatDistanceToNow(parseISO(iso), { addSuffix: true });
-  } catch {
-    return iso;
-  }
-}
 
 export interface TracerouteHeatmapMapProps {
   edges: HeatmapEdge[];
@@ -133,10 +34,10 @@ export interface TracerouteHeatmapMapProps {
   edgeMetric?: 'packets' | 'snr';
   /** Hours without last_seen before treating as stale for styling (default 6). */
   staleThresholdHours?: number;
-}
-
-function getNodeLabel(node: HeatmapNode): string {
-  return node.short_name || node.long_name || node.node_id_str || `!${node.node_id.toString(16)}`;
+  selectedNode: HeatmapNode | null;
+  onSelectedNodeChange: (node: HeatmapNode | null) => void;
+  /** Optional link in popup (e.g. switch to topology with same filters). */
+  topologyLink?: { to: string; label: string };
 }
 
 export function TracerouteHeatmapMap({
@@ -145,68 +46,52 @@ export function TracerouteHeatmapMap({
   intensity = 0.7,
   edgeMetric = 'packets',
   staleThresholdHours = DEFAULT_STALE_THRESHOLD_HOURS,
+  selectedNode,
+  onSelectedNodeChange,
+  topologyLink,
 }: TracerouteHeatmapMapProps) {
-  const [selectedNode, setSelectedNode] = useState<HeatmapNode | null>(null);
   const [zoom, setZoom] = useState<number>(typeof DEFAULT_CENTER.zoom === 'number' ? DEFAULT_CENTER.zoom : 8);
-
   const staleMs = staleThresholdMs(staleThresholdHours);
 
-  const nodeMetrics = useMemo(() => {
-    const hasSignal = nodes.some((n) => n.centrality != null && n.degree != null);
-    const centralities = nodes.map((n) => n.centrality).filter((c): c is number => c != null && !Number.isNaN(c));
-    const degrees = nodes.map((n) => n.degree).filter((d): d is number => d != null && !Number.isNaN(d));
-    const cExt = numericExtent(centralities.length ? centralities : [0, 1]);
-    const dExt = numericExtent(degrees.length ? degrees : [0, 1]);
-    return { cExt, dExt, hasSignal };
-  }, [nodes]);
+  const nodeMetrics = useMemo(() => computeHeatmapNodeExtents(nodes), [nodes]);
 
-  const handleClick = useCallback((info: PickingInfo) => {
-    if (info.object && (info.layer?.id === 'heatmap-nodes' || info.layer?.id === 'heatmap-node-labels')) {
-      setSelectedNode(info.object as HeatmapNode);
-    } else {
-      setSelectedNode(null);
-    }
-  }, []);
+  const handleClick = useCallback(
+    (info: PickingInfo) => {
+      if (info.object && (info.layer?.id === 'heatmap-nodes' || info.layer?.id === 'heatmap-node-labels')) {
+        onSelectedNodeChange(info.object as HeatmapNode);
+      } else {
+        onSelectedNodeChange(null);
+      }
+    },
+    [onSelectedNodeChange]
+  );
 
   const handleViewStateChange = useCallback((params: { viewState: { zoom?: number } }) => {
     const z = params.viewState?.zoom;
     if (typeof z === 'number' && !Number.isNaN(z)) setZoom(z);
   }, []);
 
+  const arcEncoding = useMemo(
+    () => computeHeatmapArcEncoding(edges, edgeMetric, intensity),
+    [edges, edgeMetric, intensity]
+  );
+
   const arcLayer = useMemo(() => {
-    if (edges.length === 0) return null;
-    const preferSnr = edgeMetric === 'snr';
-    const snrValues = edges.map((e) => e.avg_snr ?? -999).filter((v) => v > -999);
-    const hasSnrData = snrValues.length > 0;
-    const useSnrColors = preferSnr;
-    const values = hasSnrData ? snrValues : edges.map((e) => e.weight);
-    const valueKey = hasSnrData ? 'avg_snr' : 'weight';
-    if (values.length === 0) return null;
-    const minVal = Math.min(...values);
-    const maxVal = Math.max(...values);
-    const baseWidth = 1 + intensity * 4;
+    if (!arcEncoding || edges.length === 0) return null;
+    const enc = arcEncoding;
     return new ArcLayer({
       id: `heatmap-arcs-${edgeMetric}`,
       data: edges,
       getSourcePosition: (d) => [d.from_lng, d.from_lat],
       getTargetPosition: (d) => [d.to_lng, d.to_lat],
-      getSourceColor: (d) => {
-        const v = valueKey === 'avg_snr' ? (d.avg_snr ?? minVal) : d.weight;
-        return useSnrColors ? interpolateSnrColor(v, minVal, maxVal) : interpolatePacketsColor(v, minVal, maxVal);
-      },
-      getTargetColor: (d) => {
-        const v = valueKey === 'avg_snr' ? (d.avg_snr ?? minVal) : d.weight;
-        return useSnrColors ? interpolateSnrColor(v, minVal, maxVal) : interpolatePacketsColor(v, minVal, maxVal);
-      },
-      getWidth: (d) => {
-        const v = valueKey === 'avg_snr' ? (d.avg_snr ?? minVal) : d.weight;
-        return baseWidth * (0.5 + (v - minVal) / Math.max(maxVal - minVal, 0.001));
-      },
+      getSourceColor: (d) => edgeArcColor(d, enc),
+      getTargetColor: (d) => edgeArcColor(d, enc),
+      getWidth: (d) => edgeArcWidth(d, enc),
       widthMinPixels: 1,
       widthMaxPixels: 20,
       getHeight: 0,
     });
-  }, [edges, intensity, edgeMetric]);
+  }, [edges, arcEncoding, edgeMetric]);
 
   const scatterLayer = useMemo(() => {
     if (nodes.length === 0) return null;
@@ -217,7 +102,8 @@ export function TracerouteHeatmapMap({
       id: 'heatmap-nodes',
       data: nodes,
       getPosition: (d) => [d.lng, d.lat],
-      getFillColor: (d) => (hasSignal ? degreeFillColor(d, dExt.min, dExt.max, nowMs, staleMs) : NODE_COLOR),
+      getFillColor: (d) =>
+        hasSignal ? degreeFillColor(d, dExt.min, dExt.max, nowMs, staleMs) : HEATMAP_NODE_COLOR_FALLBACK,
       getRadius: (d) => (hasSignal ? nodeRadiusMeters(d.centrality, cExt.min, cExt.max) : 380),
       radiusMinPixels: 4,
       radiusMaxPixels: 22,
@@ -244,7 +130,7 @@ export function TracerouteHeatmapMap({
       id: 'heatmap-node-labels',
       data: nodes,
       getPosition: (d) => [d.lng, d.lat],
-      getText: getNodeLabel,
+      getText: getHeatmapNodeLabel,
       getSize: 11,
       sizeMinPixels: 9,
       sizeMaxPixels: 12,
@@ -279,61 +165,15 @@ export function TracerouteHeatmapMap({
           anchor="bottom"
           closeButton={false}
           closeOnClick={false}
-          onClose={() => setSelectedNode(null)}
+          onClose={() => onSelectedNodeChange(null)}
           maxWidth="320px"
           className="meshflow-map-popup"
         >
-          <div className="relative min-w-[120px] rounded-md border border-slate-600 bg-slate-800 px-3 py-2 text-sm text-slate-100 shadow-lg">
-            <button
-              type="button"
-              onClick={() => setSelectedNode(null)}
-              className="absolute right-1 top-1 rounded p-0.5 text-slate-400 hover:bg-slate-700 hover:text-slate-200"
-              aria-label="Close"
-            >
-              <X className="h-3.5 w-3.5" aria-hidden />
-            </button>
-            <div className="pr-5">
-              <div className="font-semibold">
-                {selectedNode.long_name && selectedNode.short_name
-                  ? `${selectedNode.long_name} (${selectedNode.short_name})`
-                  : getNodeLabel(selectedNode)}
-              </div>
-              <div className="mt-0.5 text-xs text-slate-400">
-                {selectedNode.node_id_str || `!${selectedNode.node_id.toString(16)}`}
-              </div>
-              {(selectedNode.centrality != null || selectedNode.degree != null) && (
-                <dl className="mt-2 space-y-0.5 text-xs text-slate-300">
-                  {selectedNode.centrality != null && (
-                    <div className="flex justify-between gap-2">
-                      <dt className="text-slate-500">Centrality</dt>
-                      <dd>{(selectedNode.centrality * 100).toFixed(1)}%</dd>
-                    </div>
-                  )}
-                  {selectedNode.degree != null && (
-                    <div className="flex justify-between gap-2">
-                      <dt className="text-slate-500">Degree</dt>
-                      <dd>{selectedNode.degree}</dd>
-                    </div>
-                  )}
-                  {selectedNode.role && (
-                    <div className="flex justify-between gap-2">
-                      <dt className="text-slate-500">Role</dt>
-                      <dd className="capitalize">{selectedNode.role}</dd>
-                    </div>
-                  )}
-                </dl>
-              )}
-              <div className="mt-1.5 text-xs text-slate-400">
-                Last seen: <span className="text-slate-300">{formatRecency(selectedNode.last_seen)}</span>
-              </div>
-              <Link
-                to={`/nodes/${selectedNode.node_id}`}
-                className="mt-1 inline-block text-xs text-emerald-400 hover:text-emerald-300 hover:underline"
-              >
-                Open details
-              </Link>
-            </div>
-          </div>
+          <TracerouteHeatmapNodePanel
+            node={selectedNode}
+            onClose={() => onSelectedNodeChange(null)}
+            secondaryLink={topologyLink}
+          />
         </Popup>
       )}
     </DeckMapboxMap>

--- a/src/components/traceroutes/TracerouteHeatmapMap.tsx
+++ b/src/components/traceroutes/TracerouteHeatmapMap.tsx
@@ -1,7 +1,8 @@
 import { useMemo, useCallback, useState } from 'react';
 import { Popup } from 'react-map-gl';
-import { ArcLayer, ScatterplotLayer, TextLayer } from '@deck.gl/layers';
-import type { PickingInfo } from '@deck.gl/core';
+import type { Layer, PickingInfo } from '@deck.gl/core';
+import { PathStyleExtension } from '@deck.gl/extensions';
+import { ArcLayer, PathLayer, ScatterplotLayer, TextLayer } from '@deck.gl/layers';
 import type { HeatmapEdge, HeatmapNode } from '@/hooks/api/useHeatmapEdges';
 
 import { DeckMapboxMap } from '@/components/map/DeckMapboxMap';
@@ -26,6 +27,11 @@ const HEATMAP_LABEL_MIN_ZOOM = 9.5;
 
 /** Default hours without mesh observation before nodes fade (client-side styling). */
 const DEFAULT_STALE_THRESHOLD_HOURS = 6;
+
+/** Grey dashed strokes for edges that touch a leaf node (matches topology view). */
+const LEAF_EDGE_GREY: [number, number, number, number] = [142, 142, 148, 200];
+
+const leafEdgeDashExtension = new PathStyleExtension({ dash: true });
 
 export interface TracerouteHeatmapMapProps {
   edges: HeatmapEdge[];
@@ -76,12 +82,55 @@ export function TracerouteHeatmapMap({
     [edges, edgeMetric, intensity]
   );
 
+  const roleById = useMemo(() => {
+    const m = new Map<number, HeatmapNode['role']>();
+    for (const n of nodes) m.set(n.node_id, n.role);
+    return m;
+  }, [nodes]);
+
+  const { coreEdges, leafEdges } = useMemo(() => {
+    const core: HeatmapEdge[] = [];
+    const leaf: HeatmapEdge[] = [];
+    for (const e of edges) {
+      const ra = roleById.get(e.from_node_id);
+      const rb = roleById.get(e.to_node_id);
+      const touchesLeaf = ra === 'leaf' || rb === 'leaf';
+      if (touchesLeaf) leaf.push(e);
+      else core.push(e);
+    }
+    return { coreEdges: core, leafEdges: leaf };
+  }, [edges, roleById]);
+
+  const leafPathLayer = useMemo(() => {
+    if (!arcEncoding || leafEdges.length === 0) return null;
+    const enc = arcEncoding;
+    return new PathLayer({
+      id: `heatmap-leaf-edges-${edgeMetric}`,
+      data: leafEdges,
+      extensions: [leafEdgeDashExtension],
+      getPath: (d: HeatmapEdge) => [
+        [d.from_lng, d.from_lat],
+        [d.to_lng, d.to_lat],
+      ],
+      getColor: LEAF_EDGE_GREY,
+      getWidth: (d: HeatmapEdge) => edgeArcWidth(d, enc),
+      widthMinPixels: 1,
+      widthMaxPixels: 18,
+      getDashArray: [5, 5],
+      capRounded: true,
+      jointRounded: true,
+      updateTriggers: {
+        getWidth: [enc.minVal, enc.maxVal, enc.baseWidth],
+      },
+    });
+  }, [leafEdges, arcEncoding, edgeMetric]);
+
   const arcLayer = useMemo(() => {
-    if (!arcEncoding || edges.length === 0) return null;
+    if (!arcEncoding || coreEdges.length === 0) return null;
     const enc = arcEncoding;
     return new ArcLayer({
       id: `heatmap-arcs-${edgeMetric}`,
-      data: edges,
+      data: coreEdges,
       getSourcePosition: (d) => [d.from_lng, d.from_lat],
       getTargetPosition: (d) => [d.to_lng, d.to_lat],
       getSourceColor: (d) => edgeArcColor(d, enc),
@@ -91,7 +140,7 @@ export function TracerouteHeatmapMap({
       widthMaxPixels: 20,
       getHeight: 0,
     });
-  }, [edges, arcEncoding, edgeMetric]);
+  }, [coreEdges, arcEncoding, edgeMetric]);
 
   const scatterLayer = useMemo(() => {
     if (nodes.length === 0) return null;
@@ -146,8 +195,8 @@ export function TracerouteHeatmapMap({
   }, [nodes, zoom]);
 
   const layers = useMemo(
-    () => [arcLayer, scatterLayer, textLayer].filter(Boolean) as (ArcLayer | ScatterplotLayer | TextLayer)[],
-    [arcLayer, scatterLayer, textLayer]
+    () => [leafPathLayer, arcLayer, scatterLayer, textLayer].filter(Boolean) as Layer[],
+    [leafPathLayer, arcLayer, scatterLayer, textLayer]
   );
 
   return (

--- a/src/components/traceroutes/TracerouteHeatmapNodePanel.tsx
+++ b/src/components/traceroutes/TracerouteHeatmapNodePanel.tsx
@@ -1,0 +1,94 @@
+import { formatDistanceToNow, parseISO } from 'date-fns';
+import { Link } from 'react-router-dom';
+import { X } from 'lucide-react';
+import { getHeatmapNodeLabel } from '@/components/traceroutes/heatmapEncoding';
+import type { HeatmapNode } from '@/hooks/api/useHeatmapEdges';
+
+function formatRecency(iso: string | null | undefined): string {
+  if (!iso) return 'No recent mesh observation';
+  try {
+    return formatDistanceToNow(parseISO(iso), { addSuffix: true });
+  } catch {
+    return iso;
+  }
+}
+
+export interface TracerouteHeatmapNodePanelProps {
+  node: HeatmapNode;
+  onClose?: () => void;
+  /** Optional link shown below “Open details” (e.g. topology ↔ map with preserved params). */
+  secondaryLink?: { to: string; label: string };
+  className?: string;
+}
+
+export function TracerouteHeatmapNodePanel({
+  node,
+  onClose,
+  secondaryLink,
+  className,
+}: TracerouteHeatmapNodePanelProps) {
+  return (
+    <div
+      className={
+        className ??
+        'relative min-w-[120px] rounded-md border border-slate-600 bg-slate-800 px-3 py-2 text-sm text-slate-100 shadow-lg'
+      }
+    >
+      {onClose && (
+        <button
+          type="button"
+          onClick={onClose}
+          className="absolute right-1 top-1 rounded p-0.5 text-slate-400 hover:bg-slate-700 hover:text-slate-200"
+          aria-label="Close"
+        >
+          <X className="h-3.5 w-3.5" aria-hidden />
+        </button>
+      )}
+      <div className={onClose ? 'pr-5' : undefined}>
+        <div className="font-semibold">
+          {node.long_name && node.short_name ? `${node.long_name} (${node.short_name})` : getHeatmapNodeLabel(node)}
+        </div>
+        <div className="mt-0.5 text-xs text-slate-400">{node.node_id_str || `!${node.node_id.toString(16)}`}</div>
+        {(node.centrality != null || node.degree != null) && (
+          <dl className="mt-2 space-y-0.5 text-xs text-slate-300">
+            {node.centrality != null && (
+              <div className="flex justify-between gap-2">
+                <dt className="text-slate-500">Centrality</dt>
+                <dd>{(node.centrality * 100).toFixed(1)}%</dd>
+              </div>
+            )}
+            {node.degree != null && (
+              <div className="flex justify-between gap-2">
+                <dt className="text-slate-500">Degree</dt>
+                <dd>{node.degree}</dd>
+              </div>
+            )}
+            {node.role && (
+              <div className="flex justify-between gap-2">
+                <dt className="text-slate-500">Role</dt>
+                <dd className="capitalize">{node.role}</dd>
+              </div>
+            )}
+          </dl>
+        )}
+        <div className="mt-1.5 text-xs text-slate-400">
+          Last seen: <span className="text-slate-300">{formatRecency(node.last_seen)}</span>
+        </div>
+        <Link
+          to={`/nodes/${node.node_id}`}
+          className="mt-1 inline-block text-xs text-emerald-400 hover:text-emerald-300 hover:underline"
+        >
+          Open details
+        </Link>
+        {secondaryLink && (
+          <Link
+            to={secondaryLink.to}
+            className="mt-1 ml-2 inline-block text-xs text-sky-400 hover:text-sky-300 hover:underline"
+          >
+            {secondaryLink.label}
+          </Link>
+        )}
+      </div>
+    </div>
+  );
+}

--- a/src/components/traceroutes/TracerouteTopologyGraph.tsx
+++ b/src/components/traceroutes/TracerouteTopologyGraph.tsx
@@ -1,0 +1,405 @@
+import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
+import * as d3 from 'd3';
+import type { HeatmapEdge, HeatmapNode } from '@/hooks/api/useHeatmapEdges';
+import {
+  computeHeatmapArcEncoding,
+  computeHeatmapNodeExtents,
+  degreeFillColor,
+  edgeArcColor,
+  edgeArcWidth,
+  HEATMAP_NODE_COLOR_FALLBACK,
+  nodeLineColor,
+  nodeLineWidth,
+  nodeRadiusPixels,
+  staleThresholdMs,
+} from '@/components/traceroutes/heatmapEncoding';
+type EdgeMetric = 'packets' | 'snr';
+
+type SimNode = HeatmapNode & { x?: number; y?: number; vx?: number; vy?: number; index?: number };
+
+interface GraphLink {
+  source: SimNode;
+  target: SimNode;
+  edge: HeatmapEdge;
+}
+
+function deterministicSeedXY(nodeId: number, w: number, h: number): { x: number; y: number } {
+  let s = nodeId >>> 0;
+  s = (Math.imul(s, 1664525) + 1013904223) >>> 0;
+  const u1 = s / 0xffffffff;
+  s = (Math.imul(s ^ nodeId, 22695477) + 1) >>> 0;
+  const u2 = s / 0xffffffff;
+  const cx = w / 2;
+  const cy = h / 2;
+  const r = Math.min(w, h) * 0.35;
+  return { x: cx + (u1 - 0.5) * 2 * r, y: cy + (u2 - 0.5) * 2 * r };
+}
+
+function linkStrengthValue(edge: HeatmapEdge, enc: NonNullable<ReturnType<typeof computeHeatmapArcEncoding>>): number {
+  const v = enc.valueKey === 'avg_snr' ? (edge.avg_snr ?? enc.minVal) : edge.weight;
+  const t = (v - enc.minVal) / Math.max(enc.maxVal - enc.minVal, 1e-9);
+  return Math.min(1, Math.max(0, t));
+}
+
+export interface TracerouteTopologyGraphProps {
+  edges: HeatmapEdge[];
+  nodes: HeatmapNode[];
+  edgeMetric: EdgeMetric;
+  staleThresholdHours: number;
+  intensity?: number;
+  onSelectedNodeChange: (node: HeatmapNode | null) => void;
+  /** Deep-link sync */
+  selectedNodeId: number | null;
+}
+
+export function TracerouteTopologyGraph({
+  edges,
+  nodes,
+  edgeMetric,
+  staleThresholdHours,
+  intensity = 0.7,
+  onSelectedNodeChange,
+  selectedNodeId,
+}: TracerouteTopologyGraphProps) {
+  const containerRef = useRef<HTMLDivElement>(null);
+  const canvasRef = useRef<HTMLCanvasElement>(null);
+  const warmRef = useRef<Map<number, { x: number; y: number }>>(new Map());
+  const [dimensions, setDimensions] = useState({ width: 640, height: 480 });
+  const [transform, setTransform] = useState(d3.zoomIdentity);
+  const [hoverId, setHoverId] = useState<number | null>(null);
+  const [focusIndex, setFocusIndex] = useState(0);
+  const [liveMsg, setLiveMsg] = useState('');
+
+  const staleMs = staleThresholdMs(staleThresholdHours);
+  const nodeExtents = useMemo(() => computeHeatmapNodeExtents(nodes), [nodes]);
+  const arcEnc = useMemo(() => computeHeatmapArcEncoding(edges, edgeMetric, intensity), [edges, edgeMetric, intensity]);
+
+  const adjacency = useMemo(() => {
+    const m = new Map<number, Set<number>>();
+    const add = (a: number, b: number) => {
+      if (!m.has(a)) m.set(a, new Set());
+      m.get(a)!.add(b);
+    };
+    for (const e of edges) {
+      add(e.from_node_id, e.to_node_id);
+      add(e.to_node_id, e.from_node_id);
+    }
+    return m;
+  }, [edges]);
+
+  const sortedIds = useMemo(() => [...nodes.map((n) => n.node_id)].sort((a, b) => a - b), [nodes]);
+
+  const simulationNodesRef = useRef<SimNode[]>([]);
+  const simulationLinksRef = useRef<GraphLink[]>([]);
+
+  useEffect(() => {
+    const el = containerRef.current;
+    if (!el) return;
+    const ro = new ResizeObserver((entries) => {
+      const cr = entries[0]?.contentRect;
+      if (cr && cr.width > 0 && cr.height > 0) {
+        setDimensions({ width: Math.floor(cr.width), height: Math.floor(cr.height) });
+      }
+    });
+    ro.observe(el);
+    const rect = el.getBoundingClientRect();
+    if (rect.width > 0 && rect.height > 0) {
+      setDimensions({ width: Math.floor(rect.width), height: Math.floor(rect.height) });
+    }
+    return () => ro.disconnect();
+  }, []);
+
+  useEffect(() => {
+    const { width, height } = dimensions;
+    if (width < 32 || height < 32 || nodes.length === 0) {
+      simulationNodesRef.current = [];
+      simulationLinksRef.current = [];
+      return;
+    }
+
+    const byId = new Map(nodes.map((n) => [n.node_id, { ...n } as SimNode]));
+    const simNodes: SimNode[] = nodes.map((n) => {
+      const prev = warmRef.current.get(n.node_id);
+      const seed = deterministicSeedXY(n.node_id, width, height);
+      return {
+        ...n,
+        x: prev?.x ?? seed.x,
+        y: prev?.y ?? seed.y,
+      };
+    });
+
+    for (const sn of simNodes) {
+      byId.set(sn.node_id, sn);
+    }
+
+    const linkObjs: GraphLink[] = [];
+    for (const e of edges) {
+      const s = byId.get(e.from_node_id);
+      const t = byId.get(e.to_node_id);
+      if (s && t) linkObjs.push({ source: s, target: t, edge: e });
+    }
+
+    const enc = arcEnc;
+    const minD = 18;
+    const maxD = 140;
+    const simulation = d3
+      .forceSimulation(simNodes as SimNode[])
+      .force(
+        'link',
+        d3
+          .forceLink<SimNode, GraphLink>(linkObjs)
+          .id((d) => d.node_id)
+          .distance((d) => {
+            if (!enc) return (minD + maxD) / 2;
+            const t = linkStrengthValue(d.edge, enc);
+            return maxD - t * (maxD - minD);
+          })
+          .strength(0.55)
+      )
+      .force('charge', d3.forceManyBody<SimNode>().strength(-120).theta(0.9))
+      .force('center', d3.forceCenter(width / 2, height / 2))
+      .force(
+        'collide',
+        d3.forceCollide<SimNode>().radius((d) => {
+          const r = nodeExtents.hasSignal
+            ? nodeRadiusPixels(d.centrality, nodeExtents.cExt.min, nodeExtents.cExt.max)
+            : 11;
+          return r + 3;
+        })
+      )
+      .alpha(0.35)
+      .alphaDecay(0.052)
+      .velocityDecay(0.55);
+
+    let ticks = 0;
+    while (simulation.alpha() > 0.02 && ticks < 280) {
+      simulation.tick();
+      ticks += 1;
+    }
+    simulation.stop();
+
+    for (const n of simNodes) {
+      if (n.x != null && n.y != null) {
+        warmRef.current.set(n.node_id, { x: n.x, y: n.y });
+      }
+    }
+
+    simulationNodesRef.current = simNodes;
+    simulationLinksRef.current = linkObjs;
+  }, [nodes, edges, dimensions, arcEnc, nodeExtents, edgeMetric]);
+
+  const draw = useCallback(() => {
+    const canvas = canvasRef.current;
+    if (!canvas) return;
+    const ctx = canvas.getContext('2d');
+    if (!ctx) return;
+    const { width, height } = dimensions;
+    const dpr = typeof window !== 'undefined' ? window.devicePixelRatio || 1 : 1;
+    canvas.width = width * dpr;
+    canvas.height = height * dpr;
+    canvas.style.width = `${width}px`;
+    canvas.style.height = `${height}px`;
+    ctx.setTransform(dpr, 0, 0, dpr, 0, 0);
+    ctx.clearRect(0, 0, width, height);
+
+    const simNodes = simulationNodesRef.current;
+    const linkObjs = simulationLinksRef.current;
+    const enc = arcEnc;
+    const nowMs = Date.now();
+    const { cExt, dExt, hasSignal } = nodeExtents;
+
+    ctx.save();
+    ctx.translate(transform.x, transform.y);
+    ctx.scale(transform.k, transform.k);
+
+    const highlight = hoverId ?? selectedNodeId;
+    const neigh = highlight != null ? adjacency.get(highlight) : null;
+
+    const edgeFade = (a: number, b: number) => {
+      if (highlight == null) return 1;
+      const touches = a === highlight || b === highlight || neigh?.has(a) || neigh?.has(b);
+      return touches ? 1 : 0.12;
+    };
+
+    const nodeFade = (id: number) => {
+      if (highlight == null) return 1;
+      if (id === highlight) return 1;
+      if (neigh?.has(id)) return 1;
+      return 0.22;
+    };
+
+    for (const L of linkObjs) {
+      const a = L.source;
+      const b = L.target;
+      if (a.x == null || a.y == null || b.x == null || b.y == null) continue;
+      const alphaMul = edgeFade(a.node_id, b.node_id);
+      let stroke: [number, number, number, number];
+      let lw: number;
+      if (enc) {
+        stroke = edgeArcColor(L.edge, enc);
+        lw = edgeArcWidth(L.edge, enc);
+      } else {
+        stroke = [148, 163, 184, 180];
+        lw = 1.5;
+      }
+      ctx.beginPath();
+      ctx.moveTo(a.x, a.y);
+      ctx.lineTo(b.x, b.y);
+      ctx.strokeStyle = `rgba(${stroke[0]},${stroke[1]},${stroke[2]},${(stroke[3] / 255) * alphaMul})`;
+      ctx.lineWidth = Math.max(0.6, lw * 0.35);
+      ctx.stroke();
+    }
+
+    const nodeDrawOrder = [...simNodes].sort((u, v) => {
+      if (highlight == null) return 0;
+      if (u.node_id === highlight) return 1;
+      if (v.node_id === highlight) return -1;
+      return 0;
+    });
+
+    for (const n of nodeDrawOrder) {
+      if (n.x == null || n.y == null) continue;
+      const r = hasSignal ? nodeRadiusPixels(n.centrality, cExt.min, cExt.max) : 9;
+      const fill = hasSignal ? degreeFillColor(n, dExt.min, dExt.max, nowMs, staleMs) : HEATMAP_NODE_COLOR_FALLBACK;
+      const strokeCol = nodeLineColor(fill);
+      const fade = nodeFade(n.node_id);
+      ctx.beginPath();
+      ctx.arc(n.x, n.y, r, 0, Math.PI * 2);
+      ctx.fillStyle = `rgba(${fill[0]},${fill[1]},${fill[2]},${(fill[3] / 255) * fade})`;
+      ctx.fill();
+      ctx.strokeStyle = `rgba(${strokeCol[0]},${strokeCol[1]},${strokeCol[2]},${(strokeCol[3] / 255) * fade})`;
+      ctx.lineWidth = hasSignal ? nodeLineWidth(n, dExt.min, dExt.max) : 1;
+      ctx.stroke();
+    }
+
+    ctx.restore();
+  }, [dimensions, transform, arcEnc, nodeExtents, staleMs, hoverId, selectedNodeId, adjacency]);
+
+  useEffect(() => {
+    draw();
+  }, [draw]);
+
+  useEffect(() => {
+    const canvas = canvasRef.current;
+    if (!canvas) return;
+    const z = d3
+      .zoom<HTMLCanvasElement, unknown>()
+      .scaleExtent([0.15, 12])
+      .on('zoom', (event) => {
+        setTransform(event.transform);
+      });
+    const sel = d3.select(canvas);
+    sel.call(z);
+    return () => {
+      sel.on('.zoom', null);
+    };
+  }, []);
+
+  const pickNode = useCallback(
+    (clientX: number, clientY: number): HeatmapNode | null => {
+      const canvas = canvasRef.current;
+      if (!canvas) return null;
+      const rect = canvas.getBoundingClientRect();
+      const px = clientX - rect.left;
+      const py = clientY - rect.top;
+      const graphX = (px - transform.x) / transform.k;
+      const graphY = (py - transform.y) / transform.k;
+      const simNodes = simulationNodesRef.current;
+      const { cExt, hasSignal } = nodeExtents;
+      let best: HeatmapNode | null = null;
+      let bestD = Infinity;
+      for (const n of simNodes) {
+        if (n.x == null || n.y == null) continue;
+        const r = (hasSignal ? nodeRadiusPixels(n.centrality, cExt.min, cExt.max) : 9) + 6 / transform.k;
+        const dx = n.x - graphX;
+        const dy = n.y - graphY;
+        const d2 = dx * dx + dy * dy;
+        if (d2 <= r * r && d2 < bestD) {
+          bestD = d2;
+          best = n;
+        }
+      }
+      return best;
+    },
+    [transform, nodeExtents]
+  );
+
+  const onPointerMove = useCallback(
+    (e: React.PointerEvent) => {
+      const n = pickNode(e.clientX, e.clientY);
+      setHoverId(n?.node_id ?? null);
+    },
+    [pickNode]
+  );
+
+  const onPointerLeave = useCallback(() => setHoverId(null), []);
+
+  const onClick = useCallback(
+    (e: React.MouseEvent) => {
+      const n = pickNode(e.clientX, e.clientY);
+      onSelectedNodeChange(n);
+      if (n) setLiveMsg(`${n.short_name ?? n.node_id_str ?? n.node_id} selected`);
+    },
+    [pickNode, onSelectedNodeChange]
+  );
+
+  const onKeyDown = useCallback(
+    (e: React.KeyboardEvent) => {
+      if (sortedIds.length === 0) return;
+      if (e.key === 'ArrowRight' || e.key === 'ArrowDown') {
+        e.preventDefault();
+        setFocusIndex((i) => (i + 1) % sortedIds.length);
+      } else if (e.key === 'ArrowLeft' || e.key === 'ArrowUp') {
+        e.preventDefault();
+        setFocusIndex((i) => (i - 1 + sortedIds.length) % sortedIds.length);
+      } else if (e.key === 'Enter' || e.key === ' ') {
+        e.preventDefault();
+        const id = sortedIds[focusIndex];
+        const node = nodes.find((n) => n.node_id === id) ?? null;
+        onSelectedNodeChange(node);
+        if (node) setLiveMsg(`${node.short_name ?? node.node_id_str ?? node.node_id} selected`);
+      }
+    },
+    [sortedIds, focusIndex, nodes, onSelectedNodeChange]
+  );
+
+  useEffect(() => {
+    const id = sortedIds[focusIndex];
+    const node = nodes.find((n) => n.node_id === id);
+    if (node && document.activeElement?.getAttribute('data-testid') === 'topology-canvas') {
+      setLiveMsg(`Focused ${node.short_name ?? node.node_id_str ?? id}`);
+    }
+  }, [focusIndex, sortedIds, nodes]);
+
+  const empty = edges.length === 0 || nodes.length === 0;
+
+  return (
+    <div ref={containerRef} className="relative h-full min-h-[300px] w-full md:min-h-[calc(100dvh-16rem)]">
+      <canvas
+        ref={canvasRef}
+        role="img"
+        aria-label="Traceroute topology graph. Use arrow keys to focus nodes, Enter to select."
+        tabIndex={0}
+        data-testid="topology-canvas"
+        className="absolute inset-0 h-full w-full cursor-grab touch-none outline-none active:cursor-grabbing"
+        onPointerMove={onPointerMove}
+        onPointerLeave={onPointerLeave}
+        onClick={onClick}
+        onKeyDown={onKeyDown}
+      />
+      {empty && (
+        <div className="pointer-events-none absolute inset-0 flex items-center justify-center text-sm text-muted-foreground">
+          No edges to display for the current filters.
+        </div>
+      )}
+      <ul className="sr-only" aria-hidden>
+        {nodes.map((n) => (
+          <li key={n.node_id}>{n.short_name ?? n.node_id_str ?? n.node_id}</li>
+        ))}
+      </ul>
+      <div className="sr-only" aria-live="polite">
+        {liveMsg}
+      </div>
+    </div>
+  );
+}

--- a/src/components/traceroutes/TracerouteTopologyGraph.tsx
+++ b/src/components/traceroutes/TracerouteTopologyGraph.tsx
@@ -7,6 +7,7 @@ import {
   degreeFillColor,
   edgeArcColor,
   edgeArcWidth,
+  getHeatmapNodeLabel,
   HEATMAP_NODE_COLOR_FALLBACK,
   nodeLineColor,
   nodeLineWidth,
@@ -39,6 +40,16 @@ function linkStrengthValue(edge: HeatmapEdge, enc: NonNullable<ReturnType<typeof
   const v = enc.valueKey === 'avg_snr' ? (edge.avg_snr ?? enc.minVal) : edge.weight;
   const t = (v - enc.minVal) / Math.max(enc.maxVal - enc.minVal, 1e-9);
   return Math.min(1, Math.max(0, t));
+}
+
+/** Screen-space font px; scales slightly when zoomed out so labels stay usable. */
+function topologyLabelFontPx(viewScale: number): number {
+  return Math.round(Math.max(9, Math.min(13, 10 + Math.log2(Math.max(viewScale, 0.05)) * 1.5)));
+}
+
+function truncateTopologyLabel(raw: string): string {
+  if (raw.length <= 28) return raw;
+  return `${raw.slice(0, 26)}…`;
 }
 
 export interface TracerouteTopologyGraphProps {
@@ -273,6 +284,28 @@ export function TracerouteTopologyGraph({
     }
 
     ctx.restore();
+
+    // Labels in CSS pixel space so they stay readable at every zoom level (constant-ish screen size).
+    const labelPx = topologyLabelFontPx(transform.k);
+    ctx.font = `${labelPx}px ui-sans-serif, system-ui, sans-serif`;
+    ctx.textAlign = 'center';
+    ctx.textBaseline = 'middle';
+
+    for (const n of nodeDrawOrder) {
+      if (n.x == null || n.y == null) continue;
+      const gx = n.x * transform.k + transform.x;
+      const gy = n.y * transform.k + transform.y;
+      const rPx = (hasSignal ? nodeRadiusPixels(n.centrality, cExt.min, cExt.max) : 9) * transform.k;
+      const fade = nodeFade(n.node_id);
+      const label = truncateTopologyLabel(getHeatmapNodeLabel(n));
+      const ty = gy + rPx + labelPx * 0.65 + 2;
+      ctx.strokeStyle = `rgba(15, 23, 42, ${0.92 * fade})`;
+      ctx.lineWidth = Math.max(3, labelPx * 0.35);
+      ctx.lineJoin = 'round';
+      ctx.strokeText(label, gx, ty);
+      ctx.fillStyle = `rgba(226, 232, 240, ${fade})`;
+      ctx.fillText(label, gx, ty);
+    }
   }, [dimensions, transform, arcEnc, nodeExtents, staleMs, hoverId, selectedNodeId, adjacency]);
 
   useEffect(() => {

--- a/src/components/traceroutes/TracerouteTopologyGraph.tsx
+++ b/src/components/traceroutes/TracerouteTopologyGraph.tsx
@@ -85,6 +85,12 @@ export function TracerouteTopologyGraph({
   const nodeExtents = useMemo(() => computeHeatmapNodeExtents(nodes), [nodes]);
   const arcEnc = useMemo(() => computeHeatmapArcEncoding(edges, edgeMetric, intensity), [edges, edgeMetric, intensity]);
 
+  const roleById = useMemo(() => {
+    const m = new Map<number, HeatmapNode['role']>();
+    for (const n of nodes) m.set(n.node_id, n.role);
+    return m;
+  }, [nodes]);
+
   const adjacency = useMemo(() => {
     const m = new Map<number, Set<number>>();
     const add = (a: number, b: number) => {
@@ -244,9 +250,13 @@ export function TracerouteTopologyGraph({
       const b = L.target;
       if (a.x == null || a.y == null || b.x == null || b.y == null) continue;
       const alphaMul = edgeFade(a.node_id, b.node_id);
+      const touchesLeaf = roleById.get(a.node_id) === 'leaf' || roleById.get(b.node_id) === 'leaf';
       let stroke: [number, number, number, number];
       let lw: number;
-      if (enc) {
+      if (touchesLeaf) {
+        stroke = [142, 142, 148, 200];
+        lw = enc ? edgeArcWidth(L.edge, enc) : 1.5;
+      } else if (enc) {
         stroke = edgeArcColor(L.edge, enc);
         lw = edgeArcWidth(L.edge, enc);
       } else {
@@ -258,7 +268,10 @@ export function TracerouteTopologyGraph({
       ctx.lineTo(b.x, b.y);
       ctx.strokeStyle = `rgba(${stroke[0]},${stroke[1]},${stroke[2]},${(stroke[3] / 255) * alphaMul})`;
       ctx.lineWidth = Math.max(0.6, lw * 0.35);
+      if (touchesLeaf) ctx.setLineDash([6, 5]);
+      else ctx.setLineDash([]);
       ctx.stroke();
+      ctx.setLineDash([]);
     }
 
     const nodeDrawOrder = [...simNodes].sort((u, v) => {
@@ -306,7 +319,7 @@ export function TracerouteTopologyGraph({
       ctx.fillStyle = `rgba(226, 232, 240, ${fade})`;
       ctx.fillText(label, gx, ty);
     }
-  }, [dimensions, transform, arcEnc, nodeExtents, staleMs, hoverId, selectedNodeId, adjacency]);
+  }, [dimensions, transform, arcEnc, nodeExtents, staleMs, hoverId, selectedNodeId, adjacency, roleById]);
 
   useEffect(() => {
     draw();

--- a/src/components/traceroutes/heatmapEncoding.test.ts
+++ b/src/components/traceroutes/heatmapEncoding.test.ts
@@ -1,0 +1,66 @@
+import { describe, it, expect } from 'vitest';
+import type { HeatmapEdge } from '@/hooks/api/useHeatmapEdges';
+import {
+  computeHeatmapArcEncoding,
+  edgeArcColor,
+  edgeArcWidth,
+  degreeFillColor,
+  numericExtent,
+  staleThresholdMs,
+} from '@/components/traceroutes/heatmapEncoding';
+
+describe('heatmapEncoding', () => {
+  const edges: HeatmapEdge[] = [
+    {
+      from_node_id: 1,
+      to_node_id: 2,
+      from_lat: 0,
+      from_lng: 0,
+      to_lat: 1,
+      to_lng: 1,
+      weight: 10,
+      avg_snr: 5,
+    },
+    {
+      from_node_id: 2,
+      to_node_id: 3,
+      from_lat: 0,
+      from_lng: 0,
+      to_lat: 1,
+      to_lng: 1,
+      weight: 20,
+      avg_snr: 15,
+    },
+  ];
+
+  it('computes stable arc colours for packets metric', () => {
+    const enc = computeHeatmapArcEncoding(edges, 'packets', 0.7);
+    expect(enc).not.toBeNull();
+    const c0 = edgeArcColor(edges[0], enc!);
+    const c1 = edgeArcColor(edges[1], enc!);
+    expect(c0).toEqual([59, 130, 246, 200]);
+    expect(c1).toEqual([249, 115, 22, 200]);
+    expect(edgeArcWidth(edges[0], enc!)).toBeCloseTo(1.9, 5);
+  });
+
+  it('degreeFillColor matches numeric extent snapshot', () => {
+    const staleMs = staleThresholdMs(6);
+    const nowMs = Date.parse('2026-01-15T12:00:00.000Z');
+    const fill = degreeFillColor(
+      {
+        node_id: 1,
+        node_id_str: '!1',
+        lat: 0,
+        lng: 0,
+        degree: 5,
+        last_seen: '2026-01-15T11:00:00.000Z',
+      },
+      0,
+      10,
+      nowMs,
+      staleMs
+    );
+    expect(fill).toEqual([154, 123, 134, 238]);
+    expect(numericExtent([3, 1, 4])).toEqual({ min: 1, max: 4 });
+  });
+});

--- a/src/components/traceroutes/heatmapEncoding.ts
+++ b/src/components/traceroutes/heatmapEncoding.ts
@@ -1,0 +1,167 @@
+import type { HeatmapEdge, HeatmapNode } from '@/hooks/api/useHeatmapEdges';
+
+export function getHeatmapNodeLabel(node: HeatmapNode): string {
+  return node.short_name || node.long_name || node.node_id_str || `!${node.node_id.toString(16)}`;
+}
+
+/** Fallback fill when API omits centrality/degree */
+export const HEATMAP_NODE_COLOR_FALLBACK: [number, number, number, number] = [134, 239, 172, 200];
+
+export const PACKETS_QUIET_COLOR: [number, number, number, number] = [59, 130, 246, 200];
+export const PACKETS_BUSY_COLOR: [number, number, number, number] = [249, 115, 22, 200];
+export const SNR_BAD_COLOR: [number, number, number, number] = [239, 68, 68, 200];
+export const SNR_GOOD_COLOR: [number, number, number, number] = [34, 197, 94, 200];
+
+export function interpolatePacketsColor(weight: number, minW: number, maxW: number): [number, number, number, number] {
+  if (maxW <= minW) return PACKETS_QUIET_COLOR;
+  const t = (weight - minW) / (maxW - minW);
+  const r = Math.round(PACKETS_QUIET_COLOR[0] + (PACKETS_BUSY_COLOR[0] - PACKETS_QUIET_COLOR[0]) * t);
+  const g = Math.round(PACKETS_QUIET_COLOR[1] + (PACKETS_BUSY_COLOR[1] - PACKETS_QUIET_COLOR[1]) * t);
+  const b = Math.round(PACKETS_QUIET_COLOR[2] + (PACKETS_BUSY_COLOR[2] - PACKETS_QUIET_COLOR[2]) * t);
+  return [r, g, b, 200];
+}
+
+export function interpolateSnrColor(snr: number, minS: number, maxS: number): [number, number, number, number] {
+  if (maxS <= minS) return SNR_GOOD_COLOR;
+  const t = (snr - minS) / (maxS - minS);
+  const r = Math.round(SNR_BAD_COLOR[0] + (SNR_GOOD_COLOR[0] - SNR_BAD_COLOR[0]) * t);
+  const g = Math.round(SNR_BAD_COLOR[1] + (SNR_GOOD_COLOR[1] - SNR_BAD_COLOR[1]) * t);
+  const b = Math.round(SNR_BAD_COLOR[2] + (SNR_GOOD_COLOR[2] - SNR_BAD_COLOR[2]) * t);
+  return [r, g, b, 200];
+}
+
+export function numericExtent(values: number[]): { min: number; max: number } {
+  if (values.length === 0) return { min: 0, max: 1 };
+  let min = values[0];
+  let max = values[0];
+  for (const v of values) {
+    if (v < min) min = v;
+    if (v > max) max = v;
+  }
+  if (max <= min) return { min, max: min + 1e-9 };
+  return { min, max };
+}
+
+export function staleThresholdMs(hours: number): number {
+  return hours * 60 * 60 * 1000;
+}
+
+export function isVisuallyStale(node: HeatmapNode, nowMs: number, staleMs: number): boolean {
+  if (node.role === 'offline') return true;
+  if (!node.last_seen) return true;
+  const t = Date.parse(node.last_seen);
+  if (Number.isNaN(t)) return true;
+  return nowMs - t > staleMs;
+}
+
+export function recencyAlpha(node: HeatmapNode, nowMs: number, staleMs: number): number {
+  if (!node.last_seen) return 95;
+  const t = Date.parse(node.last_seen);
+  if (Number.isNaN(t)) return 95;
+  const age = nowMs - t;
+  if (age >= staleMs) return 88;
+  const u = age / staleMs;
+  return Math.round(255 - u * (255 - 155));
+}
+
+export function degreeFillColor(
+  node: HeatmapNode,
+  degMin: number,
+  degMax: number,
+  nowMs: number,
+  staleMs: number
+): [number, number, number, number] {
+  const grey: [number, number, number] = [148, 163, 184];
+  if (isVisuallyStale(node, nowMs, staleMs)) {
+    return [...grey, 100];
+  }
+  const t = degMax > degMin ? ((node.degree ?? 0) - degMin) / (degMax - degMin) : 0.5;
+  const r = Math.round(59 + (249 - 59) * t);
+  const g = Math.round(130 + (115 - 130) * t);
+  const b = Math.round(246 + (22 - 246) * t);
+  const alpha = recencyAlpha(node, nowMs, staleMs);
+  return [r, g, b, alpha];
+}
+
+/** Deck.gl scatter radius in meters (matches prior TracerouteHeatmapMap behaviour). */
+export function nodeRadiusMeters(centrality: number | undefined, cMin: number, cMax: number): number {
+  if (centrality == null) return 380;
+  if (cMax <= cMin) return 380;
+  const u = (centrality - cMin) / (cMax - cMin);
+  return 140 + u * 760;
+}
+
+/** Pixel radius for canvas/SVG topology (mirrors deck min/max pixel intent ~4–22). */
+export function nodeRadiusPixels(centrality: number | undefined, cMin: number, cMax: number): number {
+  if (centrality == null) return 11;
+  if (cMax <= cMin) return 11;
+  const u = (centrality - cMin) / (cMax - cMin);
+  return 4 + u * 18;
+}
+
+export function nodeLineWidth(node: HeatmapNode, degMin: number, degMax: number): number {
+  const t = degMax > degMin ? ((node.degree ?? 0) - degMin) / (degMax - degMin) : 0;
+  let w = 1 + t * 6;
+  if (node.role === 'backbone') w += 2.5;
+  if (node.role === 'offline') w = Math.min(w, 1);
+  return w;
+}
+
+export function nodeLineColor(fill: [number, number, number, number]): [number, number, number, number] {
+  const [r, g, b, a] = fill;
+  return [Math.round(r * 0.35), Math.round(g * 0.38), Math.round(b * 0.42), Math.min(255, a + 35)];
+}
+
+export interface HeatmapNodeExtents {
+  cExt: { min: number; max: number };
+  dExt: { min: number; max: number };
+  hasSignal: boolean;
+}
+
+export function computeHeatmapNodeExtents(nodes: HeatmapNode[]): HeatmapNodeExtents {
+  const hasSignal = nodes.some((n) => n.centrality != null && n.degree != null);
+  const centralities = nodes.map((n) => n.centrality).filter((c): c is number => c != null && !Number.isNaN(c));
+  const degrees = nodes.map((n) => n.degree).filter((d): d is number => d != null && !Number.isNaN(d));
+  const cExt = numericExtent(centralities.length ? centralities : [0, 1]);
+  const dExt = numericExtent(degrees.length ? degrees : [0, 1]);
+  return { cExt, dExt, hasSignal };
+}
+
+export interface HeatmapArcEncoding {
+  minVal: number;
+  maxVal: number;
+  valueKey: 'avg_snr' | 'weight';
+  useSnrColors: boolean;
+  baseWidth: number;
+}
+
+export function computeHeatmapArcEncoding(
+  edges: HeatmapEdge[],
+  edgeMetric: 'packets' | 'snr',
+  intensity: number
+): HeatmapArcEncoding | null {
+  if (edges.length === 0) return null;
+  const preferSnr = edgeMetric === 'snr';
+  const snrValues = edges.map((e) => e.avg_snr ?? -999).filter((v) => v > -999);
+  const hasSnrData = snrValues.length > 0;
+  const useSnrColors = preferSnr;
+  const values = hasSnrData ? snrValues : edges.map((e) => e.weight);
+  const valueKey = hasSnrData ? 'avg_snr' : 'weight';
+  if (values.length === 0) return null;
+  const minVal = Math.min(...values);
+  const maxVal = Math.max(...values);
+  const baseWidth = 1 + intensity * 4;
+  return { minVal, maxVal, valueKey, useSnrColors, baseWidth };
+}
+
+export function edgeArcColor(edge: HeatmapEdge, enc: HeatmapArcEncoding): [number, number, number, number] {
+  const v = enc.valueKey === 'avg_snr' ? (edge.avg_snr ?? enc.minVal) : edge.weight;
+  return enc.useSnrColors
+    ? interpolateSnrColor(v, enc.minVal, enc.maxVal)
+    : interpolatePacketsColor(v, enc.minVal, enc.maxVal);
+}
+
+export function edgeArcWidth(edge: HeatmapEdge, enc: HeatmapArcEncoding): number {
+  const v = enc.valueKey === 'avg_snr' ? (edge.avg_snr ?? enc.minVal) : edge.weight;
+  return enc.baseWidth * (0.5 + (v - enc.minVal) / Math.max(enc.maxVal - enc.minVal, 0.001));
+}

--- a/src/index.css
+++ b/src/index.css
@@ -100,6 +100,9 @@
 }
 
 /* Mapbox GL Popup + deck.gl maps (TracerouteHeatmapMap, coverage maps, links map) */
+.meshflow-map-popup {
+  z-index: 10000;
+}
 .meshflow-map-popup .mapboxgl-popup-content {
   background: transparent;
   padding: 0;

--- a/src/pages/traceroutes/TracerouteHeatmapPage.tsx
+++ b/src/pages/traceroutes/TracerouteHeatmapPage.tsx
@@ -5,6 +5,7 @@ import { Card, CardContent } from '@/components/ui/card';
 import { useHeatmapEdges } from '@/hooks/api/useHeatmapEdges';
 import { useManagedNodesSuspense } from '@/hooks/api/useNodes';
 import { TracerouteHeatmapMap } from '@/components/traceroutes/TracerouteHeatmapMap';
+import { TracerouteHeatmapBackboneRelayTable } from '@/components/traceroutes/TracerouteHeatmapBackboneRelayTable';
 import {
   NetworkStatsCard,
   TracerouteHeatmapChrome,
@@ -143,6 +144,8 @@ export function TracerouteHeatmapPage({ edgeMetric }: { edgeMetric: EdgeMetric }
           <NetworkStatsCard meta={meta} staleThresholdHours={HEATMAP_STALE_THRESHOLD_HOURS} className="w-64" />
         </div>
       </div>
+
+      {!error && !isLoading && <TracerouteHeatmapBackboneRelayTable nodes={nodes} />}
     </div>
   );
 }

--- a/src/pages/traceroutes/TracerouteTopologyPage.test.tsx
+++ b/src/pages/traceroutes/TracerouteTopologyPage.test.tsx
@@ -30,6 +30,7 @@ const sampleNode = {
   lng: -4.2,
   degree: 2,
   centrality: 0.5,
+  role: 'relay' as const,
   last_seen: '2026-01-10T12:00:00.000Z',
 };
 
@@ -86,5 +87,11 @@ describe('TracerouteTopologyPage URL → API', () => {
     renderPage(`/traceroutes/map/topology/heat?selected=${sampleNode.node_id}`);
     expect(screen.getByTestId('topology-node-panel')).toBeInTheDocument();
     expect(screen.getByText('Open details')).toBeInTheDocument();
+  });
+
+  it('renders backbone and relay table below the graph', () => {
+    renderPage('/traceroutes/map/topology/heat');
+    expect(screen.getByTestId('heatmap-backbone-relay-table')).toBeInTheDocument();
+    expect(screen.getByText(/Normalised betweenness/)).toBeInTheDocument();
   });
 });

--- a/src/pages/traceroutes/TracerouteTopologyPage.test.tsx
+++ b/src/pages/traceroutes/TracerouteTopologyPage.test.tsx
@@ -1,0 +1,90 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { render, screen } from '@testing-library/react';
+import { MemoryRouter } from 'react-router-dom';
+import { TracerouteTopologyPage } from './TracerouteTopologyPage';
+
+vi.mock('@/hooks/api/useHeatmapEdges', () => ({
+  useHeatmapEdges: vi.fn(),
+}));
+
+vi.mock('@/hooks/api/useNodes', () => ({
+  useManagedNodesSuspense: vi.fn(),
+}));
+
+vi.mock('@/components/traceroutes/TracerouteTopologyGraph', () => ({
+  TracerouteTopologyGraph: () => <div data-testid="topology-graph-stub" />,
+}));
+
+import { useHeatmapEdges } from '@/hooks/api/useHeatmapEdges';
+import { useManagedNodesSuspense } from '@/hooks/api/useNodes';
+
+const mockUseHeatmap = vi.mocked(useHeatmapEdges);
+const mockUseManaged = vi.mocked(useManagedNodesSuspense);
+
+const sampleNode = {
+  node_id: 0x11a,
+  node_id_str: '!0000011a',
+  short_name: 'A',
+  long_name: 'Node A',
+  lat: 55.9,
+  lng: -4.2,
+  degree: 2,
+  centrality: 0.5,
+  last_seen: '2026-01-10T12:00:00.000Z',
+};
+
+describe('TracerouteTopologyPage URL → API', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockUseManaged.mockReturnValue({
+      managedNodes: [
+        {
+          node_id: 99,
+          short_name: 'Feed',
+          node_id_str: '!00000063',
+          long_name: null,
+          last_heard: null,
+          owner: { id: 1, username: 'x' },
+          constellation: { id: 1 },
+          position: { latitude: null, longitude: null },
+        },
+      ],
+      totalManagedNodes: 1,
+      fetchNextPage: vi.fn(),
+      hasNextPage: false,
+    } as unknown as ReturnType<typeof useManagedNodesSuspense>);
+    mockUseHeatmap.mockReturnValue({
+      data: {
+        edges: [{ from_node_id: 1, to_node_id: 2, from_lat: 0, from_lng: 0, to_lat: 1, to_lng: 1, weight: 1 }],
+        nodes: [sampleNode],
+        meta: { active_nodes_count: 1, total_trace_routes_count: 1 },
+      },
+      isLoading: false,
+      error: null,
+    } as unknown as ReturnType<typeof useHeatmapEdges>);
+  });
+
+  function renderPage(path: string) {
+    render(
+      <MemoryRouter initialEntries={[path]}>
+        <TracerouteTopologyPage edgeMetric="packets" />
+      </MemoryRouter>
+    );
+  }
+
+  it('passes strategy CSV and source mesh id from search params to useHeatmapEdges', () => {
+    renderPage('/traceroutes/map/topology/heat?strategy=dx_across,intra_zone&source=99');
+    expect(mockUseHeatmap).toHaveBeenCalledWith(
+      expect.objectContaining({
+        targetStrategy: 'dx_across,intra_zone',
+        sourceNodeId: 99,
+      })
+    );
+  });
+
+  it('shows node panel when selected query matches a loaded node', () => {
+    renderPage(`/traceroutes/map/topology/heat?selected=${sampleNode.node_id}`);
+    expect(screen.getByTestId('topology-node-panel')).toBeInTheDocument();
+    expect(screen.getByText('Open details')).toBeInTheDocument();
+  });
+});

--- a/src/pages/traceroutes/TracerouteTopologyPage.tsx
+++ b/src/pages/traceroutes/TracerouteTopologyPage.tsx
@@ -5,6 +5,7 @@ import { Card, CardContent } from '@/components/ui/card';
 import { useHeatmapEdges } from '@/hooks/api/useHeatmapEdges';
 import { useManagedNodesSuspense } from '@/hooks/api/useNodes';
 import { TracerouteTopologyGraph } from '@/components/traceroutes/TracerouteTopologyGraph';
+import { TracerouteHeatmapBackboneRelayTable } from '@/components/traceroutes/TracerouteHeatmapBackboneRelayTable';
 import { TracerouteHeatmapChrome, type EdgeMetric } from '@/components/traceroutes/TracerouteHeatmapChrome';
 import { TracerouteHeatmapNodePanel } from '@/components/traceroutes/TracerouteHeatmapNodePanel';
 import type { HeatmapNode } from '@/hooks/api/useHeatmapEdges';
@@ -140,6 +141,8 @@ export function TracerouteTopologyPage({ edgeMetric }: { edgeMetric: EdgeMetric 
           </div>
         )}
       </div>
+
+      {!error && !isLoading && <TracerouteHeatmapBackboneRelayTable nodes={nodes} />}
     </div>
   );
 }

--- a/src/pages/traceroutes/TracerouteTopologyPage.tsx
+++ b/src/pages/traceroutes/TracerouteTopologyPage.tsx
@@ -5,11 +5,7 @@ import { Card, CardContent } from '@/components/ui/card';
 import { useHeatmapEdges } from '@/hooks/api/useHeatmapEdges';
 import { useManagedNodesSuspense } from '@/hooks/api/useNodes';
 import { TracerouteTopologyGraph } from '@/components/traceroutes/TracerouteTopologyGraph';
-import {
-  NetworkStatsCard,
-  TracerouteHeatmapChrome,
-  type EdgeMetric,
-} from '@/components/traceroutes/TracerouteHeatmapChrome';
+import { TracerouteHeatmapChrome, type EdgeMetric } from '@/components/traceroutes/TracerouteHeatmapChrome';
 import { TracerouteHeatmapNodePanel } from '@/components/traceroutes/TracerouteHeatmapNodePanel';
 import type { HeatmapNode } from '@/hooks/api/useHeatmapEdges';
 import type { TracerouteStrategyValue } from '@/lib/traceroute-strategy';
@@ -71,7 +67,6 @@ export function TracerouteTopologyPage({ edgeMetric }: { edgeMetric: EdgeMetric 
 
   const edges = data?.edges ?? [];
   const nodes = useMemo(() => data?.nodes ?? [], [data]);
-  const meta = data?.meta ?? { active_nodes_count: 0, total_trace_routes_count: 0 };
 
   const hasGeoFilters = strategyTokens.length > 0 || sourceMeshId != null;
 
@@ -108,10 +103,6 @@ export function TracerouteTopologyPage({ edgeMetric }: { edgeMetric: EdgeMetric 
         onUpdateParams={updateParams}
       />
 
-      <div className="block md:hidden">
-        <NetworkStatsCard meta={meta} staleThresholdHours={HEATMAP_STALE_THRESHOLD_HOURS} />
-      </div>
-
       <div className="relative flex min-h-[300px] flex-1 flex-col gap-4 md:min-h-[calc(100dvh-16rem)] md:flex-row">
         <Card className="relative min-h-[300px] flex-1 overflow-hidden md:min-h-[calc(100dvh-16rem)]">
           <CardContent className="h-full min-h-[300px] p-0">
@@ -139,7 +130,7 @@ export function TracerouteTopologyPage({ edgeMetric }: { edgeMetric: EdgeMetric 
         </Card>
 
         {selectedNode && !error && !isLoading && (
-          <div className="shrink-0 md:w-80" data-testid="topology-node-panel">
+          <div className="shrink-0 md:z-20 md:w-80" data-testid="topology-node-panel">
             <TracerouteHeatmapNodePanel
               node={selectedNode}
               onClose={() => updateParams({ selected: null })}
@@ -148,10 +139,6 @@ export function TracerouteTopologyPage({ edgeMetric }: { edgeMetric: EdgeMetric 
             />
           </div>
         )}
-
-        <div className="absolute right-4 top-4 z-10 hidden md:block">
-          <NetworkStatsCard meta={meta} staleThresholdHours={HEATMAP_STALE_THRESHOLD_HOURS} className="w-64" />
-        </div>
       </div>
     </div>
   );

--- a/src/pages/traceroutes/TracerouteTopologyPage.tsx
+++ b/src/pages/traceroutes/TracerouteTopologyPage.tsx
@@ -4,12 +4,13 @@ import { subHours, subDays } from 'date-fns';
 import { Card, CardContent } from '@/components/ui/card';
 import { useHeatmapEdges } from '@/hooks/api/useHeatmapEdges';
 import { useManagedNodesSuspense } from '@/hooks/api/useNodes';
-import { TracerouteHeatmapMap } from '@/components/traceroutes/TracerouteHeatmapMap';
+import { TracerouteTopologyGraph } from '@/components/traceroutes/TracerouteTopologyGraph';
 import {
   NetworkStatsCard,
   TracerouteHeatmapChrome,
   type EdgeMetric,
 } from '@/components/traceroutes/TracerouteHeatmapChrome';
+import { TracerouteHeatmapNodePanel } from '@/components/traceroutes/TracerouteHeatmapNodePanel';
 import type { HeatmapNode } from '@/hooks/api/useHeatmapEdges';
 import type { TracerouteStrategyValue } from '@/lib/traceroute-strategy';
 
@@ -31,10 +32,9 @@ function parseSourceParam(raw: string | null): number | null {
   return Number.isFinite(n) ? n : null;
 }
 
-/** Client-side stale styling threshold (hours without mesh observation). */
 const HEATMAP_STALE_THRESHOLD_HOURS = 6;
 
-export function TracerouteHeatmapPage({ edgeMetric }: { edgeMetric: EdgeMetric }) {
+export function TracerouteTopologyPage({ edgeMetric }: { edgeMetric: EdgeMetric }) {
   const [searchParams, setSearchParams] = useSearchParams();
   const [timeRange, setTimeRange] = useState<TimeRange>('7d');
 
@@ -88,15 +88,15 @@ export function TracerouteHeatmapPage({ edgeMetric }: { edgeMetric: EdgeMetric }
   }, [nodes, selectedNodeId, updateParams]);
 
   const searchSuffix = searchParams.toString() ? `?${searchParams.toString()}` : '';
-  const topologyLink = {
-    to: `${edgeMetric === 'packets' ? '/traceroutes/map/topology/heat' : '/traceroutes/map/topology/snr'}${searchSuffix}`,
-    label: 'Topology view',
+  const mapLink = {
+    to: `/traceroutes/map/${edgeMetric === 'packets' ? 'heat' : 'snr'}${searchSuffix}`,
+    label: 'Map view',
   };
 
   return (
     <div className="flex min-h-[50vh] flex-col gap-4 px-4 py-4 md:px-6 md:py-6">
       <TracerouteHeatmapChrome
-        viewMode="map"
+        viewMode="topology"
         edgeMetric={edgeMetric}
         searchSuffix={searchSuffix}
         timeRange={timeRange}
@@ -112,9 +112,9 @@ export function TracerouteHeatmapPage({ edgeMetric }: { edgeMetric: EdgeMetric }
         <NetworkStatsCard meta={meta} staleThresholdHours={HEATMAP_STALE_THRESHOLD_HOURS} />
       </div>
 
-      <div className="relative flex-1 min-h-[300px] md:min-h-[calc(100dvh-16rem)]" data-testid="heatmap-map">
-        <Card className="h-full min-h-[300px]">
-          <CardContent className="h-full p-0">
+      <div className="relative flex min-h-[300px] flex-1 flex-col gap-4 md:min-h-[calc(100dvh-16rem)] md:flex-row">
+        <Card className="relative min-h-[300px] flex-1 overflow-hidden md:min-h-[calc(100dvh-16rem)]">
+          <CardContent className="h-full min-h-[300px] p-0">
             {error && (
               <div className="flex h-full min-h-[300px] items-center justify-center text-destructive">
                 Failed to load heatmap: {error instanceof Error ? error.message : 'Unknown error'}
@@ -126,18 +126,28 @@ export function TracerouteHeatmapPage({ edgeMetric }: { edgeMetric: EdgeMetric }
               </div>
             )}
             {!error && !isLoading && (
-              <TracerouteHeatmapMap
+              <TracerouteTopologyGraph
                 edges={edges}
                 nodes={nodes}
                 edgeMetric={edgeMetric}
                 staleThresholdHours={HEATMAP_STALE_THRESHOLD_HOURS}
-                selectedNode={selectedNode}
+                selectedNodeId={selectedNodeId}
                 onSelectedNodeChange={(node) => updateParams({ selected: node ? String(node.node_id) : null })}
-                topologyLink={topologyLink}
               />
             )}
           </CardContent>
         </Card>
+
+        {selectedNode && !error && !isLoading && (
+          <div className="shrink-0 md:w-80" data-testid="topology-node-panel">
+            <TracerouteHeatmapNodePanel
+              node={selectedNode}
+              onClose={() => updateParams({ selected: null })}
+              secondaryLink={mapLink}
+              className="relative min-w-[120px] rounded-md border border-border bg-card px-3 py-2 text-sm text-card-foreground shadow-sm"
+            />
+          </div>
+        )}
 
         <div className="absolute right-4 top-4 z-10 hidden md:block">
           <NetworkStatsCard meta={meta} staleThresholdHours={HEATMAP_STALE_THRESHOLD_HOURS} className="w-64" />


### PR DESCRIPTION
# Summary

Adds a non-geographic topology view and improves traceroute heatmap role exploration:

- Adds a force-directed topology view for heatmap/SNR traceroute data, sharing filters, URL state, node selection, and encodings with the geographic map.
- Extracts shared heatmap encoding and node-panel helpers so the map and topology views stay consistent.
- Adds backbone/relay tables below both the geographic and topology views, with fixed-height scroll regions and descriptions for centrality and degree.
- Styles edges connected to leaf nodes as dashed grey on both views.
- Fixes Mapbox popup stacking so node detail overlays render above deck.gl canvas layers.

Related API PR: https://github.com/pskillen/meshflow-api/pull/254

Closes #159.

## Testing performed

- `npm run build`
- `npm test`
- `npm run lint` (warnings only; existing repository warnings outside this change)