### PR TITLE
Mesh Infrastructure: 14d list window, low-battery table, chart layout, map legend

### DIFF
--- a/src/components/nodes/NodesAndConstellationsMap.test.tsx
+++ b/src/components/nodes/NodesAndConstellationsMap.test.tsx
@@ -1,0 +1,82 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { render, screen, waitFor } from '@testing-library/react';
+import type { ManagedNode } from '@/lib/models';
+import { NodesAndConstellationsMap } from './NodesAndConstellationsMap';
+
+vi.mock('@/hooks/useMapTileUrl', () => ({
+  useMapTileUrl: () => ({
+    url: 'https://tile.example/{z}/{x}/{y}.png',
+    attribution: 'OSM',
+  }),
+}));
+
+const { mapMocks } = vi.hoisted(() => {
+  const mapInstance = {
+    setView: vi.fn(),
+    fitBounds: vi.fn(),
+    remove: vi.fn(),
+    removeLayer: vi.fn(),
+    addLayer: vi.fn(),
+    on: vi.fn(),
+  };
+  mapInstance.setView.mockImplementation(() => mapInstance);
+  mapInstance.fitBounds.mockImplementation(() => mapInstance);
+  return { mapMocks: { mapInstance } };
+});
+
+vi.mock('leaflet', () => ({
+  default: {
+    map: vi.fn(() => mapMocks.mapInstance),
+    tileLayer: vi.fn(() => ({ addTo: vi.fn().mockReturnThis() })),
+    divIcon: vi.fn(() => ({})),
+    marker: vi.fn(() => ({
+      bindPopup: vi.fn().mockReturnThis(),
+      addTo: vi.fn().mockReturnThis(),
+      remove: vi.fn(),
+      on: vi.fn().mockReturnThis(),
+    })),
+    latLngBounds: vi.fn(() => ({
+      extend: vi.fn(),
+      isValid: vi.fn(() => false),
+    })),
+    polygon: vi.fn(() => ({ addTo: vi.fn().mockReturnThis(), remove: vi.fn() })),
+  },
+}));
+
+function managedWithConstellation(): ManagedNode {
+  return {
+    node_id: 1,
+    node_id_str: '!00000001',
+    long_name: 'A',
+    short_name: 'A',
+    last_heard: new Date(),
+    owner: { id: 1, username: 'u' },
+    constellation: { id: 10, name: 'Test Constellation', map_color: '#ff0000' },
+    position: { latitude: 55.1, longitude: -4.2 },
+  };
+}
+
+describe('NodesAndConstellationsMap', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('omits role legend when showRoleLegendSwatches is false but keeps constellation legend', async () => {
+    render(
+      <div style={{ height: 500 }}>
+        <NodesAndConstellationsMap
+          managedNodes={[managedWithConstellation()]}
+          observedNodes={[]}
+          showConstellation={true}
+          showRoleLegendSwatches={false}
+        />
+      </div>
+    );
+    await waitFor(() => {
+      expect(screen.getByRole('region', { name: /Map marker colours/i })).toBeInTheDocument();
+    });
+    const legend = screen.getByRole('region', { name: /Map marker colours/i });
+    expect(legend).toHaveTextContent('Test Constellation');
+    expect(screen.queryByText('Other mesh nodes (by role)')).not.toBeInTheDocument();
+  });
+});

