### PR TITLE
feat(nodes): configurable battery watch alerts and monitoring UI

### DIFF
--- a/src/components/nav-main.tsx
+++ b/src/components/nav-main.tsx
@@ -28,6 +28,7 @@ import {
 } from '@/components/ui/sidebar';
 import { useWebSocket } from '@/providers/WebSocketProvider';
 import { authService } from '@/lib/auth/authService';
+import { useMeshInfraMonitoringAlertsSummary } from '@/hooks/api/useNodeWatches';
 
 type NavChild = {
   title: string;
@@ -69,7 +70,10 @@ export function NavMain() {
   const { hasUnreadMessages, unreadMessages, markAllAsRead } = useWebSocket();
   const navigate = useNavigate();
   const { pathname } = useLocation();
-  const showDxMonitoring = Boolean(authService.getCurrentUser()?.is_staff);
+  const currentUser = authService.getCurrentUser();
+  const showDxMonitoring = Boolean(currentUser?.is_staff);
+  const infraAlerts = useMeshInfraMonitoringAlertsSummary(Boolean(currentUser));
+  const infraAlertCount = infraAlerts.data?.mesh_infra.alerting_nodes_count ?? 0;
 
   const handleMessagesClick = (e: React.MouseEvent<HTMLAnchorElement>) => {
     e.preventDefault();
@@ -128,7 +132,7 @@ export function NavMain() {
                       <Icon />
                       <span>{item.title}</span>
                       {hasUnreadMessages && (
-                        <span className="absolute right-2 top-2 flex h-5 w-5 items-center justify-center rounded-full bg-red-500 p-0 text-xs text-white">
+                        <span className="absolute right-2 top-2 flex h-5 w-5 items-center justify-center rounded-full bg-red-500 p-0 text-xs text-white shadow-sm ring-2 ring-sidebar">
                           {unreadMessages.length > 9 ? '9+' : unreadMessages.length}
                         </span>
                       )}
@@ -145,12 +149,24 @@ export function NavMain() {
                     {item.children.map((child) => {
                       const ChildIcon = child.icon;
                       const childIsActive = navSubItemActive(pathname, child.url);
+                      const isMeshInfra = child.title === 'Mesh infra';
                       return (
                         <SidebarMenuSubItem key={child.title}>
                           <SidebarMenuSubButton asChild isActive={childIsActive}>
-                            <Link to={child.url}>
+                            <Link
+                              to={child.url}
+                              className={isMeshInfra && infraAlertCount > 0 ? 'relative pr-8' : undefined}
+                            >
                               <ChildIcon />
                               <span>{child.title}</span>
+                              {isMeshInfra && infraAlertCount > 0 ? (
+                                <span
+                                  className="absolute right-1 top-1.5 flex h-5 min-w-5 items-center justify-center rounded-full bg-amber-600 px-1 text-[10px] font-semibold leading-none text-white shadow-sm"
+                                  title="Mesh infrastructure monitoring alerts"
+                                >
+                                  {infraAlertCount > 99 ? '99+' : infraAlertCount}
+                                </span>
+                              ) : null}
                             </Link>
                           </SidebarMenuSubButton>
                         </SidebarMenuSubItem>

--- a/src/components/nodes/MeshWatchControls.tsx
+++ b/src/components/nodes/MeshWatchControls.tsx
@@ -32,7 +32,7 @@ export function MeshWatchControls({ node, watch, watchesQuery, idPrefix, compact
   const deleteWatch = useDeleteNodeWatchMutation();
 
   const gapClass = compact ? 'gap-1.5' : 'gap-2';
-  const maxW = compact ? 'max-w-none' : 'max-w-[200px]';
+  const maxW = compact ? 'max-w-none' : 'max-w-[240px]';
 
   if (watchesQuery.isLoading) {
     return <span className="text-muted-foreground text-sm">…</span>;
@@ -54,6 +54,9 @@ export function MeshWatchControls({ node, watch, watchesQuery, idPrefix, compact
   }
 
   if (watch) {
+    const offlineDm = watch.offline_notifications_enabled ?? true;
+    const batteryDm = watch.battery_notifications_enabled ?? false;
+
     return (
       <div className={`flex flex-col ${gapClass} ${maxW}`}>
         <div className={`flex items-center ${gapClass}`}>
@@ -71,10 +74,53 @@ export function MeshWatchControls({ node, watch, watchesQuery, idPrefix, compact
               );
             }}
           />
-          <label htmlFor={`${idPrefix}-enabled`} className="text-sm cursor-pointer">
+          <label htmlFor={`${idPrefix}-enabled`} className="text-sm cursor-pointer font-medium">
             Alerts on
           </label>
         </div>
+
+        <div className={`flex flex-col ${gapClass} pl-6 border-l border-border ml-1`}>
+          <p className="text-xs text-muted-foreground">Discord notifications (requires linked Discord)</p>
+          <div className={`flex items-center ${gapClass}`}>
+            <Checkbox
+              id={`${idPrefix}-offline-dm`}
+              checked={offlineDm}
+              disabled={patchWatch.isPending || !watch.enabled}
+              onCheckedChange={(checked) => {
+                if (checked === 'indeterminate') return;
+                patchWatch.mutate(
+                  { id: watch.id, offline_notifications_enabled: Boolean(checked) },
+                  {
+                    onError: (e) => toast.error(e instanceof Error ? e.message : 'Could not update watch'),
+                  }
+                );
+              }}
+            />
+            <label htmlFor={`${idPrefix}-offline-dm`} className="text-sm cursor-pointer">
+              Offline / verification
+            </label>
+          </div>
+          <div className={`flex items-center ${gapClass}`}>
+            <Checkbox
+              id={`${idPrefix}-battery-dm`}
+              checked={batteryDm}
+              disabled={patchWatch.isPending || !watch.enabled}
+              onCheckedChange={(checked) => {
+                if (checked === 'indeterminate') return;
+                patchWatch.mutate(
+                  { id: watch.id, battery_notifications_enabled: Boolean(checked) },
+                  {
+                    onError: (e) => toast.error(e instanceof Error ? e.message : 'Could not update watch'),
+                  }
+                );
+              }}
+            />
+            <label htmlFor={`${idPrefix}-battery-dm`} className="text-sm cursor-pointer">
+              Low battery
+            </label>
+          </div>
+        </div>
+
         <div className="flex flex-wrap gap-1">
           {watch.observed_node.monitoring_verification_started_at && (
             <Badge variant="secondary" className="text-xs">
@@ -86,6 +132,11 @@ export function MeshWatchControls({ node, watch, watchesQuery, idPrefix, compact
               Offline
             </Badge>
           )}
+          {watch.observed_node.battery_alert_active ? (
+            <Badge variant="destructive" className="text-xs">
+              Low battery (monitoring)
+            </Badge>
+          ) : null}
         </div>
         <Button
           type="button"
@@ -121,7 +172,12 @@ export function MeshWatchControls({ node, watch, watchesQuery, idPrefix, compact
       disabled={createWatch.isPending}
       onClick={() =>
         createWatch.mutate(
-          { observed_node_id: String(node.internal_id), enabled: true },
+          {
+            observed_node_id: String(node.internal_id),
+            enabled: true,
+            offline_notifications_enabled: true,
+            battery_notifications_enabled: false,
+          },
           {
             onError: (e) => toast.error(e instanceof Error ? e.message : 'Could not add watch'),
           }

--- a/src/components/nodes/NodeMeshMonitoringSection.tsx
+++ b/src/components/nodes/NodeMeshMonitoringSection.tsx
@@ -1,19 +1,20 @@
 import { useState } from 'react';
 import { MeshWatchControls } from '@/components/nodes/MeshWatchControls';
 import { NodeMeshMonitoringSettingsDialog } from '@/components/nodes/NodeMeshMonitoringSettingsDialog';
-import { useMonitoringOfflineAfter, useNodeWatches } from '@/hooks/api/useNodeWatches';
+import { useNodeMonitoringConfig, useNodeWatches } from '@/hooks/api/useNodeWatches';
 import type { ObservedNode } from '@/lib/models';
 import { authService } from '@/lib/auth/authService';
 import { Card, CardContent, CardDescription, CardHeader, CardTitle } from '@/components/ui/card';
 import { Button } from '@/components/ui/button';
 import { Loader2, Settings } from 'lucide-react';
 import { formatUptimeSeconds } from '@/lib/utils';
+import { Badge } from '@/components/ui/badge';
 
 export function NodeMeshMonitoringSection({ node }: { node: ObservedNode }) {
   const currentUser = authService.getCurrentUser();
   const watchesQuery = useNodeWatches();
   const observedUuid = String(node.internal_id);
-  const offlineAfterQuery = useMonitoringOfflineAfter(observedUuid, Boolean(currentUser));
+  const configQuery = useNodeMonitoringConfig(observedUuid, Boolean(currentUser));
   const [settingsOpen, setSettingsOpen] = useState(false);
 
   const watch = watchesQuery.data?.results.find((w) => w.observed_node.node_id_str === node.node_id_str);
@@ -22,8 +23,8 @@ export function NodeMeshMonitoringSection({ node }: { node: ObservedNode }) {
     return null;
   }
 
-  const currentSeconds = offlineAfterQuery.data?.offline_after;
-  const canEditThreshold = offlineAfterQuery.data?.editable ?? false;
+  const silenceSeconds = configQuery.data?.last_heard_offline_after_seconds;
+  const canEditConfig = configQuery.data?.editable ?? false;
 
   return (
     <div className="mb-6">
@@ -33,11 +34,11 @@ export function NodeMeshMonitoringSection({ node }: { node: ObservedNode }) {
             <div className="min-w-0 flex-1">
               <CardTitle>Mesh monitoring</CardTitle>
               <CardDescription>
-                Get alerts when this node is quiet long enough that we run a verification traceroute round, then confirm
-                offline if the mesh still cannot reach it. Discord notifications use your linked account settings.
+                Watch this node for silence / offline verification and optional low-battery episodes. Discord uses your
+                linked account; choose which notification channels apply to this watch below.
               </CardDescription>
             </div>
-            {canEditThreshold && (
+            {canEditConfig && (
               <Button
                 type="button"
                 variant="outline"
@@ -51,7 +52,7 @@ export function NodeMeshMonitoringSection({ node }: { node: ObservedNode }) {
             )}
           </div>
         </CardHeader>
-        <CardContent className="space-y-6">
+        <CardContent className="space-y-8">
           <div>
             <h3 className="text-sm font-medium text-foreground mb-2">Your watch</h3>
             <MeshWatchControls
@@ -62,23 +63,65 @@ export function NodeMeshMonitoringSection({ node }: { node: ObservedNode }) {
             />
           </div>
 
-          <div className="space-y-1">
-            <h3 className="text-sm font-medium text-foreground">Silence before verification</h3>
-            {offlineAfterQuery.isLoading && (
+          <div className="space-y-2">
+            <h3 className="text-sm font-medium text-foreground">Offline monitoring</h3>
+            <p className="text-sm text-muted-foreground">
+              When the node is quiet longer than the silence threshold, monitoring may run a verification traceroute
+              round and confirm offline if the mesh still cannot reach it.
+            </p>
+            {configQuery.isLoading && (
               <div className="flex items-center gap-2 text-muted-foreground text-sm">
                 <Loader2 className="h-4 w-4 animate-spin" aria-hidden />
                 Loading threshold…
               </div>
             )}
-            {offlineAfterQuery.isError && (
-              <p className="text-sm text-muted-foreground">Could not load silence threshold.</p>
-            )}
-            {!offlineAfterQuery.isLoading && !offlineAfterQuery.isError && currentSeconds != null && (
+            {configQuery.isError && <p className="text-sm text-muted-foreground">Could not load silence threshold.</p>}
+            {!configQuery.isLoading && !configQuery.isError && silenceSeconds != null && (
               <p className="text-sm text-muted-foreground">
                 Current silence before verification:{' '}
-                <span className="text-foreground font-medium">{formatUptimeSeconds(currentSeconds)}</span>.
-                {canEditThreshold ? ' Use the settings button above to change it.' : ''}
+                <span className="text-foreground font-medium">{formatUptimeSeconds(silenceSeconds)}</span>.
+                {canEditConfig ? ' Use the settings button above to change it.' : ''}
               </p>
+            )}
+          </div>
+
+          <div className="space-y-2">
+            <h3 className="text-sm font-medium text-foreground">Battery monitoring</h3>
+            <p className="text-sm text-muted-foreground">
+              Optional per-node rules for low-battery episodes (consecutive below-threshold telemetry). When enabled and
+              confirmed, watchers who opt into battery Discord notifications can be DM’d once per episode.
+            </p>
+            {configQuery.isLoading && (
+              <div className="flex items-center gap-2 text-muted-foreground text-sm">
+                <Loader2 className="h-4 w-4 animate-spin" aria-hidden />
+                Loading battery rules…
+              </div>
+            )}
+            {configQuery.isError && <p className="text-sm text-muted-foreground">Could not load battery settings.</p>}
+            {!configQuery.isLoading && !configQuery.isError && configQuery.data && (
+              <div className="flex flex-wrap items-center gap-2 text-sm">
+                <Badge variant={configQuery.data.battery_alert_enabled ? 'secondary' : 'outline'}>
+                  {configQuery.data.battery_alert_enabled ? 'Battery rules on' : 'Battery rules off'}
+                </Badge>
+                {configQuery.data.battery_alert_enabled ? (
+                  <>
+                    <span className="text-muted-foreground">
+                      Threshold {configQuery.data.battery_alert_threshold_percent}%, streak{' '}
+                      {configQuery.data.battery_alert_report_count} reports
+                    </span>
+                    {configQuery.data.battery_alert_active ? (
+                      <Badge variant="destructive" className="text-xs">
+                        Active alert
+                      </Badge>
+                    ) : null}
+                  </>
+                ) : null}
+                {canEditConfig ? (
+                  <span className="text-muted-foreground">— edit in settings</span>
+                ) : (
+                  <span className="text-muted-foreground">— only claim owner or staff can edit rules</span>
+                )}
+              </div>
             )}
           </div>
         </CardContent>

--- a/src/components/nodes/NodeMeshMonitoringSettingsDialog.tsx
+++ b/src/components/nodes/NodeMeshMonitoringSettingsDialog.tsx
@@ -11,7 +11,8 @@ import {
 import { Button } from '@/components/ui/button';
 import { Label } from '@/components/ui/label';
 import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from '@/components/ui/select';
-import { useMonitoringOfflineAfter, usePatchMonitoringOfflineAfterMutation } from '@/hooks/api/useNodeWatches';
+import { Checkbox } from '@/components/ui/checkbox';
+import { useNodeMonitoringConfig, usePatchNodeMonitoringConfigMutation } from '@/hooks/api/useNodeWatches';
 import { formatUptimeSeconds } from '@/lib/utils';
 import { Loader2 } from 'lucide-react';
 
@@ -23,6 +24,8 @@ const SILENCE_PRESETS: { label: string; seconds: number }[] = [
   { label: '24 hours', seconds: 86400 },
 ];
 
+const BATTERY_THRESHOLD_CHOICES = [20, 30, 40, 50, 60, 70, 80] as const;
+
 export interface NodeMeshMonitoringSettingsDialogProps {
   open: boolean;
   onOpenChange: (open: boolean) => void;
@@ -31,8 +34,8 @@ export interface NodeMeshMonitoringSettingsDialogProps {
 }
 
 /**
- * Admin-style silence threshold (NodePresence.offline_after). Parent should only open when the user can edit
- * (API `editable: true`); PATCH still enforces permissions server-side.
+ * Per-node monitoring config: silence before verification + optional battery alerting.
+ * Parent should only open when the user can edit (`editable: true`); PATCH still enforces server-side.
  */
 export function NodeMeshMonitoringSettingsDialog({
   open,
@@ -40,30 +43,51 @@ export function NodeMeshMonitoringSettingsDialog({
   observedNodeId,
   nodeId,
 }: NodeMeshMonitoringSettingsDialogProps) {
-  const offlineAfterQuery = useMonitoringOfflineAfter(observedNodeId, open);
-  const patchOfflineAfter = usePatchMonitoringOfflineAfterMutation();
+  const configQuery = useNodeMonitoringConfig(observedNodeId, open);
+  const patchConfig = usePatchNodeMonitoringConfigMutation();
   const [seconds, setSeconds] = useState(21600);
+  const [batteryEnabled, setBatteryEnabled] = useState(false);
+  const [thresholdPct, setThresholdPct] = useState(50);
+  const [reportCount, setReportCount] = useState(2);
 
   useEffect(() => {
-    if (open && offlineAfterQuery.data?.offline_after != null) {
-      setSeconds(offlineAfterQuery.data.offline_after);
+    if (open && configQuery.data) {
+      setSeconds(configQuery.data.last_heard_offline_after_seconds);
+      setBatteryEnabled(configQuery.data.battery_alert_enabled);
+      setThresholdPct(configQuery.data.battery_alert_threshold_percent);
+      setReportCount(configQuery.data.battery_alert_report_count);
     }
-  }, [open, offlineAfterQuery.data?.offline_after]);
+  }, [open, configQuery.data]);
 
   const presetValues = new Set(SILENCE_PRESETS.map((p) => p.seconds));
   const selectValue = presetValues.has(seconds) ? String(seconds) : `custom:${seconds}`;
-  const initialSeconds = offlineAfterQuery.data?.offline_after;
-  const unchanged = initialSeconds != null && seconds === initialSeconds;
+  const d = configQuery.data;
+  const unchanged =
+    d != null &&
+    seconds === d.last_heard_offline_after_seconds &&
+    batteryEnabled === d.battery_alert_enabled &&
+    thresholdPct === d.battery_alert_threshold_percent &&
+    reportCount === d.battery_alert_report_count;
 
   const handleSave = () => {
-    patchOfflineAfter.mutate(
-      { observedNodeId, offline_after: seconds, nodeId },
+    if (!d) return;
+    patchConfig.mutate(
+      {
+        observedNodeId,
+        nodeId,
+        body: {
+          last_heard_offline_after_seconds: seconds,
+          battery_alert_enabled: batteryEnabled,
+          battery_alert_threshold_percent: thresholdPct,
+          battery_alert_report_count: reportCount,
+        },
+      },
       {
         onSuccess: () => {
-          toast.success('Silence threshold saved');
+          toast.success('Monitoring settings saved');
           onOpenChange(false);
         },
-        onError: (e) => toast.error(e instanceof Error ? e.message : 'Could not save threshold'),
+        onError: (e) => toast.error(e instanceof Error ? e.message : 'Could not save settings'),
       }
     );
   };
@@ -74,23 +98,22 @@ export function NodeMeshMonitoringSettingsDialog({
         <DialogHeader>
           <DialogTitle>Mesh monitoring settings</DialogTitle>
           <DialogDescription>
-            Silence before verification: how long the node can go without packets (last heard) before monitoring may
-            start a verification traceroute round. Claim owners and staff can change this value.
+            Silence before verification (how long without packets before a verification round may start) and optional
+            low-battery alerting (consecutive below-threshold telemetry reports). Claim owners and staff can edit these
+            values.
           </DialogDescription>
         </DialogHeader>
-        {offlineAfterQuery.isLoading && (
+        {configQuery.isLoading && (
           <div className="flex items-center gap-2 py-6 text-muted-foreground text-sm">
             <Loader2 className="h-4 w-4 animate-spin" aria-hidden />
             Loading…
           </div>
         )}
-        {offlineAfterQuery.isError && (
-          <p className="text-sm text-destructive py-4">Could not load monitoring settings.</p>
-        )}
-        {!offlineAfterQuery.isLoading && !offlineAfterQuery.isError && offlineAfterQuery.data?.editable && (
-          <div className="grid gap-4 py-2">
+        {configQuery.isError && <p className="text-sm text-destructive py-4">Could not load monitoring settings.</p>}
+        {!configQuery.isLoading && !configQuery.isError && configQuery.data?.editable && (
+          <div className="grid gap-5 py-2">
             <div className="grid gap-2">
-              <Label htmlFor="mesh-offline-after-trigger">Silence before verification</Label>
+              <Label htmlFor="mesh-silence-select">Silence before verification</Label>
               <Select
                 value={selectValue}
                 onValueChange={(v) => {
@@ -98,7 +121,7 @@ export function NodeMeshMonitoringSettingsDialog({
                   if (Number.isFinite(sec) && sec >= 1) setSeconds(sec);
                 }}
               >
-                <SelectTrigger id="mesh-offline-after-trigger">
+                <SelectTrigger id="mesh-silence-select">
                   <SelectValue />
                 </SelectTrigger>
                 <SelectContent>
@@ -113,15 +136,73 @@ export function NodeMeshMonitoringSettingsDialog({
                 </SelectContent>
               </Select>
             </div>
+
+            <div className="rounded-md border p-3 space-y-3">
+              <div className="flex items-center gap-2">
+                <Checkbox
+                  id="mesh-battery-enabled"
+                  checked={batteryEnabled}
+                  onCheckedChange={(c) => {
+                    if (c === 'indeterminate') return;
+                    setBatteryEnabled(Boolean(c));
+                  }}
+                />
+                <label htmlFor="mesh-battery-enabled" className="text-sm font-medium cursor-pointer">
+                  Battery alerting enabled
+                </label>
+              </div>
+              <p className="text-xs text-muted-foreground">
+                When enabled, consecutive device-metric reports below the threshold confirm a low-battery episode (for
+                Discord notifications to watchers who opt in).
+              </p>
+              <div className="grid gap-2">
+                <Label htmlFor="mesh-battery-threshold">Battery threshold (%)</Label>
+                <Select
+                  value={String(thresholdPct)}
+                  onValueChange={(v) => setThresholdPct(parseInt(v, 10))}
+                  disabled={!batteryEnabled}
+                >
+                  <SelectTrigger id="mesh-battery-threshold">
+                    <SelectValue />
+                  </SelectTrigger>
+                  <SelectContent>
+                    {BATTERY_THRESHOLD_CHOICES.map((t) => (
+                      <SelectItem key={t} value={String(t)}>
+                        {t}%
+                      </SelectItem>
+                    ))}
+                  </SelectContent>
+                </Select>
+              </div>
+              <div className="grid gap-2">
+                <Label htmlFor="mesh-battery-streak">Consecutive reports to confirm</Label>
+                <Select
+                  value={String(reportCount)}
+                  onValueChange={(v) => setReportCount(parseInt(v, 10))}
+                  disabled={!batteryEnabled}
+                >
+                  <SelectTrigger id="mesh-battery-streak">
+                    <SelectValue />
+                  </SelectTrigger>
+                  <SelectContent>
+                    {Array.from({ length: 10 }, (_, i) => i + 1).map((n) => (
+                      <SelectItem key={n} value={String(n)}>
+                        {n}
+                      </SelectItem>
+                    ))}
+                  </SelectContent>
+                </Select>
+              </div>
+            </div>
           </div>
         )}
         <DialogFooter>
           <Button type="button" variant="outline" onClick={() => onOpenChange(false)}>
             Cancel
           </Button>
-          {offlineAfterQuery.data?.editable && (
-            <Button type="button" onClick={handleSave} disabled={patchOfflineAfter.isPending || unchanged}>
-              {patchOfflineAfter.isPending ? 'Saving…' : 'Save'}
+          {configQuery.data?.editable && (
+            <Button type="button" onClick={handleSave} disabled={patchConfig.isPending || unchanged}>
+              {patchConfig.isPending ? 'Saving…' : 'Save'}
             </Button>
           )}
         </DialogFooter>

--- a/src/components/nodes/WatchDashboardSummary.test.tsx
+++ b/src/components/nodes/WatchDashboardSummary.test.tsx
@@ -27,6 +27,8 @@ function makeWatch(id: number, node: Partial<ObservedNode>): NodeWatch {
     observed_node: makeNode({ internal_id: id, node_id: 50 + id, ...node }) as NodeWatch['observed_node'],
     offline_after: 3600,
     enabled: true,
+    offline_notifications_enabled: true,
+    battery_notifications_enabled: false,
     created_at: '2026-04-21T00:00:00Z',
   };
 }

--- a/src/components/nodes/WatchDashboardSummary.tsx
+++ b/src/components/nodes/WatchDashboardSummary.tsx
@@ -7,7 +7,7 @@ import {
   type WatchMonitoringStatus,
 } from '@/lib/watch-monitoring-status';
 
-const SUMMARY_ORDER: WatchMonitoringStatus[] = ['offline', 'verifying', 'unknown', 'online'];
+const SUMMARY_ORDER: WatchMonitoringStatus[] = ['offline', 'verifying', 'battery_low', 'unknown', 'online'];
 
 export interface WatchDashboardSummaryProps {
   watches: NodeWatch[];
@@ -18,7 +18,7 @@ export interface WatchDashboardSummaryProps {
 export function WatchDashboardSummary({ watches, counts, onJumpToWatch }: WatchDashboardSummaryProps) {
   return (
     <div className="bg-background rounded-lg border p-4 space-y-4">
-      <div className="grid grid-cols-2 sm:grid-cols-4 gap-3">
+      <div className="grid grid-cols-2 sm:grid-cols-3 md:grid-cols-5 gap-3">
         {SUMMARY_ORDER.map((s) => (
           <div key={s} className="rounded-md border bg-card/50 p-3 text-center">
             <div className="text-2xl font-semibold tabular-nums">{counts[s]}</div>
@@ -43,7 +43,13 @@ export function WatchDashboardSummary({ watches, counts, onJumpToWatch }: WatchD
                 <span className="flex flex-col items-start gap-0.5 min-w-0">
                   <span className="font-medium truncate w-full">{n.short_name || n.node_id_str}</span>
                   <span className="text-xs text-muted-foreground font-mono">{n.node_id_str}</span>
-                  <span className={cn('text-xs', st === 'offline' && 'text-destructive font-medium')}>
+                  <span
+                    className={cn(
+                      'text-xs',
+                      st === 'offline' && 'text-destructive font-medium',
+                      st === 'battery_low' && 'text-amber-700 dark:text-amber-400 font-medium'
+                    )}
+                  >
                     {WATCH_STATUS_LABEL[st]}
                   </span>
                 </span>

--- a/src/components/nodes/WatchedNodesTable.test.tsx
+++ b/src/components/nodes/WatchedNodesTable.test.tsx
@@ -54,6 +54,8 @@ function makeWatch(overrides: Partial<NodeWatch> & { node?: Partial<ObservedNode
     observed_node: node as NodeWatch['observed_node'],
     offline_after: rest.offline_after ?? 3600,
     enabled: rest.enabled ?? true,
+    offline_notifications_enabled: rest.offline_notifications_enabled ?? true,
+    battery_notifications_enabled: rest.battery_notifications_enabled ?? false,
     created_at: rest.created_at ?? '2026-04-21T00:00:00Z',
   };
 }

--- a/src/components/nodes/WatchedNodesTable.tsx
+++ b/src/components/nodes/WatchedNodesTable.tsx
@@ -26,7 +26,7 @@ import {
 
 const LATEST_TRACEROUTES = 5;
 
-const GROUP_ORDER: WatchMonitoringStatus[] = ['offline', 'verifying', 'unknown', 'online'];
+const GROUP_ORDER: WatchMonitoringStatus[] = ['offline', 'verifying', 'battery_low', 'unknown', 'online'];
 
 function toDate(value: Date | string | null | undefined): Date | null {
   if (value == null) return null;
@@ -180,6 +180,7 @@ function BatteryBlock({ node }: { node: ObservedNode }) {
 function statusBadgeVariant(status: WatchMonitoringStatus): 'default' | 'secondary' | 'destructive' | 'outline' {
   if (status === 'offline') return 'destructive';
   if (status === 'verifying') return 'secondary';
+  if (status === 'battery_low') return 'secondary';
   if (status === 'online') return 'default';
   return 'outline';
 }

--- a/src/hooks/api/useNodeWatches.ts
+++ b/src/hooks/api/useNodeWatches.ts
@@ -1,11 +1,19 @@
 import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query';
 import { useMeshtasticApi } from './useApi';
-import type { MonitoringOfflineAfterResponse, NodeWatch, PaginatedResponse } from '@/lib/models';
+import type {
+  MeshInfraMonitoringAlertSummary,
+  NodeMonitoringConfig,
+  NodeMonitoringConfigPatch,
+  NodeWatch,
+  PaginatedResponse,
+} from '@/lib/models';
 
 const watchesKey = ['monitoring', 'watches'] as const;
 
-export const monitoringOfflineAfterQueryKey = (observedNodeId: string) =>
-  ['monitoring', 'offline-after', observedNodeId] as const;
+const meshInfraAlertsSummaryKey = ['monitoring', 'alerts-summary', 'mesh_infra'] as const;
+
+export const nodeMonitoringConfigQueryKey = (observedNodeId: string) =>
+  ['monitoring', 'config', observedNodeId] as const;
 
 function mergeWatchIntoWatchesCache(
   old: PaginatedResponse<NodeWatch> | undefined,
@@ -47,33 +55,38 @@ export function useNodeWatches(pageSize = 500) {
   });
 }
 
-export function useMonitoringOfflineAfter(observedNodeId: string | undefined, enabled = true) {
+export function useMeshInfraMonitoringAlertsSummary(enabled = true) {
   const api = useMeshtasticApi();
-  return useQuery<MonitoringOfflineAfterResponse>({
-    queryKey: monitoringOfflineAfterQueryKey(observedNodeId ?? ''),
-    queryFn: () => api.getMonitoringOfflineAfter(observedNodeId!),
+  return useQuery<{ mesh_infra: MeshInfraMonitoringAlertSummary }>({
+    queryKey: meshInfraAlertsSummaryKey,
+    queryFn: () => api.getMeshInfraMonitoringAlertsSummary(),
+    enabled,
+    staleTime: 60_000,
+    refetchInterval: 120_000,
+  });
+}
+
+export function useNodeMonitoringConfig(observedNodeId: string | undefined, enabled = true) {
+  const api = useMeshtasticApi();
+  return useQuery<NodeMonitoringConfig>({
+    queryKey: nodeMonitoringConfigQueryKey(observedNodeId ?? ''),
+    queryFn: () => api.getNodeMonitoringConfig(observedNodeId!),
     enabled: Boolean(enabled && observedNodeId),
   });
 }
 
-export function usePatchMonitoringOfflineAfterMutation() {
+export function usePatchNodeMonitoringConfigMutation() {
   const api = useMeshtasticApi();
   const queryClient = useQueryClient();
   return useMutation({
-    mutationFn: ({
-      observedNodeId,
-      offline_after,
-    }: {
-      observedNodeId: string;
-      offline_after: number;
-      /** When set, invalidates single-node detail cache after threshold change. */
-      nodeId?: number;
-    }) => api.patchMonitoringOfflineAfter(observedNodeId, { offline_after }),
-    onSuccess: (data, variables) => {
-      queryClient.setQueryData(monitoringOfflineAfterQueryKey(variables.observedNodeId), data);
+    mutationFn: (variables: { observedNodeId: string; body: NodeMonitoringConfigPatch; nodeId?: number }) =>
+      api.patchNodeMonitoringConfig(variables.observedNodeId, variables.body),
+    onSuccess: (data, { observedNodeId, nodeId }) => {
+      queryClient.setQueryData(nodeMonitoringConfigQueryKey(observedNodeId), data);
       queryClient.invalidateQueries({ queryKey: watchesKey });
-      if (variables.nodeId != null) {
-        queryClient.invalidateQueries({ queryKey: ['nodes', variables.nodeId] });
+      queryClient.invalidateQueries({ queryKey: meshInfraAlertsSummaryKey });
+      if (nodeId != null) {
+        queryClient.invalidateQueries({ queryKey: ['nodes', nodeId] });
       }
     },
   });
@@ -83,13 +96,19 @@ export function useCreateNodeWatchMutation() {
   const api = useMeshtasticApi();
   const queryClient = useQueryClient();
   return useMutation({
-    mutationFn: (body: { observed_node_id: string; enabled?: boolean }) => api.createNodeWatch(body),
+    mutationFn: (body: {
+      observed_node_id: string;
+      enabled?: boolean;
+      offline_notifications_enabled?: boolean;
+      battery_notifications_enabled?: boolean;
+    }) => api.createNodeWatch(body),
     onSuccess: (newWatch) => {
       queryClient.setQueriesData<PaginatedResponse<NodeWatch>>({ queryKey: watchesKey }, (old) =>
         mergeWatchIntoWatchesCache(old, newWatch)
       );
       queryClient.invalidateQueries({ queryKey: watchesKey });
       queryClient.invalidateQueries({ queryKey: ['observed-nodes', 'mine'] });
+      queryClient.invalidateQueries({ queryKey: meshInfraAlertsSummaryKey });
     },
   });
 }
@@ -98,13 +117,22 @@ export function usePatchNodeWatchMutation() {
   const api = useMeshtasticApi();
   const queryClient = useQueryClient();
   return useMutation({
-    mutationFn: ({ id, ...body }: { id: number; enabled?: boolean }) => api.patchNodeWatch(id, body),
+    mutationFn: ({
+      id,
+      ...body
+    }: {
+      id: number;
+      enabled?: boolean;
+      offline_notifications_enabled?: boolean;
+      battery_notifications_enabled?: boolean;
+    }) => api.patchNodeWatch(id, body),
     onSuccess: (updated) => {
       queryClient.setQueriesData<PaginatedResponse<NodeWatch>>({ queryKey: watchesKey }, (old) =>
         mergeWatchIntoWatchesCache(old, updated)
       );
       queryClient.invalidateQueries({ queryKey: watchesKey });
       queryClient.invalidateQueries({ queryKey: ['observed-nodes', 'mine'] });
+      queryClient.invalidateQueries({ queryKey: meshInfraAlertsSummaryKey });
     },
   });
 }
@@ -120,6 +148,7 @@ export function useDeleteNodeWatchMutation() {
       );
       queryClient.invalidateQueries({ queryKey: watchesKey });
       queryClient.invalidateQueries({ queryKey: ['observed-nodes', 'mine'] });
+      queryClient.invalidateQueries({ queryKey: meshInfraAlertsSummaryKey });
     },
   });
 }

--- a/src/lib/api/api-utils.ts
+++ b/src/lib/api/api-utils.ts
@@ -37,6 +37,10 @@ export function parseObservedNodeFromAPI(node: ObservedNode): ObservedNode {
             : null,
         }
       : null,
+    battery_alert_confirmed_at:
+      node.battery_alert_confirmed_at == null
+        ? (node.battery_alert_confirmed_at as null | undefined)
+        : new Date(node.battery_alert_confirmed_at as string | Date),
   };
 }
 

--- a/src/lib/api/meshtastic-api.ts
+++ b/src/lib/api/meshtastic-api.ts
@@ -23,7 +23,9 @@ import {
   AutoTraceRoute,
   DiscordNotificationPrefs,
   NodeWatch,
-  MonitoringOfflineAfterResponse,
+  NodeMonitoringConfig,
+  NodeMonitoringConfigPatch,
+  MeshInfraMonitoringAlertSummary,
   DxEventListItem,
   DxEventDetail,
   DxNodeExclusionResponse,
@@ -1041,12 +1043,24 @@ export class MeshtasticApi extends BaseApi {
     };
   }
 
-  async createNodeWatch(body: { observed_node_id: string; enabled?: boolean }): Promise<NodeWatch> {
+  async createNodeWatch(body: {
+    observed_node_id: string;
+    enabled?: boolean;
+    offline_notifications_enabled?: boolean;
+    battery_notifications_enabled?: boolean;
+  }): Promise<NodeWatch> {
     const watch = await this.post<NodeWatch>('/monitoring/watches/', body);
     return parseNodeWatchFromAPI(watch);
   }
 
-  async patchNodeWatch(id: number, body: { enabled?: boolean }): Promise<NodeWatch> {
+  async patchNodeWatch(
+    id: number,
+    body: {
+      enabled?: boolean;
+      offline_notifications_enabled?: boolean;
+      battery_notifications_enabled?: boolean;
+    }
+  ): Promise<NodeWatch> {
     const watch = await this.patch<NodeWatch>(`/monitoring/watches/${id}/`, body);
     return parseNodeWatchFromAPI(watch);
   }
@@ -1055,15 +1069,19 @@ export class MeshtasticApi extends BaseApi {
     await this.delete<unknown>(`/monitoring/watches/${id}/`);
   }
 
-  async getMonitoringOfflineAfter(observedNodeId: string): Promise<MonitoringOfflineAfterResponse> {
-    return this.get<MonitoringOfflineAfterResponse>(`/monitoring/nodes/${observedNodeId}/offline-after/`);
+  async getNodeMonitoringConfig(observedNodeId: string): Promise<NodeMonitoringConfig> {
+    return this.get<NodeMonitoringConfig>(`/monitoring/nodes/${observedNodeId}/config/`);
   }
 
-  async patchMonitoringOfflineAfter(
+  async patchNodeMonitoringConfig(
     observedNodeId: string,
-    body: { offline_after: number }
-  ): Promise<MonitoringOfflineAfterResponse> {
-    return this.patch<MonitoringOfflineAfterResponse>(`/monitoring/nodes/${observedNodeId}/offline-after/`, body);
+    body: NodeMonitoringConfigPatch
+  ): Promise<NodeMonitoringConfig> {
+    return this.patch<NodeMonitoringConfig>(`/monitoring/nodes/${observedNodeId}/config/`, body);
+  }
+
+  async getMeshInfraMonitoringAlertsSummary(): Promise<{ mesh_infra: MeshInfraMonitoringAlertSummary }> {
+    return this.get<{ mesh_infra: MeshInfraMonitoringAlertSummary }>('/monitoring/alerts/summary/?scope=mesh_infra');
   }
 
   // ===== DX monitoring (staff-only) =====

--- a/src/lib/infrastructure-low-battery.test.ts
+++ b/src/lib/infrastructure-low-battery.test.ts
@@ -1,169 +1,58 @@
-import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { describe, it, expect } from 'vitest';
 import type { ObservedNode } from '@/lib/models';
-import {
-  getBatteryMetricsReportedAt,
-  getLowBatteryRowFlags,
-  isBatteryTelemetryStale,
-  LOW_BATTERY_THRESHOLD_PERCENT,
-  partitionLowBatteryNodes,
-  qualifiesLowBatterySection,
-} from './infrastructure-low-battery';
+import { partitionMeshInfraLowBatteryTableNodes, partitionLowBatteryNodes } from './infrastructure-low-battery';
 
-function baseNode(overrides: Partial<ObservedNode> = {}): ObservedNode {
+function node(partial: Partial<ObservedNode>): ObservedNode {
   return {
     internal_id: 1,
-    node_id: 100,
-    node_id_str: '!00000064',
+    node_id: 1,
+    node_id_str: '!00000001',
     mac_addr: null,
-    long_name: 'Test',
-    short_name: 'T',
+    long_name: 'A',
+    short_name: 'A',
     hw_model: null,
     public_key: null,
-    last_heard: new Date('2026-01-15T12:00:00Z'),
-    ...overrides,
+    last_heard: new Date(),
+    latest_position: null,
+    latest_device_metrics: null,
+    latest_environment_metrics: null,
+    latest_power_metrics: null,
+    ...partial,
   } as ObservedNode;
 }
 
-describe('infrastructure-low-battery', () => {
-  beforeEach(() => {
-    vi.useFakeTimers();
-    vi.setSystemTime(new Date('2026-01-15T12:00:00Z'));
-  });
-
-  afterEach(() => {
-    vi.useRealTimers();
-  });
-
-  it('getBatteryMetricsReportedAt returns null without metrics', () => {
-    expect(getBatteryMetricsReportedAt(baseNode())).toBeNull();
-  });
-
-  it('qualifiesLowBatterySection when metrics missing', () => {
-    expect(qualifiesLowBatterySection(baseNode())).toBe(true);
-  });
-
-  it('qualifies when battery below threshold with fresh telemetry', () => {
-    const n = baseNode({
+describe('partitionMeshInfraLowBatteryTableNodes', () => {
+  it('includes nodes with battery_alert_active even when not in heuristic low-battery list', () => {
+    const okBattery = node({
+      node_id: 1,
       latest_device_metrics: {
-        reported_time: new Date('2026-01-14T12:00:00Z'),
+        battery_level: 90,
+        reported_time: new Date(),
         logged_time: null,
-        battery_level: 40,
-        voltage: 3.5,
-        channel_utilization: 0,
-        air_util_tx: 0,
-        uptime_seconds: 0,
-      },
+      } as ObservedNode['latest_device_metrics'],
+      battery_alert_active: false,
     });
-    expect(qualifiesLowBatterySection(n)).toBe(true);
-    expect(isBatteryTelemetryStale(n)).toBe(false);
-  });
-
-  it('qualifies when telemetry is stale (>3 days) even if battery reads high', () => {
-    const n = baseNode({
+    const alertOnly = node({
+      node_id: 2,
       latest_device_metrics: {
-        reported_time: new Date('2026-01-10T12:00:00Z'),
+        battery_level: 90,
+        reported_time: new Date(),
         logged_time: null,
-        battery_level: 99,
-        voltage: 4,
-        channel_utilization: 0,
-        air_util_tx: 0,
-        uptime_seconds: 0,
-      },
+      } as ObservedNode['latest_device_metrics'],
+      battery_alert_active: true,
     });
-    expect(qualifiesLowBatterySection(n)).toBe(true);
-    expect(isBatteryTelemetryStale(n)).toBe(true);
-  });
-
-  it('does not qualify when fresh telemetry and battery healthy', () => {
-    const n = baseNode({
+    const low = node({
+      node_id: 3,
       latest_device_metrics: {
-        reported_time: new Date('2026-01-14T12:00:00Z'),
+        battery_level: 10,
+        reported_time: new Date(),
         logged_time: null,
-        battery_level: LOW_BATTERY_THRESHOLD_PERCENT,
-        voltage: 4,
-        channel_utilization: 0,
-        air_util_tx: 0,
-        uptime_seconds: 0,
-      },
+      } as ObservedNode['latest_device_metrics'],
     });
-    expect(qualifiesLowBatterySection(n)).toBe(false);
-  });
-
-  it('partitionLowBatteryNodes dedupes by node_id and puts 0% last', () => {
-    const dup = baseNode({
-      node_id: 200,
-      internal_id: 2,
-      latest_device_metrics: {
-        reported_time: new Date('2026-01-14T12:00:00Z'),
-        logged_time: null,
-        battery_level: 0,
-        voltage: 0,
-        channel_utilization: 0,
-        air_util_tx: 0,
-        uptime_seconds: 0,
-      },
-    });
-    const lowFresh = baseNode({
-      node_id: 201,
-      internal_id: 3,
-      last_heard: new Date('2026-01-15T10:00:00Z'),
-      latest_device_metrics: {
-        reported_time: new Date('2026-01-14T12:00:00Z'),
-        logged_time: null,
-        battery_level: 30,
-        voltage: 3.4,
-        channel_utilization: 0,
-        air_util_tx: 0,
-        uptime_seconds: 0,
-      },
-    });
-    const out = partitionLowBatteryNodes([dup, dup, lowFresh]);
-    expect(out.map((n) => n.node_id)).toEqual([201, 200]);
-  });
-
-  it('getLowBatteryRowFlags shows both badges when low and stale', () => {
-    const n = baseNode({
-      latest_device_metrics: {
-        reported_time: new Date('2026-01-10T12:00:00Z'),
-        logged_time: null,
-        battery_level: 20,
-        voltage: 3.2,
-        channel_utilization: 0,
-        air_util_tx: 0,
-        uptime_seconds: 0,
-      },
-    });
-    const f = getLowBatteryRowFlags(n);
-    expect(f.showLowBatteryBadge).toBe(true);
-    expect(f.showStaleBatteryBadge).toBe(true);
-    expect(f.isZeroPercent).toBe(false);
-  });
-
-  it('stale threshold uses STALE_BATTERY_TELEMETRY_DAYS boundary', () => {
-    const freshEdge = baseNode({
-      latest_device_metrics: {
-        reported_time: new Date('2026-01-12T12:00:01Z'),
-        logged_time: null,
-        battery_level: 99,
-        voltage: 4,
-        channel_utilization: 0,
-        air_util_tx: 0,
-        uptime_seconds: 0,
-      },
-    });
-    expect(isBatteryTelemetryStale(freshEdge)).toBe(false);
-
-    const staleEdge = baseNode({
-      latest_device_metrics: {
-        reported_time: new Date('2026-01-12T11:59:59Z'),
-        logged_time: null,
-        battery_level: 99,
-        voltage: 4,
-        channel_utilization: 0,
-        air_util_tx: 0,
-        uptime_seconds: 0,
-      },
-    });
-    expect(isBatteryTelemetryStale(staleEdge)).toBe(true);
+    const out = partitionMeshInfraLowBatteryTableNodes([okBattery, alertOnly, low]);
+    expect(out.map((n) => n.node_id)).toContain(2);
+    expect(out.map((n) => n.node_id)).toContain(3);
+    expect(out[0].node_id).toBe(2);
+    expect(partitionLowBatteryNodes([okBattery, alertOnly, low]).some((n) => n.node_id === 2)).toBe(false);
   });
 });

--- a/src/lib/infrastructure-low-battery.ts
+++ b/src/lib/infrastructure-low-battery.ts
@@ -52,6 +52,22 @@ function lastHeardTime(node: ObservedNode): number {
 }
 
 /**
+ * Infrastructure “low battery” table: heuristic low/stale rows **plus** nodes with an active mesh
+ * monitoring battery alert from the API (`battery_alert_active`), even when telemetry looks fine.
+ */
+export function partitionMeshInfraLowBatteryTableNodes(nodes: ObservedNode[], now: Date = new Date()): ObservedNode[] {
+  const base = partitionLowBatteryNodes(nodes, now);
+  const inBase = new Set(base.map((n) => n.node_id));
+  const additions: ObservedNode[] = [];
+  for (const n of nodes) {
+    if (inBase.has(n.node_id)) continue;
+    if (n.battery_alert_active) additions.push(n);
+  }
+  additions.sort((a, b) => lastHeardTime(b) - lastHeardTime(a));
+  return [...additions, ...base];
+}
+
+/**
  * Deduplicates by node id, partitions 0% rows to the bottom, sorts by most recently heard within each group.
  */
 export function partitionLowBatteryNodes(nodes: ObservedNode[], now: Date = new Date()): ObservedNode[] {

--- a/src/lib/models.ts
+++ b/src/lib/models.ts
@@ -101,6 +101,9 @@ export interface ObservedNode {
   rf_profile_editable?: boolean;
   has_rf_profile?: boolean;
   has_ready_rf_render?: boolean;
+  /** True when battery alerting is enabled and a low-battery episode is confirmed (mesh monitoring). */
+  battery_alert_active?: boolean;
+  battery_alert_confirmed_at?: Date | string | null;
   // Additional fields for UI compatibility
   last_heard?: Date | null;
   latest_device_metrics?: DeviceMetrics | null;
@@ -599,16 +602,39 @@ export const DX_NOTIFICATION_CATEGORY_META: Record<
  * plus mesh monitoring hints (`GET /api/monitoring/watches/`).
  */
 export type ObservedNodeWatchSummary = ObservedNode & {
-  /** Node-level silence threshold (seconds); duplicated from NodePresence for convenience. */
+  /** Node-level silence threshold (seconds); alias for `last_heard_offline_after_seconds` on config. */
   offline_after?: number;
   monitoring_verification_started_at?: string | null;
   monitoring_offline_confirmed_at?: string | null;
 };
 
-/** GET/PATCH `/api/monitoring/nodes/{internal_id}/offline-after/` */
-export interface MonitoringOfflineAfterResponse {
-  offline_after: number;
+/** GET/PATCH `/api/monitoring/nodes/{internal_id}/config/` */
+export interface NodeMonitoringConfig {
+  last_heard_offline_after_seconds: number;
+  battery_alert_enabled: boolean;
+  battery_alert_threshold_percent: number;
+  battery_alert_report_count: number;
   editable: boolean;
+  battery_alert_active: boolean;
+  battery_alert_confirmed_at: string | null;
+}
+
+export type NodeMonitoringConfigPatch = Partial<
+  Pick<
+    NodeMonitoringConfig,
+    | 'last_heard_offline_after_seconds'
+    | 'battery_alert_enabled'
+    | 'battery_alert_threshold_percent'
+    | 'battery_alert_report_count'
+  >
+>;
+
+/** GET `/api/monitoring/alerts/summary/?scope=mesh_infra` */
+export interface MeshInfraMonitoringAlertSummary {
+  alerting_nodes_count: number;
+  offline_count: number;
+  battery_count: number;
+  verifying_count: number;
 }
 
 /** User watch on an observed node (`GET/POST /monitoring/watches/`). */
@@ -617,6 +643,8 @@ export interface NodeWatch {
   observed_node: ObservedNodeWatchSummary;
   offline_after: number;
   enabled: boolean;
+  offline_notifications_enabled: boolean;
+  battery_notifications_enabled: boolean;
   created_at: string;
 }
 

--- a/src/lib/watch-monitoring-status.test.ts
+++ b/src/lib/watch-monitoring-status.test.ts
@@ -34,6 +34,8 @@ function makeWatch(overrides: {
     observed_node: node,
     offline_after: 3600,
     enabled: true,
+    offline_notifications_enabled: true,
+    battery_notifications_enabled: false,
     created_at: '2026-01-01T00:00:00Z',
     ...overrides.watch,
   };
@@ -60,6 +62,19 @@ describe('deriveWatchMonitoringStatus', () => {
       },
     });
     expect(deriveWatchMonitoringStatus(w, now)).toBe('verifying');
+  });
+
+  it('returns battery_low when battery_alert_active and not verifying/offline', () => {
+    const w = makeWatch({
+      node: {
+        battery_alert_active: true,
+        monitoring_verification_started_at: null,
+        monitoring_offline_confirmed_at: null,
+        last_heard: new Date('2026-01-01T12:30:00.000Z'),
+      },
+      watch: { offline_after: 7200 },
+    });
+    expect(deriveWatchMonitoringStatus(w, now)).toBe('battery_low');
   });
 
   it('returns online when last_heard is within offline_after', () => {
@@ -132,6 +147,7 @@ describe('countWatchesByMonitoringStatus', () => {
     expect(countWatchesByMonitoringStatus(watches, now)).toEqual({
       offline: 1,
       verifying: 0,
+      battery_low: 0,
       unknown: 0,
       online: 1,
     });

--- a/src/lib/watch-monitoring-status.ts
+++ b/src/lib/watch-monitoring-status.ts
@@ -1,19 +1,21 @@
 import type { NodeWatch } from '@/lib/models';
 
 /** Mesh monitoring status for a watched node (UI + map + sorting). */
-export type WatchMonitoringStatus = 'offline' | 'verifying' | 'unknown' | 'online';
+export type WatchMonitoringStatus = 'offline' | 'verifying' | 'battery_low' | 'unknown' | 'online';
 
 /** Sort rank: lower = show first. */
 export const WATCH_STATUS_SORT_RANK: Record<WatchMonitoringStatus, number> = {
   offline: 0,
   verifying: 1,
-  unknown: 2,
-  online: 3,
+  battery_low: 2,
+  unknown: 3,
+  online: 4,
 };
 
 export const WATCH_STATUS_MAP_COLOR: Record<WatchMonitoringStatus, string> = {
   offline: '#dc2626',
   verifying: '#d97706',
+  battery_low: '#b45309',
   unknown: '#64748b',
   online: '#16a34a',
 };
@@ -21,6 +23,7 @@ export const WATCH_STATUS_MAP_COLOR: Record<WatchMonitoringStatus, string> = {
 export const WATCH_STATUS_LABEL: Record<WatchMonitoringStatus, string> = {
   offline: 'Offline',
   verifying: 'Verifying',
+  battery_low: 'Low battery',
   unknown: 'Unknown / stale',
   online: 'Online',
 };
@@ -35,7 +38,7 @@ function toTimeMs(value: Date | string | null | undefined): number | null {
 /**
  * Derive monitoring status for a watch using API hints and last_heard vs silence threshold.
  *
- * Precedence: offline confirmed > verifying > online (heard within threshold) > unknown.
+ * Precedence: offline confirmed > verifying > active battery alert > online (heard within threshold) > unknown.
  */
 export function deriveWatchMonitoringStatus(watch: NodeWatch, nowMs: number = Date.now()): WatchMonitoringStatus {
   const n = watch.observed_node;
@@ -44,6 +47,9 @@ export function deriveWatchMonitoringStatus(watch: NodeWatch, nowMs: number = Da
   }
   if (n.monitoring_verification_started_at) {
     return 'verifying';
+  }
+  if (n.battery_alert_active) {
+    return 'battery_low';
   }
 
   const offlineAfterSec = watch.offline_after ?? n.offline_after;
@@ -94,6 +100,7 @@ export function countWatchesByMonitoringStatus(
   const counts: Record<WatchMonitoringStatus, number> = {
     offline: 0,
     verifying: 0,
+    battery_low: 0,
     unknown: 0,
     online: 0,
   };

--- a/src/pages/nodes/MeshInfrastructure.tsx
+++ b/src/pages/nodes/MeshInfrastructure.tsx
@@ -30,7 +30,7 @@ import {
   getBatteryMetricsReportedAt,
   getLowBatteryRowFlags,
   LOW_BATTERY_THRESHOLD_PERCENT,
-  partitionLowBatteryNodes,
+  partitionMeshInfraLowBatteryTableNodes,
   STALE_BATTERY_TELEMETRY_DAYS,
 } from '@/lib/infrastructure-low-battery';
 
@@ -144,7 +144,7 @@ function MeshInfrastructureContent() {
   const nodesWithLocation = useMemo(() => allInfraNodes.filter(hasRecentLocation), [allInfraNodes]);
   const nodesWithoutLocation = useMemo(() => allInfraNodes.filter((n) => !hasRecentLocation(n)), [allInfraNodes]);
 
-  const lowBatteryNodesOrdered = useMemo(() => partitionLowBatteryNodes(allInfraNodes), [allInfraNodes]);
+  const lowBatteryNodesOrdered = useMemo(() => partitionMeshInfraLowBatteryTableNodes(allInfraNodes), [allInfraNodes]);
 
   const sortedNodes = useMemo(
     () =>
@@ -361,9 +361,10 @@ function MeshInfrastructureContent() {
               Low battery nodes ({lowBatteryNodesOrdered.length})
             </CardTitle>
             <CardDescription>
-              Includes nodes below {LOW_BATTERY_THRESHOLD_PERCENT}% battery, no battery telemetry, or a reading older
-              than {STALE_BATTERY_TELEMETRY_DAYS} days. Last heard can still be recent while metrics are missing or
-              stale—that is not always a problem. Rows showing 0% are often bogus telemetry and are listed last.
+              Includes nodes below {LOW_BATTERY_THRESHOLD_PERCENT}% battery, no battery telemetry, a reading older than{' '}
+              {STALE_BATTERY_TELEMETRY_DAYS} days, or an active mesh monitoring low-battery alert. Last heard can still
+              be recent while metrics are missing or stale—that is not always a problem. Rows showing 0% are often bogus
+              telemetry and are listed last.
             </CardDescription>
           </CardHeader>
           <CardContent>
@@ -464,6 +465,11 @@ function MeshInfrastructureContent() {
                               {node.latest_device_metrics?.reported_time
                                 ? `Battery reading ${STALE_BATTERY_TELEMETRY_DAYS}+ days old`
                                 : 'No battery telemetry'}
+                            </Badge>
+                          ) : null}
+                          {node.battery_alert_active ? (
+                            <Badge variant="destructive" className="text-xs">
+                              Mesh battery alert
                             </Badge>
                           ) : null}
                         </div>

--- a/src/pages/user/NodeWatchDiscordInfoPanel.tsx
+++ b/src/pages/user/NodeWatchDiscordInfoPanel.tsx
@@ -1,0 +1,46 @@
+import { Link } from 'react-router-dom';
+import { Card, CardContent, CardDescription, CardHeader, CardTitle } from '@/components/ui/card';
+import { Bell } from 'lucide-react';
+
+/**
+ * Explains how mesh node watches use Discord DMs (separate from global Discord link + DX alerts).
+ */
+export function NodeWatchDiscordInfoPanel() {
+  return (
+    <Card>
+      <CardHeader>
+        <CardTitle className="flex items-center gap-2">
+          <Bell className="h-5 w-5" aria-hidden />
+          Node watch Discord notifications
+        </CardTitle>
+        <CardDescription>
+          Mesh monitoring can DM you when watched nodes go quiet (verification / offline) or when a configured
+          low-battery episode is confirmed. Uses the same linked Discord account as above.
+        </CardDescription>
+      </CardHeader>
+      <CardContent className="space-y-3 text-sm text-muted-foreground">
+        <ul className="list-disc space-y-1 pl-5">
+          <li>
+            Add a watch from <span className="text-foreground">My nodes</span>,{' '}
+            <span className="text-foreground">Mesh infra</span>, or a node&apos;s{' '}
+            <span className="text-foreground">Monitoring</span> tab.
+          </li>
+          <li>
+            Turn <strong className="text-foreground">Alerts on</strong> for the watch, then choose{' '}
+            <strong className="text-foreground">Offline</strong> and/or{' '}
+            <strong className="text-foreground">Low battery</strong> Discord notifications per watch.
+          </li>
+          <li>
+            Silence thresholds and battery rules (streak count, threshold %) are configured per node (where you have
+            permission) in Monitoring settings — not on this page.
+          </li>
+        </ul>
+        <p>
+          <Link to="/nodes/monitor" className="text-primary font-medium hover:underline">
+            Open watches list
+          </Link>
+        </p>
+      </CardContent>
+    </Card>
+  );
+}

--- a/src/pages/user/UserPage.test.tsx
+++ b/src/pages/user/UserPage.test.tsx
@@ -1,5 +1,6 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest';
 import { render, screen, waitFor } from '@testing-library/react';
+import { MemoryRouter } from 'react-router-dom';
 import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
 import { UserPage } from '@/pages/user/UserPage';
 import { DX_NOTIFICATION_CATEGORY_ORDER } from '@/lib/models';
@@ -59,7 +60,9 @@ function renderUserPage() {
   const client = new QueryClient({ defaultOptions: { queries: { retry: false } } });
   return render(
     <QueryClientProvider client={client}>
-      <UserPage />
+      <MemoryRouter>
+        <UserPage />
+      </MemoryRouter>
     </QueryClientProvider>
   );
 }
@@ -69,12 +72,13 @@ describe('UserPage', () => {
     vi.clearAllMocks();
   });
 
-  it('renders Discord setup and DX Discord notification panels', async () => {
+  it('renders Discord, node watch info, and DX Discord notification panels', async () => {
     renderUserPage();
     await waitFor(() => {
       expect(screen.getByRole('heading', { name: 'User Profile' })).toBeInTheDocument();
     });
     expect(screen.getByText('Discord')).toBeInTheDocument();
+    expect(screen.getByText('Node watch Discord notifications')).toBeInTheDocument();
     expect(screen.getByText('DX Discord notifications')).toBeInTheDocument();
   });
 });

--- a/src/pages/user/UserPage.tsx
+++ b/src/pages/user/UserPage.tsx
@@ -7,6 +7,7 @@ import { useToast } from '@/hooks/use-toast';
 import { authService } from '@/lib/auth/authService';
 import { useConfig } from '@/providers/ConfigProvider';
 import { DiscordNotificationsPanel } from '@/pages/user/DiscordNotificationsPanel';
+import { NodeWatchDiscordInfoPanel } from '@/pages/user/NodeWatchDiscordInfoPanel';
 import { DxNotificationsPanel } from '@/pages/user/DxNotificationsPanel';
 
 export function UserPage() {
@@ -154,6 +155,7 @@ export function UserPage() {
 
       <div className="mb-6 space-y-6">
         <DiscordNotificationsPanel />
+        <NodeWatchDiscordInfoPanel />
         <DxNotificationsPanel />
       </div>
 


### PR DESCRIPTION
# Summary

Adds UI support for configurable low-battery mesh monitoring alerts and clearer per-watch Discord notification controls.

The UI now consumes the new monitoring API from meshflow-api:

- node monitoring config (`GET/PATCH /api/monitoring/nodes/{id}/config/`)
- per-watch offline and battery notification opt-ins
- mesh infrastructure alert summary for the sidebar badge
- active battery alert state on observed-node payloads

Node Details now separates mesh monitoring into two clearer concepts:

- **Offline monitoring**: silence threshold -> verification traceroute -> confirmed offline.
- **Battery monitoring**: configurable threshold and consecutive report count -> active low-battery alert episode.

The settings dialog lets permitted users configure both the silence threshold and battery alert rules for a node. Watch controls now let each user opt their own watch into offline / verification Discord notifications, low-battery Discord notifications, or both.

Mesh Infrastructure now shows active monitoring state more prominently:

- sidebar badge for alerting mesh infrastructure nodes
- low-battery table includes both heuristic low/stale battery rows and API-confirmed active battery alerts
- active mesh battery alerts are visually distinguished from passive low-battery visibility

User Profile now includes a **Node watch Discord notifications** section between the global Discord connection panel and DX Discord notifications, explaining where watch-level notification preferences are managed and how offline vs battery alerts work.

## Background

This is the UI companion to the mesh monitoring battery alert API work.

Related work:

- API PR: https://github.com/pskillen/meshflow-api/pull/257
- API issue: pskillen/meshflow-api#255

## Rollout / dependency notes

This PR expects the API contract added by https://github.com/pskillen/meshflow-api/pull/257.

Deploy the API migrations before rolling out this UI so the following endpoints and fields exist:

- `GET/PATCH /api/monitoring/nodes/{id}/config/`
- `GET /api/monitoring/alerts/summary/?scope=mesh_infra`
- `NodeWatch.offline_notifications_enabled`
- `NodeWatch.battery_notifications_enabled`
- `ObservedNode.battery_alert_active`
- `ObservedNode.battery_alert_confirmed_at`

No new frontend environment variables are required.

Closes #240
Refs pskillen/meshflow-api#255

## Testing performed

- `npm run format`
- `npm run lint` — existing warnings only, no errors.
- `npm run build`
- `npm test` — 236 passed.