--- a/src/components/nodes/NodesAndConstellationsMap.tsx
+++ b/src/components/nodes/NodesAndConstellationsMap.tsx
@@ -74,6 +74,8 @@ export interface NodesAndConstellationsMapProps {
    * Set `false` to hide; set `true` to force on even with `getMarkerColor`.
    */
   showMapLegend?: boolean;
+  /** When false, hides role-colour swatches in the legend (constellation section unchanged). Default true. */
+  showRoleLegendSwatches?: boolean;
 }
 
 export function NodesAndConstellationsMap({
@@ -97,6 +99,7 @@ export function NodesAndConstellationsMap({
   getMarkerBorderColor,
   getManagedNodeMarkerColor,
   showMapLegend,
+  showRoleLegendSwatches = true,
 }: NodesAndConstellationsMapProps) {
   const mapRef = useRef<HTMLDivElement>(null);
   const mapInstanceRef = useRef<L.Map | null>(null);
@@ -502,7 +505,7 @@ export function NodesAndConstellationsMap({
       {showLegendResolved ? (
         <MapMarkerLegend
           constellationItems={showConstellation ? legendConstellationItems : []}
-          showRoleSwatches={getMarkerColor == null}
+          showRoleSwatches={showRoleLegendSwatches && getMarkerColor == null}
           roleSwatches={roleLegendData}
           roleSectionTitle={showConstellation ? 'Other mesh nodes (by role)' : 'Node role'}
         />

--- a/src/hooks/api/useNodes.ts
+++ b/src/hooks/api/useNodes.ts
@@ -373,6 +373,44 @@ export function useInfrastructureNodesSuspense(options?: UseInfrastructureNodesO
   };
 }
 
+/** API page size when walking every page of infrastructure results. */
+const INFRASTRUCTURE_FULL_FETCH_PAGE_SIZE = 1000;
+
+/**
+ * Fetches every infrastructure node for the given filters (all pages), for maps and summary tables.
+ * Use {@link useInfrastructureNodesSuspense} with a small page size for the card grid and "Load more".
+ */
+export function useAllInfrastructureNodesSuspense(options?: UseInfrastructureNodesOptions) {
+  const api = useMeshtasticApi();
+  const lastHeardAfterKey = options?.lastHeardAfter ? roundToFiveMinutes(options.lastHeardAfter) : null;
+  const includeClientBase = options?.includeClientBase ?? false;
+
+  const query = useSuspenseQuery({
+    queryKey: ['nodes', 'infrastructure', 'all-pages', lastHeardAfterKey, includeClientBase],
+    queryFn: async () => {
+      const all: ObservedNode[] = [];
+      let page = 1;
+      let totalNodes = 0;
+      while (true) {
+        const res = await api.getInfrastructureNodes({
+          page,
+          pageSize: INFRASTRUCTURE_FULL_FETCH_PAGE_SIZE,
+          lastHeardAfter: options?.lastHeardAfter,
+          includeClientBase: options?.includeClientBase,
+        });
+        totalNodes = res.count;
+        all.push(...res.results);
+        if (!res.next || res.results.length === 0) break;
+        page += 1;
+      }
+      return { nodes: all, totalNodes };
+    },
+    refetchInterval: 1000 * 60,
+  });
+
+  return { nodes: query.data.nodes, totalNodes: query.data.totalNodes };
+}
+
 export interface UseWeatherNodesOptions {
   pageSize?: number;
   environmentReportedAfter?: Date;

--- a/src/lib/infrastructure-low-battery.test.ts
+++ b/src/lib/infrastructure-low-battery.test.ts
@@ -1,0 +1,169 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import type { ObservedNode } from '@/lib/models';
+import {
+  getBatteryMetricsReportedAt,
+  getLowBatteryRowFlags,
+  isBatteryTelemetryStale,
+  LOW_BATTERY_THRESHOLD_PERCENT,
+  partitionLowBatteryNodes,
+  qualifiesLowBatterySection,
+} from './infrastructure-low-battery';
+
+function baseNode(overrides: Partial<ObservedNode> = {}): ObservedNode {
+  return {
+    internal_id: 1,
+    node_id: 100,
+    node_id_str: '!00000064',
+    mac_addr: null,
+    long_name: 'Test',
+    short_name: 'T',
+    hw_model: null,
+    public_key: null,
+    last_heard: new Date('2026-01-15T12:00:00Z'),
+    ...overrides,
+  } as ObservedNode;
+}
+
+describe('infrastructure-low-battery', () => {
+  beforeEach(() => {
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date('2026-01-15T12:00:00Z'));
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  it('getBatteryMetricsReportedAt returns null without metrics', () => {
+    expect(getBatteryMetricsReportedAt(baseNode())).toBeNull();
+  });
+
+  it('qualifiesLowBatterySection when metrics missing', () => {
+    expect(qualifiesLowBatterySection(baseNode())).toBe(true);
+  });
+
+  it('qualifies when battery below threshold with fresh telemetry', () => {
+    const n = baseNode({
+      latest_device_metrics: {
+        reported_time: new Date('2026-01-14T12:00:00Z'),
+        logged_time: null,
+        battery_level: 40,
+        voltage: 3.5,
+        channel_utilization: 0,
+        air_util_tx: 0,
+        uptime_seconds: 0,
+      },
+    });
+    expect(qualifiesLowBatterySection(n)).toBe(true);
+    expect(isBatteryTelemetryStale(n)).toBe(false);
+  });
+
+  it('qualifies when telemetry is stale (>3 days) even if battery reads high', () => {
+    const n = baseNode({
+      latest_device_metrics: {
+        reported_time: new Date('2026-01-10T12:00:00Z'),
+        logged_time: null,
+        battery_level: 99,
+        voltage: 4,
+        channel_utilization: 0,
+        air_util_tx: 0,
+        uptime_seconds: 0,
+      },
+    });
+    expect(qualifiesLowBatterySection(n)).toBe(true);
+    expect(isBatteryTelemetryStale(n)).toBe(true);
+  });
+
+  it('does not qualify when fresh telemetry and battery healthy', () => {
+    const n = baseNode({
+      latest_device_metrics: {
+        reported_time: new Date('2026-01-14T12:00:00Z'),
+        logged_time: null,
+        battery_level: LOW_BATTERY_THRESHOLD_PERCENT,
+        voltage: 4,
+        channel_utilization: 0,
+        air_util_tx: 0,
+        uptime_seconds: 0,
+      },
+    });
+    expect(qualifiesLowBatterySection(n)).toBe(false);
+  });
+
+  it('partitionLowBatteryNodes dedupes by node_id and puts 0% last', () => {
+    const dup = baseNode({
+      node_id: 200,
+      internal_id: 2,
+      latest_device_metrics: {
+        reported_time: new Date('2026-01-14T12:00:00Z'),
+        logged_time: null,
+        battery_level: 0,
+        voltage: 0,
+        channel_utilization: 0,
+        air_util_tx: 0,
+        uptime_seconds: 0,
+      },
+    });
+    const lowFresh = baseNode({
+      node_id: 201,
+      internal_id: 3,
+      last_heard: new Date('2026-01-15T10:00:00Z'),
+      latest_device_metrics: {
+        reported_time: new Date('2026-01-14T12:00:00Z'),
+        logged_time: null,
+        battery_level: 30,
+        voltage: 3.4,
+        channel_utilization: 0,
+        air_util_tx: 0,
+        uptime_seconds: 0,
+      },
+    });
+    const out = partitionLowBatteryNodes([dup, dup, lowFresh]);
+    expect(out.map((n) => n.node_id)).toEqual([201, 200]);
+  });
+
+  it('getLowBatteryRowFlags shows both badges when low and stale', () => {
+    const n = baseNode({
+      latest_device_metrics: {
+        reported_time: new Date('2026-01-10T12:00:00Z'),
+        logged_time: null,
+        battery_level: 20,
+        voltage: 3.2,
+        channel_utilization: 0,
+        air_util_tx: 0,
+        uptime_seconds: 0,
+      },
+    });
+    const f = getLowBatteryRowFlags(n);
+    expect(f.showLowBatteryBadge).toBe(true);
+    expect(f.showStaleBatteryBadge).toBe(true);
+    expect(f.isZeroPercent).toBe(false);
+  });
+
+  it('stale threshold uses STALE_BATTERY_TELEMETRY_DAYS boundary', () => {
+    const freshEdge = baseNode({
+      latest_device_metrics: {
+        reported_time: new Date('2026-01-12T12:00:01Z'),
+        logged_time: null,
+        battery_level: 99,
+        voltage: 4,
+        channel_utilization: 0,
+        air_util_tx: 0,
+        uptime_seconds: 0,
+      },
+    });
+    expect(isBatteryTelemetryStale(freshEdge)).toBe(false);
+
+    const staleEdge = baseNode({
+      latest_device_metrics: {
+        reported_time: new Date('2026-01-12T11:59:59Z'),
+        logged_time: null,
+        battery_level: 99,
+        voltage: 4,
+        channel_utilization: 0,
+        air_util_tx: 0,
+        uptime_seconds: 0,
+      },
+    });
+    expect(isBatteryTelemetryStale(staleEdge)).toBe(true);
+  });
+});

--- a/src/lib/infrastructure-low-battery.ts
+++ b/src/lib/infrastructure-low-battery.ts
@@ -1,0 +1,78 @@
+import { subDays } from 'date-fns';
+import type { ObservedNode } from '@/lib/models';
+
+/** Battery reading older than this is treated as stale (separate from GPS freshness). */
+export const STALE_BATTERY_TELEMETRY_DAYS = 3;
+
+/** Below this percentage (inclusive of 0) counts as “low battery” when telemetry exists. */
+export const LOW_BATTERY_THRESHOLD_PERCENT = 50;
+
+export function getBatteryMetricsReportedAt(node: ObservedNode): Date | null {
+  const m = node.latest_device_metrics;
+  if (!m?.reported_time) return null;
+  const t = m.reported_time;
+  return t instanceof Date ? t : new Date(t);
+}
+
+export function isBatteryTelemetryStale(node: ObservedNode, now: Date = new Date()): boolean {
+  const at = getBatteryMetricsReportedAt(node);
+  if (!at) return true;
+  return at < subDays(now, STALE_BATTERY_TELEMETRY_DAYS);
+}
+
+/** True if the node should appear in the low-battery section (union of low % and stale / missing telemetry). */
+export function qualifiesLowBatterySection(node: ObservedNode, now: Date = new Date()): boolean {
+  const m = node.latest_device_metrics;
+  if (!m) return true;
+  if (isBatteryTelemetryStale(node, now)) return true;
+  return m.battery_level < LOW_BATTERY_THRESHOLD_PERCENT;
+}
+
+export type LowBatteryRowFlags = {
+  /** Shown in the muted bottom group; telemetry often bogus at 0%. */
+  isZeroPercent: boolean;
+  showLowBatteryBadge: boolean;
+  showStaleBatteryBadge: boolean;
+};
+
+export function getLowBatteryRowFlags(node: ObservedNode, now: Date = new Date()): LowBatteryRowFlags {
+  const m = node.latest_device_metrics;
+  const reportedAt = getBatteryMetricsReportedAt(node);
+  const hasUsableMetrics = Boolean(m && reportedAt);
+  const level = m?.battery_level;
+  const isZeroPercent = hasUsableMetrics && level === 0;
+  const showStaleBatteryBadge = !hasUsableMetrics || isBatteryTelemetryStale(node, now);
+  const showLowBatteryBadge = hasUsableMetrics && level != null && level < LOW_BATTERY_THRESHOLD_PERCENT;
+  return { isZeroPercent, showLowBatteryBadge, showStaleBatteryBadge };
+}
+
+function lastHeardTime(node: ObservedNode): number {
+  if (!node.last_heard) return 0;
+  return node.last_heard instanceof Date ? node.last_heard.getTime() : new Date(node.last_heard).getTime();
+}
+
+/**
+ * Deduplicates by node id, partitions 0% rows to the bottom, sorts by most recently heard within each group.
+ */
+export function partitionLowBatteryNodes(nodes: ObservedNode[], now: Date = new Date()): ObservedNode[] {
+  const seen = new Set<number>();
+  const candidates: ObservedNode[] = [];
+  for (const n of nodes) {
+    if (seen.has(n.node_id)) continue;
+    if (!qualifiesLowBatterySection(n, now)) continue;
+    seen.add(n.node_id);
+    candidates.push(n);
+  }
+
+  const primary: ObservedNode[] = [];
+  const zeroPercent: ObservedNode[] = [];
+  for (const n of candidates) {
+    if (getLowBatteryRowFlags(n, now).isZeroPercent) zeroPercent.push(n);
+    else primary.push(n);
+  }
+
+  const byLastHeard = (a: ObservedNode, b: ObservedNode) => lastHeardTime(b) - lastHeardTime(a);
+  primary.sort(byLastHeard);
+  zeroPercent.sort(byLastHeard);
+  return [...primary, ...zeroPercent];
+}

--- a/src/pages/nodes/MeshInfrastructure.tsx
+++ b/src/pages/nodes/MeshInfrastructure.tsx
@@ -21,7 +21,14 @@ import { Button } from '@/components/ui/button';
 import { ObservedNode, type NodeWatch } from '@/lib/models';
 import { filterManagedNodesForMapDisplay } from '@/lib/managed-node-status';
 import { MeshWatchControls } from '@/components/nodes/MeshWatchControls';
-import { MapPinOff } from 'lucide-react';
+import { Battery, MapPinOff } from 'lucide-react';
+import {
+  getBatteryMetricsReportedAt,
+  getLowBatteryRowFlags,
+  LOW_BATTERY_THRESHOLD_PERCENT,
+  partitionLowBatteryNodes,
+  STALE_BATTERY_TELEMETRY_DAYS,
+} from '@/lib/infrastructure-low-battery';
 
 const CHART_TIME_RANGE_OPTIONS = [
   { key: '24h', label: '24 hours' },
@@ -32,12 +39,13 @@ const CHART_TIME_RANGE_OPTIONS = [
   { key: '14d', label: '14 days' },
 ];
 
-type NodeListTimeRange = '2h' | '24h' | '7d' | '30d' | 'all';
+type NodeListTimeRange = '2h' | '24h' | '7d' | '14d' | '30d' | 'all';
 
 const TIME_RANGE_OPTIONS: { value: NodeListTimeRange; label: string }[] = [
   { value: '2h', label: '2 hours' },
   { value: '24h', label: '24 hours' },
   { value: '7d', label: '7 days' },
+  { value: '14d', label: '14 days' },
   { value: '30d', label: '30 days' },
   { value: 'all', label: 'All time' },
 ];
@@ -52,6 +60,8 @@ function getLastHeardAfter(timeRange: NodeListTimeRange): Date | undefined {
       return subHours(now, 24);
     case '7d':
       return subDays(now, 7);
+    case '14d':
+      return subDays(now, 14);
     case '30d':
       return subDays(now, 30);
     default:
@@ -84,7 +94,7 @@ function hasRecentLocation(node: ObservedNode): boolean {
 }
 
 function MeshInfrastructureContent() {
-  const [timeRange, setTimeRange] = useState<NodeListTimeRange>('30d');
+  const [timeRange, setTimeRange] = useState<NodeListTimeRange>('14d');
   const [includeClientBase, setIncludeClientBase] = useState(false);
   const [chartTimeRangeLabel, setChartTimeRangeLabel] = useState('7d');
   const [chartDateRange, setChartDateRange] = useState<{ startDate: Date; endDate: Date }>({
@@ -98,7 +108,7 @@ function MeshInfrastructureContent() {
 
   const { nodes, totalNodes, fetchNextPage, hasNextPage } = useInfrastructureNodesSuspense({
     lastHeardAfter,
-    pageSize: 100,
+    pageSize: 12,
     includeClientBase,
   });
 
@@ -123,6 +133,8 @@ function MeshInfrastructureContent() {
 
   const nodesWithLocation = useMemo(() => nodes.filter(hasRecentLocation), [nodes]);
   const nodesWithoutLocation = useMemo(() => nodes.filter((n) => !hasRecentLocation(n)), [nodes]);
+
+  const lowBatteryNodesOrdered = useMemo(() => partitionLowBatteryNodes(nodes), [nodes]);
 
   const sortedNodes = useMemo(
     () =>
@@ -187,16 +199,6 @@ function MeshInfrastructureContent() {
             </SelectContent>
           </Select>
         </div>
-        <div className="flex items-center gap-2">
-          <label htmlFor="chart-time-range" className="text-sm text-muted-foreground">
-            Chart time range:
-          </label>
-          <TimeRangeSelect
-            options={CHART_TIME_RANGE_OPTIONS}
-            value={chartTimeRangeLabel}
-            onChange={handleChartTimeRangeChange}
-          />
-        </div>
       </div>
 
       <div className="mb-8">
@@ -213,6 +215,7 @@ function MeshInfrastructureContent() {
                 showUnmanagedNodes={true}
                 drawPositionUncertainty={true}
                 enableBubbles={true}
+                showRoleLegendSwatches={false}
               />
             </div>
           </CardContent>
@@ -224,11 +227,13 @@ function MeshInfrastructureContent() {
           <CardHeader>
             <CardTitle className="flex items-center gap-2">
               <MapPinOff className="h-5 w-5" />
-              Nodes without recent location
+              Nodes without recent location ({nodesWithoutLocation.length})
             </CardTitle>
             <CardDescription>
-              Infrastructure nodes that have not broadcast their GPS position in the last 7 days (
-              {nodesWithoutLocation.length}). A node can be active (Last Heard) without reporting location.
+              &quot;Recent location&quot; means a GPS fix reported in the last {STALE_LOCATION_DAYS} days. The node list
+              time range (default 14 days of last heard) controls which infrastructure nodes appear on this page—nodes
+              outside that window are not listed, which is separate from GPS freshness. A node can be active (last
+              heard) without reporting location.
             </CardDescription>
           </CardHeader>
           <CardContent>
@@ -338,12 +343,171 @@ function MeshInfrastructureContent() {
         </Card>
       )}
 
+      {lowBatteryNodesOrdered.length > 0 && (
+        <Card className="mb-8">
+          <CardHeader>
+            <CardTitle className="flex items-center gap-2">
+              <Battery className="h-5 w-5" />
+              Low battery nodes ({lowBatteryNodesOrdered.length})
+            </CardTitle>
+            <CardDescription>
+              Includes nodes below {LOW_BATTERY_THRESHOLD_PERCENT}% battery, no battery telemetry, or a reading older
+              than {STALE_BATTERY_TELEMETRY_DAYS} days. Last heard can still be recent while metrics are missing or
+              stale—that is not always a problem. Rows showing 0% are often bogus telemetry and are listed last.
+            </CardDescription>
+          </CardHeader>
+          <CardContent>
+            <Table>
+              <TableHeader>
+                <TableRow>
+                  <TableHead>Node</TableHead>
+                  <TableHead>Node ID</TableHead>
+                  <TableHead>Last heard</TableHead>
+                  <TableHead>Battery</TableHead>
+                  <TableHead>Status</TableHead>
+                  <TableHead>Owner</TableHead>
+                  <TableHead>Mesh watch</TableHead>
+                  <TableHead className="w-0"></TableHead>
+                </TableRow>
+              </TableHeader>
+              <TableBody>
+                {lowBatteryNodesOrdered.map((node) => {
+                  const flags = getLowBatteryRowFlags(node);
+                  const reportedAt = getBatteryMetricsReportedAt(node);
+                  const level = node.latest_device_metrics?.battery_level;
+                  const watch = watchesByNodeIdStr.get(node.node_id_str);
+                  const managed = managedByMeshId.get(node.node_id);
+                  const cutoff = subDays(new Date(), 7);
+                  const isOffline =
+                    !node.last_heard ||
+                    (node.last_heard instanceof Date ? node.last_heard : new Date(node.last_heard)) < cutoff;
+                  return (
+                    <TableRow
+                      key={node.internal_id}
+                      className={flags.isZeroPercent ? 'opacity-70 text-muted-foreground' : undefined}
+                    >
+                      <TableCell>
+                        <div className="flex items-center gap-2">
+                          <Link to={`/nodes/${node.node_id}`} className="font-medium text-primary hover:underline">
+                            {node.long_name} ({node.short_name || node.node_id_str})
+                          </Link>
+                          {isOffline && (
+                            <Badge
+                              variant="outline"
+                              className="text-xs border-red-500/70 text-red-700 dark:border-red-400 dark:text-red-300"
+                            >
+                              OFFLINE
+                            </Badge>
+                          )}
+                        </div>
+                      </TableCell>
+                      <TableCell className="text-muted-foreground">{node.node_id_str}</TableCell>
+                      <TableCell>
+                        <div className="flex flex-col">
+                          {node.last_heard ? (
+                            <>
+                              <span>
+                                {format(
+                                  node.last_heard instanceof Date ? node.last_heard : new Date(node.last_heard),
+                                  'PPpp',
+                                  { locale: enGB }
+                                )}
+                              </span>
+                              <StaleReportedTime
+                                at={node.last_heard instanceof Date ? node.last_heard : new Date(node.last_heard)}
+                                className="text-xs text-muted-foreground"
+                              />
+                            </>
+                          ) : (
+                            'Never'
+                          )}
+                        </div>
+                      </TableCell>
+                      <TableCell>
+                        <div className="flex flex-col">
+                          {level != null ? (
+                            <>
+                              <span>{level}%</span>
+                              {reportedAt ? (
+                                <>
+                                  <span className="text-xs text-muted-foreground">
+                                    {format(reportedAt, 'PPpp', { locale: enGB })}
+                                  </span>
+                                  <StaleReportedTime at={reportedAt} className="text-xs text-muted-foreground" />
+                                </>
+                              ) : null}
+                            </>
+                          ) : (
+                            '—'
+                          )}
+                        </div>
+                      </TableCell>
+                      <TableCell>
+                        <div className="flex flex-wrap gap-1">
+                          {flags.showLowBatteryBadge ? (
+                            <Badge variant="secondary" className="text-xs">
+                              Low battery
+                            </Badge>
+                          ) : null}
+                          {flags.showStaleBatteryBadge ? (
+                            <Badge variant="outline" className="text-xs">
+                              {node.latest_device_metrics?.reported_time
+                                ? `Battery reading ${STALE_BATTERY_TELEMETRY_DAYS}+ days old`
+                                : 'No battery telemetry'}
+                            </Badge>
+                          ) : null}
+                        </div>
+                      </TableCell>
+                      <TableCell>{node.owner?.username ?? '—'}</TableCell>
+                      <TableCell>
+                        <MeshWatchControls
+                          node={node}
+                          watch={watch}
+                          watchesQuery={watchesQuery}
+                          idPrefix={`infra-batt-${node.node_id}`}
+                        />
+                      </TableCell>
+                      <TableCell>
+                        <div className="flex flex-col items-start gap-1 sm:flex-row sm:items-center sm:gap-3">
+                          <Link to={`/nodes/${node.node_id}`} className="text-primary text-sm hover:underline">
+                            View details
+                          </Link>
+                          {managed != null && (
+                            <Link
+                              to={`/traceroutes/map/coverage?feeder=${node.node_id}`}
+                              className="text-muted-foreground text-sm underline-offset-4 hover:text-primary hover:underline"
+                              data-testid={`infra-batt-coverage-link-${node.node_id}`}
+                            >
+                              Coverage map
+                            </Link>
+                          )}
+                        </div>
+                      </TableCell>
+                    </TableRow>
+                  );
+                })}
+              </TableBody>
+            </Table>
+          </CardContent>
+        </Card>
+      )}
+
       <div className="space-y-4">
-        <div className="flex items-center justify-between">
+        <div className="flex flex-col gap-4 sm:flex-row sm:flex-wrap sm:items-center sm:justify-between">
           <h2 className="text-xl font-semibold">
             All Infrastructure Nodes ({sortedNodes.length}
             {totalNodes > sortedNodes.length ? ` of ${totalNodes}` : ''})
           </h2>
+          <div className="flex items-center gap-2 sm:ml-auto">
+            <label htmlFor="chart-time-range" className="text-sm text-muted-foreground whitespace-nowrap">
+              Chart time range:
+            </label>
+            <TimeRangeSelect
+              options={CHART_TIME_RANGE_OPTIONS}
+              value={chartTimeRangeLabel}
+              onChange={handleChartTimeRangeChange}
+            />
+          </div>
         </div>
         <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-6">
           {sortedNodes.map((node) => (

--- a/src/pages/nodes/MeshInfrastructure.tsx
+++ b/src/pages/nodes/MeshInfrastructure.tsx
@@ -3,7 +3,11 @@ import { Link } from 'react-router-dom';
 import { subDays, subHours, format } from 'date-fns';
 import { enGB } from 'date-fns/locale';
 import { StaleReportedTime } from '@/components/nodes/StaleReportedTime';
-import { useInfrastructureNodesSuspense, useManagedNodesSuspense } from '@/hooks/api/useNodes';
+import {
+  useAllInfrastructureNodesSuspense,
+  useInfrastructureNodesSuspense,
+  useManagedNodesSuspense,
+} from '@/hooks/api/useNodes';
 import { useNodeWatches } from '@/hooks/api/useNodeWatches';
 import { useMultiNodeMetricsSuspense } from '@/hooks/api/useMultiNodeMetrics';
 import { InfrastructureNodeCard } from '@/components/nodes/InfrastructureNodeCard';
@@ -112,6 +116,12 @@ function MeshInfrastructureContent() {
     includeClientBase,
   });
 
+  /** Full list for map + alert tables; the paged `nodes` above only includes loaded card pages. */
+  const { nodes: allInfraNodes } = useAllInfrastructureNodesSuspense({
+    lastHeardAfter,
+    includeClientBase,
+  });
+
   const watchesQuery = useNodeWatches();
   const watchesByNodeIdStr = useMemo(() => {
     const m = new Map<string, NodeWatch>();
@@ -131,10 +141,10 @@ function MeshInfrastructureContent() {
 
   const { metricsMap } = useMultiNodeMetricsSuspense(nodes, chartDateRange);
 
-  const nodesWithLocation = useMemo(() => nodes.filter(hasRecentLocation), [nodes]);
-  const nodesWithoutLocation = useMemo(() => nodes.filter((n) => !hasRecentLocation(n)), [nodes]);
+  const nodesWithLocation = useMemo(() => allInfraNodes.filter(hasRecentLocation), [allInfraNodes]);
+  const nodesWithoutLocation = useMemo(() => allInfraNodes.filter((n) => !hasRecentLocation(n)), [allInfraNodes]);
 
-  const lowBatteryNodesOrdered = useMemo(() => partitionLowBatteryNodes(nodes), [nodes]);
+  const lowBatteryNodesOrdered = useMemo(() => partitionLowBatteryNodes(allInfraNodes), [allInfraNodes]);
 
   const sortedNodes = useMemo(
     () =>


### PR DESCRIPTION
## Summary

Implements [issue #239](https://github.com/pskillen/meshtastic-bot-ui/issues/239): clearer time-range behaviour on Mesh Infrastructure, a low-battery / stale telemetry section, chart controls next to the node cards, smaller initial page size, and a cleaner map legend on this page only.

- **Node list time range:** Added **14 days**; default is **14d** so the list matches a ~two-week last-heard window. **Without recent location** title includes the count (like the main list); copy distinguishes **7-day GPS freshness** from the **selected list cutoff**.
- **Low battery:** New card + table for nodes under 50% battery, missing device metrics, or battery `reported_time` older than 3 days. Helpers live in `src/lib/infrastructure-low-battery.ts` with Vitest coverage; 0% rows are sorted last and muted.
- **Charts:** **Chart time range** moved to the top of the **All Infrastructure Nodes** block (above the card grid); removed from the global header row.
- **Paging:** Initial `useInfrastructureNodesSuspense` **pageSize** is **12**; **Load more** unchanged. Query key already includes `pageSize`.
- **Map:** `NodesAndConstellationsMap` accepts **`showRoleLegendSwatches`** (default `true`); Mesh Infrastructure passes `false` so **Other mesh nodes (by role)** is hidden while constellation legend remains.

Closes #239

## Testing performed

- `npm run lint` and `npm test` (all passing).
- New unit tests: `infrastructure-low-battery.test.ts`, `NodesAndConstellationsMap.test.tsx`.