### PR TITLE
feat(mesh-infra): infra filters and watches dashboard polish

### DIFF
--- a/src/components/nodes/NodeMiniChart.tsx
+++ b/src/components/nodes/NodeMiniChart.tsx
@@ -7,6 +7,8 @@ import { Formatter, NameType, ValueType, Payload } from 'recharts/types/componen
 interface NodeMiniChartProps {
   metrics: DeviceMetrics[];
   dateRange: { startDate: Date; endDate: Date };
+  /** When `battery`, only the battery % series is drawn (e.g. compact watch cards). */
+  lines?: 'all' | 'battery';
 }
 
 const chartConfig: ChartConfig = {
@@ -14,7 +16,7 @@ const chartConfig: ChartConfig = {
   channel_utilization: { color: '#ff7b72', label: 'Ch. util %' },
 };
 
-export function NodeMiniChart({ metrics, dateRange }: NodeMiniChartProps) {
+export function NodeMiniChart({ metrics, dateRange, lines = 'all' }: NodeMiniChartProps) {
   const chartData = React.useMemo(() => {
     return metrics
       .filter((m) => m.reported_time != null)
@@ -80,14 +82,16 @@ export function NodeMiniChart({ metrics, dateRange }: NodeMiniChartProps) {
           }
         />
         <Line type="monotone" dataKey="battery_level" stroke="#76d9c4" strokeWidth={1.5} dot={false} connectNulls />
-        <Line
-          type="monotone"
-          dataKey="channel_utilization"
-          stroke="#ff7b72"
-          strokeWidth={1.5}
-          dot={false}
-          connectNulls
-        />
+        {lines === 'all' ? (
+          <Line
+            type="monotone"
+            dataKey="channel_utilization"
+            stroke="#ff7b72"
+            strokeWidth={1.5}
+            dot={false}
+            connectNulls
+          />
+        ) : null}
       </LineChart>
     </ChartContainer>
   );

--- a/src/components/nodes/NodesAndConstellationsMap.tsx
+++ b/src/components/nodes/NodesAndConstellationsMap.tsx
@@ -76,6 +76,8 @@ export interface NodesAndConstellationsMapProps {
   showMapLegend?: boolean;
   /** When false, hides role-colour swatches in the legend (constellation section unchanged). Default true. */
   showRoleLegendSwatches?: boolean;
+  /** Optional alert ring around standard pins (e.g. Mesh Infra ops); constellation fill colour unchanged. */
+  getNodeAlertRing?: (nodeId: number) => 'diamond' | 'rounded-square' | null | undefined;
 }
 
 export function NodesAndConstellationsMap({
@@ -100,6 +102,7 @@ export function NodesAndConstellationsMap({
   getManagedNodeMarkerColor,
   showMapLegend,
   showRoleLegendSwatches = true,
+  getNodeAlertRing,
 }: NodesAndConstellationsMapProps) {
   const mapRef = useRef<HTMLDivElement>(null);
   const mapInstanceRef = useRef<L.Map | null>(null);
@@ -434,7 +437,15 @@ export function NodesAndConstellationsMap({
             grayscale,
             getMarkerBorderColor?.(node as ObservedNode)
           )
-        : createNodeIcon(label, color, isSelected, dimmed, opacity, grayscale);
+        : createNodeIcon(
+            label,
+            color,
+            isSelected,
+            dimmed,
+            opacity,
+            grayscale,
+            getNodeAlertRing?.(node.node_id) ?? undefined
+          );
       const marker = L.marker(position, { icon });
       marker.on('click', () => handleMarkerClick(node));
       if (enableBubbles) {
@@ -458,7 +469,10 @@ export function NodesAndConstellationsMap({
               node.short_name || node.node_id_str?.slice(4, 8) || '?',
               getManagedNodeMarkerColor ? getManagedNodeMarkerColor(node) : c.color,
               isSelected,
-              hasSelection && !isSelected
+              hasSelection && !isSelected,
+              undefined,
+              undefined,
+              getNodeAlertRing?.(node.node_id) ?? undefined
             ),
           });
           marker.on('click', () => handleMarkerClick(node));
@@ -498,6 +512,7 @@ export function NodesAndConstellationsMap({
     getMarkerGrayscale,
     getMarkerBorderColor,
     getManagedNodeMarkerColor,
+    getNodeAlertRing,
   ]);
 
   return (

--- a/src/components/nodes/WatchedNodesTable.test.tsx
+++ b/src/components/nodes/WatchedNodesTable.test.tsx
@@ -23,6 +23,15 @@ vi.mock('@/hooks/useTraceroutesWithWebSocket', () => ({
   useTraceroutesWebSocketInvalidator: vi.fn(),
 }));
 
+vi.mock('@/hooks/api/useMultiNodeMetrics', () => ({
+  useMultiNodeMetrics: () => ({
+    metricsMap: {} as Record<number, unknown[]>,
+    isLoading: false,
+    isError: false,
+    errors: [],
+  }),
+}));
+
 function makeObservedNode(overrides: Partial<ObservedNodeWatchSummary> = {}): ObservedNode {
   return {
     internal_id: 1,
@@ -120,6 +129,27 @@ describe('WatchedNodesTable', () => {
     const offlineIdx = headings.findIndex((h) => h.textContent?.startsWith('Offline'));
     const onlineIdx = headings.findIndex((h) => h.textContent?.startsWith('Online'));
     expect(offlineIdx).toBeLessThan(onlineIdx);
+  });
+
+  it('hides latest traceroutes for low-battery watches (same as online)', () => {
+    const recent = new Date(Date.now() - 10 * 60 * 1000);
+    renderTable({
+      watches: [
+        makeWatch({
+          id: 1,
+          node: {
+            node_id: 1,
+            short_name: 'LowBatt',
+            last_heard: recent,
+            monitoring_offline_confirmed_at: null,
+            monitoring_verification_started_at: null,
+            battery_alert_active: true,
+          },
+        }),
+      ],
+    });
+    expect(screen.getByText(/Low battery watch — traceroute history is hidden/)).toBeInTheDocument();
+    expect(screen.queryByText('Latest traceroutes (this target)')).not.toBeInTheDocument();
   });
 
   it('hides latest traceroutes table for online watches', () => {

--- a/src/components/nodes/WatchedNodesTable.tsx
+++ b/src/components/nodes/WatchedNodesTable.tsx
@@ -1,11 +1,11 @@
 import type { ReactNode } from 'react';
 import { useMemo } from 'react';
-import { format } from 'date-fns';
+import { format, subDays } from 'date-fns';
 import { enGB } from 'date-fns/locale';
 import { StaleReportedTime } from '@/components/nodes/StaleReportedTime';
 import { Link } from 'react-router-dom';
 import { useQuery, type UseQueryResult } from '@tanstack/react-query';
-import type { AutoTraceRoute, NodeWatch, ObservedNode, PaginatedResponse } from '@/lib/models';
+import type { AutoTraceRoute, DeviceMetrics, NodeWatch, ObservedNode, PaginatedResponse } from '@/lib/models';
 import { labelForTriggerTypeApi } from '@/lib/traceroute-trigger-type';
 import { TracerouteQueueDispatchCell } from '@/components/traceroutes/TracerouteQueueDispatchCell';
 import { TracerouteStatusBadge } from '@/components/traceroutes/TracerouteStatusBadge';
@@ -15,7 +15,9 @@ import { Card, CardHeader, CardTitle, CardDescription } from '@/components/ui/ca
 import { Badge } from '@/components/ui/badge';
 import { MeshWatchControls } from '@/components/nodes/MeshWatchControls';
 import { useMeshtasticApi } from '@/hooks/api/useApi';
-import { BatteryIcon, RouteIcon } from 'lucide-react';
+import { useMultiNodeMetrics } from '@/hooks/api/useMultiNodeMetrics';
+import { NodeMiniChart } from '@/components/nodes/NodeMiniChart';
+import { BatteryIcon, RouteIcon, Settings2 } from 'lucide-react';
 import { Button } from '@/components/ui/button';
 import { cn } from '@/lib/utils';
 import {
@@ -23,6 +25,7 @@ import {
   WATCH_STATUS_LABEL,
   type WatchMonitoringStatus,
 } from '@/lib/watch-monitoring-status';
+import { Dialog, DialogContent, DialogHeader, DialogTitle, DialogTrigger } from '@/components/ui/dialog';
 
 const LATEST_TRACEROUTES = 5;
 
@@ -60,6 +63,14 @@ function routeSummary(tr: AutoTraceRoute): string {
   const outStr = outEmpty ? 'Direct' : `${route.length} hops`;
   const backStr = backEmpty ? 'Direct' : `${routeBack.length} hops`;
   return `${outStr} out, ${backStr} back`;
+}
+
+function watchSettingsSummary(watch: NodeWatch): string {
+  if (!watch.enabled) return 'Alerts off';
+  const parts: string[] = ['Alerts on'];
+  if (watch.offline_notifications_enabled ?? true) parts.push('Offline notify');
+  if (watch.battery_notifications_enabled) parts.push('Battery notify');
+  return parts.join(' · ');
 }
 
 function WatchTracerouteHistoryRows({
@@ -191,16 +202,22 @@ function WatchCard({
   onOpenTraceroute,
   onRequestTriggerTraceroute,
   canTriggerTraceroute,
+  metrics,
+  chartDateRange,
+  metricsLoading,
 }: {
   watch: NodeWatch;
   watchesQuery: Pick<UseQueryResult<PaginatedResponse<NodeWatch>>, 'isLoading' | 'isError'>;
   onOpenTraceroute: (id: number) => void;
   onRequestTriggerTraceroute?: (node: ObservedNode) => void;
   canTriggerTraceroute?: boolean;
+  metrics: DeviceMetrics[];
+  chartDateRange: { startDate: Date; endDate: Date };
+  metricsLoading: boolean;
 }) {
   const node = observedAsNode(watch);
   const status = deriveWatchMonitoringStatus(watch);
-  const showTraceroutes = status !== 'online';
+  const showTraceroutes = status !== 'online' && status !== 'battery_low';
 
   return (
     <div
@@ -209,27 +226,60 @@ function WatchCard({
       className={cn(
         'rounded-lg border-2 bg-card text-card-foreground shadow-sm p-4 space-y-4 outline-none scroll-mt-24',
         status === 'offline' && 'border-destructive ring-2 ring-destructive/25',
-        status !== 'offline' && 'border-slate-300 dark:border-slate-400'
+        status === 'battery_low' && 'border-amber-600 ring-2 ring-amber-600/30 dark:border-amber-500',
+        status !== 'offline' && status !== 'battery_low' && 'border-slate-300 dark:border-slate-400'
       )}
     >
       <div className="flex flex-wrap items-start justify-between gap-3">
         <div className="flex flex-wrap items-center gap-2">
           <Badge variant={statusBadgeVariant(status)}>{WATCH_STATUS_LABEL[status]}</Badge>
         </div>
-        {onRequestTriggerTraceroute && (
-          <Button
-            type="button"
-            variant="outline"
-            size="sm"
-            className="shrink-0"
-            disabled={!canTriggerTraceroute}
-            title={canTriggerTraceroute ? undefined : 'No eligible source nodes for traceroute'}
-            onClick={() => onRequestTriggerTraceroute(node)}
+        <div className="flex flex-wrap items-center justify-end gap-2 sm:gap-3">
+          <span
+            className="text-xs text-muted-foreground max-w-[min(100%,14rem)] sm:max-w-[20rem] truncate"
+            title={watchSettingsSummary(watch)}
           >
-            <RouteIcon className="h-4 w-4 mr-1.5" aria-hidden />
-            Trigger traceroute
-          </Button>
-        )}
+            {watchSettingsSummary(watch)}
+          </span>
+          <Dialog>
+            <DialogTrigger asChild>
+              <Button
+                type="button"
+                variant="outline"
+                size="icon"
+                className="h-8 w-8 shrink-0"
+                aria-label="Watch settings"
+              >
+                <Settings2 className="h-4 w-4" />
+              </Button>
+            </DialogTrigger>
+            <DialogContent className="sm:max-w-md">
+              <DialogHeader>
+                <DialogTitle>Watch settings</DialogTitle>
+              </DialogHeader>
+              <MeshWatchControls
+                node={node}
+                watch={watch}
+                watchesQuery={watchesQuery}
+                idPrefix={`watch-dash-${watch.id}`}
+              />
+            </DialogContent>
+          </Dialog>
+          {onRequestTriggerTraceroute && (
+            <Button
+              type="button"
+              variant="outline"
+              size="sm"
+              className="shrink-0"
+              disabled={!canTriggerTraceroute}
+              title={canTriggerTraceroute ? undefined : 'No eligible source nodes for traceroute'}
+              onClick={() => onRequestTriggerTraceroute(node)}
+            >
+              <RouteIcon className="h-4 w-4 mr-1.5" aria-hidden />
+              Trigger traceroute
+            </Button>
+          )}
+        </div>
       </div>
 
       <div className="grid gap-6 sm:grid-cols-2 lg:grid-cols-4">
@@ -252,15 +302,15 @@ function WatchCard({
           <FieldLabel>Battery</FieldLabel>
           <BatteryBlock node={node} />
         </div>
-        <div>
-          <FieldLabel>Watch</FieldLabel>
-          <MeshWatchControls
-            node={node}
-            watch={watch}
-            watchesQuery={watchesQuery}
-            idPrefix={`watch-dash-${watch.id}`}
-            compact
-          />
+        <div className="min-w-0">
+          <FieldLabel>Battery (last 7 days)</FieldLabel>
+          {metricsLoading ? (
+            <div className="h-[120px] rounded-md bg-muted/60 animate-pulse" aria-hidden />
+          ) : (
+            <div className="-mx-1">
+              <NodeMiniChart metrics={metrics} dateRange={chartDateRange} lines="battery" />
+            </div>
+          )}
         </div>
       </div>
 
@@ -288,11 +338,23 @@ function WatchCard({
       ) : (
         <div className="border-t border-slate-300 pt-4 dark:border-slate-500">
           <p className="text-sm text-muted-foreground">
-            Node is currently online; traceroute history is hidden here.{' '}
-            <Link to="/traceroutes" className="text-teal-600 dark:text-teal-400 hover:underline">
-              Open full traceroute history
-            </Link>
-            .
+            {status === 'battery_low' ? (
+              <>
+                Low battery watch — traceroute history is hidden while the node is otherwise online.{' '}
+                <Link to="/traceroutes" className="text-teal-600 dark:text-teal-400 hover:underline">
+                  Open full traceroute history
+                </Link>
+                .
+              </>
+            ) : (
+              <>
+                Node is currently online; traceroute history is hidden here.{' '}
+                <Link to="/traceroutes" className="text-teal-600 dark:text-teal-400 hover:underline">
+                  Open full traceroute history
+                </Link>
+                .
+              </>
+            )}
           </p>
         </div>
       )}
@@ -308,6 +370,16 @@ export function WatchedNodesTable({
   canTriggerTraceroute,
 }: WatchedNodesTableProps) {
   useTraceroutesWebSocketInvalidator();
+
+  const watchedObservedNodes = useMemo(() => watches.map((w) => observedAsNode(w)), [watches]);
+  const chartDateRange = useMemo(
+    () => ({
+      startDate: subDays(new Date(), 7),
+      endDate: new Date(),
+    }),
+    []
+  );
+  const { metricsMap, isLoading: metricsLoading } = useMultiNodeMetrics(watchedObservedNodes, chartDateRange);
 
   const grouped = useMemo(() => {
     const m = new Map<WatchMonitoringStatus, NodeWatch[]>();
@@ -349,6 +421,9 @@ export function WatchedNodesTable({
                     onOpenTraceroute={onOpenTraceroute}
                     onRequestTriggerTraceroute={onRequestTriggerTraceroute}
                     canTriggerTraceroute={canTriggerTraceroute}
+                    metrics={metricsMap[watch.observed_node.node_id] ?? []}
+                    chartDateRange={chartDateRange}
+                    metricsLoading={metricsLoading}
                   />
                 ))}
               </div>

--- a/src/components/nodes/map-utils.ts
+++ b/src/components/nodes/map-utils.ts
@@ -186,7 +186,9 @@ export function createNodeIcon(
   highlighted = false,
   dimmed = false,
   opacity?: number,
-  grayscale?: number
+  grayscale?: number,
+  /** Optional outer frame for ops alerts (Mesh Infra); keeps pin fill `color`. */
+  alertRing?: 'diamond' | 'rounded-square'
 ): L.DivIcon {
   const highlightClass = highlighted ? ' marker-pin-highlighted' : '';
   const styles: string[] = [];
@@ -194,17 +196,40 @@ export function createNodeIcon(
   else if (dimmed) styles.push('opacity: 0.5');
   if (grayscale != null && grayscale > 0) styles.push(`filter: grayscale(${grayscale * 100}%)`);
   const containerStyle = styles.length > 0 ? styles.join('; ') + ';' : '';
+  const ringColor = 'rgba(234, 88, 12, 0.95)';
+  const diamondRing =
+    alertRing === 'diamond'
+      ? `<div style="position:absolute;left:50%;top:50%;width:42px;height:42px;margin:-21px 0 0 -21px;border:3px solid ${ringColor};border-radius:5px;transform:rotate(45deg);pointer-events:none;z-index:0;"></div>`
+      : '';
+  const roundedRing =
+    alertRing === 'rounded-square'
+      ? `<div style="position:absolute;left:50%;top:50%;width:46px;height:46px;margin:-23px 0 0 -23px;border:3px solid ${ringColor};border-radius:12px;pointer-events:none;z-index:0;"></div>`
+      : '';
+  const stackOpen =
+    alertRing != null
+      ? `<div class="marker-stack" style="position:relative;width:52px;height:52px;margin:-6px 0 0 -6px;">${diamondRing}${roundedRing}`
+      : '';
+  const stackClose = alertRing != null ? '</div>' : '';
+  const innerWrap = alertRing != null ? `<div style="position:relative;z-index:1;">` : '';
+  const innerClose = alertRing != null ? '</div>' : '';
+  const iconSize: [number, number] = alertRing != null ? [52, 52] : [40, 40];
+  const iconAnchor: [number, number] = alertRing != null ? [26, 46] : [20, 40];
+  const popupY = alertRing != null ? -46 : -40;
   return L.divIcon({
     className: 'custom-node-marker',
     html: `
+      ${stackOpen}
+      ${innerWrap}
       <div class="marker-container" style="${containerStyle}">
         <div class="marker-pin${highlightClass}" style="background: ${color};"></div>
         <span class="marker-text">${text}</span>
       </div>
+      ${innerClose}
+      ${stackClose}
     `,
-    iconSize: [40, 40],
-    iconAnchor: [20, 40],
-    popupAnchor: [0, -40],
+    iconSize,
+    iconAnchor,
+    popupAnchor: [0, popupY],
   });
 }
 

--- a/src/lib/infrastructure-low-battery.test.ts
+++ b/src/lib/infrastructure-low-battery.test.ts
@@ -1,6 +1,12 @@
 import { describe, it, expect } from 'vitest';
 import type { ObservedNode } from '@/lib/models';
-import { partitionMeshInfraLowBatteryTableNodes, partitionLowBatteryNodes } from './infrastructure-low-battery';
+import {
+  hasMeshInfraMapBatteryOrPresenceAlert,
+  isLowBatteryTableRowVisible,
+  matchesLowBatteryStaleReadingRow,
+  partitionMeshInfraLowBatteryTableNodes,
+  partitionLowBatteryNodes,
+} from './infrastructure-low-battery';
 
 function node(partial: Partial<ObservedNode>): ObservedNode {
   return {
@@ -54,5 +60,77 @@ describe('partitionMeshInfraLowBatteryTableNodes', () => {
     expect(out.map((n) => n.node_id)).toContain(3);
     expect(out[0].node_id).toBe(2);
     expect(partitionLowBatteryNodes([okBattery, alertOnly, low]).some((n) => n.node_id === 2)).toBe(false);
+  });
+});
+
+describe('isLowBatteryTableRowVisible', () => {
+  const baseFilters = {
+    showStaleReadings: false,
+    showZeroPercent: false,
+    showNoTelemetry: false,
+  };
+
+  it('hides no-telemetry rows by default', () => {
+    const n = node({ node_id: 1, latest_device_metrics: null });
+    expect(isLowBatteryTableRowVisible(n, baseFilters)).toBe(false);
+    expect(isLowBatteryTableRowVisible(n, { ...baseFilters, showNoTelemetry: true })).toBe(true);
+  });
+
+  it('hides stale-reading rows by default', () => {
+    const old = new Date(Date.now() - 10 * 24 * 60 * 60 * 1000);
+    const n = node({
+      node_id: 2,
+      latest_device_metrics: {
+        battery_level: 90,
+        reported_time: old,
+        logged_time: null,
+      } as ObservedNode['latest_device_metrics'],
+    });
+    expect(matchesLowBatteryStaleReadingRow(n)).toBe(true);
+    expect(isLowBatteryTableRowVisible(n, baseFilters)).toBe(false);
+    expect(isLowBatteryTableRowVisible(n, { ...baseFilters, showStaleReadings: true })).toBe(true);
+  });
+
+  it('shows mesh-alert-only rows regardless of battery filters', () => {
+    const n = node({
+      node_id: 3,
+      latest_device_metrics: {
+        battery_level: 90,
+        reported_time: new Date(),
+        logged_time: null,
+      } as ObservedNode['latest_device_metrics'],
+      battery_alert_active: true,
+    });
+    expect(isLowBatteryTableRowVisible(n, baseFilters)).toBe(true);
+  });
+});
+
+describe('hasMeshInfraMapBatteryOrPresenceAlert', () => {
+  it('returns false for stale-but-ok percentage', () => {
+    const old = new Date(Date.now() - 10 * 24 * 60 * 60 * 1000);
+    const n = node({
+      node_id: 1,
+      last_heard: new Date(),
+      latest_device_metrics: {
+        battery_level: 88,
+        reported_time: old,
+        logged_time: null,
+      } as ObservedNode['latest_device_metrics'],
+    });
+    expect(hasMeshInfraMapBatteryOrPresenceAlert(n)).toBe(false);
+  });
+
+  it('returns true for low percent with stale reading', () => {
+    const old = new Date(Date.now() - 10 * 24 * 60 * 60 * 1000);
+    const n = node({
+      node_id: 2,
+      last_heard: new Date(),
+      latest_device_metrics: {
+        battery_level: 12,
+        reported_time: old,
+        logged_time: null,
+      } as ObservedNode['latest_device_metrics'],
+    });
+    expect(hasMeshInfraMapBatteryOrPresenceAlert(n)).toBe(true);
   });
 });

--- a/src/lib/infrastructure-low-battery.ts
+++ b/src/lib/infrastructure-low-battery.ts
@@ -46,6 +46,72 @@ export function getLowBatteryRowFlags(node: ObservedNode, now: Date = new Date()
   return { isZeroPercent, showLowBatteryBadge, showStaleBatteryBadge };
 }
 
+/** Row matches the “no battery telemetry” bucket (no device metrics or no reported_time). */
+export function matchesLowBatteryNoTelemetryRow(node: ObservedNode): boolean {
+  const m = node.latest_device_metrics;
+  const reportedAt = getBatteryMetricsReportedAt(node);
+  return !(m && reportedAt);
+}
+
+/** Row matches the “always 0%” bucket (usable metrics, level 0). */
+export function matchesLowBatteryZeroPercentRow(node: ObservedNode, now: Date = new Date()): boolean {
+  return getLowBatteryRowFlags(node, now).isZeroPercent;
+}
+
+/** Row matches the “stale reading” bucket (usable telemetry older than STALE_BATTERY_TELEMETRY_DAYS). */
+export function matchesLowBatteryStaleReadingRow(node: ObservedNode, now: Date = new Date()): boolean {
+  if (matchesLowBatteryNoTelemetryRow(node)) return false;
+  return isBatteryTelemetryStale(node, now);
+}
+
+export type LowBatteryTableFilters = {
+  showStaleReadings: boolean;
+  showZeroPercent: boolean;
+  showNoTelemetry: boolean;
+};
+
+/**
+ * Whether a low-battery table row should be shown given pill filters (all default off = hide that bucket).
+ * Rows matching multiple buckets are hidden if any of those buckets is filtered off.
+ */
+export function isLowBatteryTableRowVisible(
+  node: ObservedNode,
+  filters: LowBatteryTableFilters,
+  now: Date = new Date()
+): boolean {
+  if (matchesLowBatteryNoTelemetryRow(node) && !filters.showNoTelemetry) return false;
+  if (matchesLowBatteryZeroPercentRow(node, now) && !filters.showZeroPercent) return false;
+  if (matchesLowBatteryStaleReadingRow(node, now) && !filters.showStaleReadings) return false;
+  return true;
+}
+
+/**
+ * Map pin alert halo on Mesh Infra: offline, mesh battery alert, missing battery telemetry, 0%, or low %.
+ * Does **not** treat “reading is old but % still looks fine” as an alert (stale-only).
+ */
+export function hasMeshInfraMapBatteryOrPresenceAlert(node: ObservedNode, now: Date = new Date()): boolean {
+  const cutoff = subDays(now, 7);
+  const lastHeard = node.last_heard
+    ? node.last_heard instanceof Date
+      ? node.last_heard
+      : new Date(node.last_heard)
+    : null;
+  const isOffline = !lastHeard || lastHeard < cutoff;
+  if (isOffline) return true;
+  if (node.battery_alert_active) return true;
+
+  const m = node.latest_device_metrics;
+  const reportedAt = getBatteryMetricsReportedAt(node);
+  const hasUsableMetrics = Boolean(m && reportedAt);
+  if (!hasUsableMetrics) return true;
+
+  const level = m!.battery_level;
+  if (level === 0) return true;
+  if (level != null && level < LOW_BATTERY_THRESHOLD_PERCENT) return true;
+
+  return false;
+}
+
 function lastHeardTime(node: ObservedNode): number {
   if (!node.last_heard) return 0;
   return node.last_heard instanceof Date ? node.last_heard.getTime() : new Date(node.last_heard).getTime();

--- a/src/pages/nodes/MeshInfrastructure.tsx
+++ b/src/pages/nodes/MeshInfrastructure.tsx
@@ -29,7 +29,12 @@ import { Battery, MapPinOff } from 'lucide-react';
 import {
   getBatteryMetricsReportedAt,
   getLowBatteryRowFlags,
+  hasMeshInfraMapBatteryOrPresenceAlert,
+  isLowBatteryTableRowVisible,
   LOW_BATTERY_THRESHOLD_PERCENT,
+  matchesLowBatteryNoTelemetryRow,
+  matchesLowBatteryStaleReadingRow,
+  matchesLowBatteryZeroPercentRow,
   partitionMeshInfraLowBatteryTableNodes,
   STALE_BATTERY_TELEMETRY_DAYS,
 } from '@/lib/infrastructure-low-battery';
@@ -146,6 +151,50 @@ function MeshInfrastructureContent() {
 
   const lowBatteryNodesOrdered = useMemo(() => partitionMeshInfraLowBatteryTableNodes(allInfraNodes), [allInfraNodes]);
 
+  const [showStaleBatteryReadings, setShowStaleBatteryReadings] = useState(false);
+  const [showZeroPercentBattery, setShowZeroPercentBattery] = useState(false);
+  const [showNoBatteryTelemetry, setShowNoBatteryTelemetry] = useState(false);
+
+  const lowBatteryTableFilters = useMemo(
+    () => ({
+      showStaleReadings: showStaleBatteryReadings,
+      showZeroPercent: showZeroPercentBattery,
+      showNoTelemetry: showNoBatteryTelemetry,
+    }),
+    [showStaleBatteryReadings, showZeroPercentBattery, showNoBatteryTelemetry]
+  );
+
+  const visibleLowBatteryRows = useMemo(
+    () => lowBatteryNodesOrdered.filter((n) => isLowBatteryTableRowVisible(n, lowBatteryTableFilters)),
+    [lowBatteryNodesOrdered, lowBatteryTableFilters]
+  );
+
+  const lowBatteryHiddenLineCounts = useMemo(() => {
+    const hidden = lowBatteryNodesOrdered.filter((n) => !isLowBatteryTableRowVisible(n, lowBatteryTableFilters));
+    let noTelemetry = 0;
+    let zeroPercent = 0;
+    let staleReadings = 0;
+    for (const n of hidden) {
+      if (matchesLowBatteryNoTelemetryRow(n) && !lowBatteryTableFilters.showNoTelemetry) {
+        noTelemetry++;
+      } else if (matchesLowBatteryZeroPercentRow(n) && !lowBatteryTableFilters.showZeroPercent) {
+        zeroPercent++;
+      } else if (matchesLowBatteryStaleReadingRow(n) && !lowBatteryTableFilters.showStaleReadings) {
+        staleReadings++;
+      }
+    }
+    return { noTelemetry, zeroPercent, staleReadings };
+  }, [lowBatteryNodesOrdered, lowBatteryTableFilters]);
+
+  const nodeAlertRing = useMemo(() => {
+    const m = new Map<number, 'diamond' | 'rounded-square'>();
+    for (const n of allInfraNodes) {
+      if (!hasMeshInfraMapBatteryOrPresenceAlert(n)) continue;
+      m.set(n.node_id, n.node_id % 2 === 0 ? 'diamond' : 'rounded-square');
+    }
+    return m;
+  }, [allInfraNodes]);
+
   const sortedNodes = useMemo(
     () =>
       [...nodes].sort((a, b) => {
@@ -226,6 +275,7 @@ function MeshInfrastructureContent() {
                 drawPositionUncertainty={true}
                 enableBubbles={true}
                 showRoleLegendSwatches={false}
+                getNodeAlertRing={(nodeId) => nodeAlertRing.get(nodeId) ?? null}
               />
             </div>
           </CardContent>
@@ -251,7 +301,6 @@ function MeshInfrastructureContent() {
               <TableHeader>
                 <TableRow>
                   <TableHead>Node</TableHead>
-                  <TableHead>Node ID</TableHead>
                   <TableHead>Last heard</TableHead>
                   <TableHead>Last GPS position reported</TableHead>
                   <TableHead>Owner</TableHead>
@@ -271,21 +320,23 @@ function MeshInfrastructureContent() {
                   return (
                     <TableRow key={node.internal_id}>
                       <TableCell>
-                        <div className="flex items-center gap-2">
-                          <Link to={`/nodes/${node.node_id}`} className="font-medium text-primary hover:underline">
-                            {node.long_name} ({node.short_name || node.node_id_str})
-                          </Link>
-                          {isOffline && (
-                            <Badge
-                              variant="outline"
-                              className="text-xs border-red-500/70 text-red-700 dark:border-red-400 dark:text-red-300"
-                            >
-                              OFFLINE
-                            </Badge>
-                          )}
+                        <div className="flex flex-col gap-0.5">
+                          <div className="flex items-center gap-2">
+                            <Link to={`/nodes/${node.node_id}`} className="font-medium text-primary hover:underline">
+                              {node.long_name} ({node.short_name || node.node_id_str})
+                            </Link>
+                            {isOffline && (
+                              <Badge
+                                variant="outline"
+                                className="text-xs border-red-500/70 text-red-700 dark:border-red-400 dark:text-red-300"
+                              >
+                                OFFLINE
+                              </Badge>
+                            )}
+                          </div>
+                          <span className="text-xs text-muted-foreground">{node.node_id_str}</span>
                         </div>
                       </TableCell>
-                      <TableCell className="text-muted-foreground">{node.node_id_str}</TableCell>
                       <TableCell>
                         <div className="flex flex-col">
                           {node.last_heard ? (
@@ -358,21 +409,76 @@ function MeshInfrastructureContent() {
           <CardHeader>
             <CardTitle className="flex items-center gap-2">
               <Battery className="h-5 w-5" />
-              Low battery nodes ({lowBatteryNodesOrdered.length})
+              Low battery nodes (
+              {visibleLowBatteryRows.length === lowBatteryNodesOrdered.length
+                ? lowBatteryNodesOrdered.length
+                : `${visibleLowBatteryRows.length} of ${lowBatteryNodesOrdered.length}`}
+              )
             </CardTitle>
             <CardDescription>
               Includes nodes below {LOW_BATTERY_THRESHOLD_PERCENT}% battery, no battery telemetry, a reading older than{' '}
               {STALE_BATTERY_TELEMETRY_DAYS} days, or an active mesh monitoring low-battery alert. Last heard can still
               be recent while metrics are missing or stale—that is not always a problem. Rows showing 0% are often bogus
-              telemetry and are listed last.
+              telemetry and are listed last. Use the toggles to reveal stale readings, 0% rows, or nodes with no battery
+              telemetry (all off by default).
             </CardDescription>
           </CardHeader>
-          <CardContent>
+          <CardContent className="space-y-4">
+            <div className="flex flex-wrap gap-2 items-center">
+              <span className="text-xs uppercase tracking-wide text-muted-foreground mr-1">Show in table:</span>
+              <Button
+                type="button"
+                variant={showStaleBatteryReadings ? 'default' : 'outline'}
+                size="sm"
+                onClick={() => setShowStaleBatteryReadings((v) => !v)}
+              >
+                Stale battery readings
+              </Button>
+              <Button
+                type="button"
+                variant={showZeroPercentBattery ? 'default' : 'outline'}
+                size="sm"
+                onClick={() => setShowZeroPercentBattery((v) => !v)}
+              >
+                0% battery
+              </Button>
+              <Button
+                type="button"
+                variant={showNoBatteryTelemetry ? 'default' : 'outline'}
+                size="sm"
+                onClick={() => setShowNoBatteryTelemetry((v) => !v)}
+              >
+                No battery telemetry
+              </Button>
+            </div>
+            {(lowBatteryHiddenLineCounts.staleReadings > 0 ||
+              lowBatteryHiddenLineCounts.zeroPercent > 0 ||
+              lowBatteryHiddenLineCounts.noTelemetry > 0) && (
+              <div className="text-sm text-muted-foreground space-y-1">
+                {lowBatteryHiddenLineCounts.staleReadings > 0 && (
+                  <p>
+                    {lowBatteryHiddenLineCounts.staleReadings} node
+                    {lowBatteryHiddenLineCounts.staleReadings === 1 ? '' : 's'} with stale battery readings hidden
+                  </p>
+                )}
+                {lowBatteryHiddenLineCounts.zeroPercent > 0 && (
+                  <p>
+                    {lowBatteryHiddenLineCounts.zeroPercent} node
+                    {lowBatteryHiddenLineCounts.zeroPercent === 1 ? '' : 's'} reporting 0% battery hidden
+                  </p>
+                )}
+                {lowBatteryHiddenLineCounts.noTelemetry > 0 && (
+                  <p>
+                    {lowBatteryHiddenLineCounts.noTelemetry} node
+                    {lowBatteryHiddenLineCounts.noTelemetry === 1 ? '' : 's'} with no battery telemetry hidden
+                  </p>
+                )}
+              </div>
+            )}
             <Table>
               <TableHeader>
                 <TableRow>
                   <TableHead>Node</TableHead>
-                  <TableHead>Node ID</TableHead>
                   <TableHead>Last heard</TableHead>
                   <TableHead>Battery</TableHead>
                   <TableHead>Status</TableHead>
@@ -382,126 +488,136 @@ function MeshInfrastructureContent() {
                 </TableRow>
               </TableHeader>
               <TableBody>
-                {lowBatteryNodesOrdered.map((node) => {
-                  const flags = getLowBatteryRowFlags(node);
-                  const reportedAt = getBatteryMetricsReportedAt(node);
-                  const level = node.latest_device_metrics?.battery_level;
-                  const watch = watchesByNodeIdStr.get(node.node_id_str);
-                  const managed = managedByMeshId.get(node.node_id);
-                  const cutoff = subDays(new Date(), 7);
-                  const isOffline =
-                    !node.last_heard ||
-                    (node.last_heard instanceof Date ? node.last_heard : new Date(node.last_heard)) < cutoff;
-                  return (
-                    <TableRow
-                      key={node.internal_id}
-                      className={flags.isZeroPercent ? 'opacity-70 text-muted-foreground' : undefined}
-                    >
-                      <TableCell>
-                        <div className="flex items-center gap-2">
-                          <Link to={`/nodes/${node.node_id}`} className="font-medium text-primary hover:underline">
-                            {node.long_name} ({node.short_name || node.node_id_str})
-                          </Link>
-                          {isOffline && (
-                            <Badge
-                              variant="outline"
-                              className="text-xs border-red-500/70 text-red-700 dark:border-red-400 dark:text-red-300"
-                            >
-                              OFFLINE
-                            </Badge>
-                          )}
-                        </div>
-                      </TableCell>
-                      <TableCell className="text-muted-foreground">{node.node_id_str}</TableCell>
-                      <TableCell>
-                        <div className="flex flex-col">
-                          {node.last_heard ? (
-                            <>
-                              <span>
-                                {format(
-                                  node.last_heard instanceof Date ? node.last_heard : new Date(node.last_heard),
-                                  'PPpp',
-                                  { locale: enGB }
-                                )}
-                              </span>
-                              <StaleReportedTime
-                                at={node.last_heard instanceof Date ? node.last_heard : new Date(node.last_heard)}
-                                className="text-xs text-muted-foreground"
-                              />
-                            </>
-                          ) : (
-                            'Never'
-                          )}
-                        </div>
-                      </TableCell>
-                      <TableCell>
-                        <div className="flex flex-col">
-                          {level != null ? (
-                            <>
-                              <span>{level}%</span>
-                              {reportedAt ? (
-                                <>
-                                  <span className="text-xs text-muted-foreground">
-                                    {format(reportedAt, 'PPpp', { locale: enGB })}
-                                  </span>
-                                  <StaleReportedTime at={reportedAt} className="text-xs text-muted-foreground" />
-                                </>
-                              ) : null}
-                            </>
-                          ) : (
-                            '—'
-                          )}
-                        </div>
-                      </TableCell>
-                      <TableCell>
-                        <div className="flex flex-wrap gap-1">
-                          {flags.showLowBatteryBadge ? (
-                            <Badge variant="secondary" className="text-xs">
-                              Low battery
-                            </Badge>
-                          ) : null}
-                          {flags.showStaleBatteryBadge ? (
-                            <Badge variant="outline" className="text-xs">
-                              {node.latest_device_metrics?.reported_time
-                                ? `Battery reading ${STALE_BATTERY_TELEMETRY_DAYS}+ days old`
-                                : 'No battery telemetry'}
-                            </Badge>
-                          ) : null}
-                          {node.battery_alert_active ? (
-                            <Badge variant="destructive" className="text-xs">
-                              Mesh battery alert
-                            </Badge>
-                          ) : null}
-                        </div>
-                      </TableCell>
-                      <TableCell>{node.owner?.username ?? '—'}</TableCell>
-                      <TableCell>
-                        <MeshWatchControls
-                          node={node}
-                          watch={watch}
-                          watchesQuery={watchesQuery}
-                          idPrefix={`infra-batt-${node.node_id}`}
-                        />
-                      </TableCell>
-                      <TableCell>
-                        <div className="flex flex-col items-start gap-1 sm:flex-row sm:items-center sm:gap-3">
-                          <Link to={`/nodes/${node.node_id}`} className="text-primary text-sm hover:underline">
-                            View details
-                          </Link>
-                          {managed != null && (
-                            <Link
-                              to={`/traceroutes/map/coverage?feeder=${node.node_id}`}
-                              className="text-muted-foreground text-sm underline-offset-4 hover:text-primary hover:underline"
-                              data-testid={`infra-batt-coverage-link-${node.node_id}`}
-                            >
-                              Coverage map
+                {visibleLowBatteryRows.length === 0 ? (
+                  <TableRow>
+                    <TableCell colSpan={7} className="text-center text-muted-foreground py-8">
+                      No rows match the current filters. Turn on one or more categories above to show hidden nodes.
+                    </TableCell>
+                  </TableRow>
+                ) : (
+                  visibleLowBatteryRows.map((node) => {
+                    const flags = getLowBatteryRowFlags(node);
+                    const reportedAt = getBatteryMetricsReportedAt(node);
+                    const level = node.latest_device_metrics?.battery_level;
+                    const watch = watchesByNodeIdStr.get(node.node_id_str);
+                    const managed = managedByMeshId.get(node.node_id);
+                    const cutoff = subDays(new Date(), 7);
+                    const isOffline =
+                      !node.last_heard ||
+                      (node.last_heard instanceof Date ? node.last_heard : new Date(node.last_heard)) < cutoff;
+                    return (
+                      <TableRow
+                        key={node.internal_id}
+                        className={flags.isZeroPercent ? 'opacity-70 text-muted-foreground' : undefined}
+                      >
+                        <TableCell>
+                          <div className="flex flex-col gap-0.5">
+                            <div className="flex items-center gap-2">
+                              <Link to={`/nodes/${node.node_id}`} className="font-medium text-primary hover:underline">
+                                {node.long_name} ({node.short_name || node.node_id_str})
+                              </Link>
+                              {isOffline && (
+                                <Badge
+                                  variant="outline"
+                                  className="text-xs border-red-500/70 text-red-700 dark:border-red-400 dark:text-red-300"
+                                >
+                                  OFFLINE
+                                </Badge>
+                              )}
+                            </div>
+                            <span className="text-xs text-muted-foreground">{node.node_id_str}</span>
+                          </div>
+                        </TableCell>
+                        <TableCell>
+                          <div className="flex flex-col">
+                            {node.last_heard ? (
+                              <>
+                                <span>
+                                  {format(
+                                    node.last_heard instanceof Date ? node.last_heard : new Date(node.last_heard),
+                                    'PPpp',
+                                    { locale: enGB }
+                                  )}
+                                </span>
+                                <StaleReportedTime
+                                  at={node.last_heard instanceof Date ? node.last_heard : new Date(node.last_heard)}
+                                  className="text-xs text-muted-foreground"
+                                />
+                              </>
+                            ) : (
+                              'Never'
+                            )}
+                          </div>
+                        </TableCell>
+                        <TableCell>
+                          <div className="flex flex-col">
+                            {level != null ? (
+                              <>
+                                <span>{level}%</span>
+                                {reportedAt ? (
+                                  <>
+                                    <span className="text-xs text-muted-foreground">
+                                      {format(reportedAt, 'PPpp', { locale: enGB })}
+                                    </span>
+                                    <StaleReportedTime at={reportedAt} className="text-xs text-muted-foreground" />
+                                  </>
+                                ) : null}
+                              </>
+                            ) : (
+                              '—'
+                            )}
+                          </div>
+                        </TableCell>
+                        <TableCell>
+                          <div className="flex flex-wrap gap-1">
+                            {flags.showLowBatteryBadge ? (
+                              <Badge variant="secondary" className="text-xs">
+                                Low battery
+                              </Badge>
+                            ) : null}
+                            {flags.showStaleBatteryBadge ? (
+                              <Badge variant="outline" className="text-xs">
+                                {node.latest_device_metrics?.reported_time
+                                  ? `Battery reading ${STALE_BATTERY_TELEMETRY_DAYS}+ days old`
+                                  : 'No battery telemetry'}
+                              </Badge>
+                            ) : null}
+                            {node.battery_alert_active ? (
+                              <Badge variant="destructive" className="text-xs">
+                                Mesh battery alert
+                              </Badge>
+                            ) : null}
+                          </div>
+                        </TableCell>
+                        <TableCell>{node.owner?.username ?? '—'}</TableCell>
+                        <TableCell>
+                          <MeshWatchControls
+                            node={node}
+                            watch={watch}
+                            watchesQuery={watchesQuery}
+                            idPrefix={`infra-batt-${node.node_id}`}
+                          />
+                        </TableCell>
+                        <TableCell>
+                          <div className="flex flex-col items-start gap-1 sm:flex-row sm:items-center sm:gap-3">
+                            <Link to={`/nodes/${node.node_id}`} className="text-primary text-sm hover:underline">
+                              View details
                             </Link>
-                          )}
-                        </div>
-                      </TableCell>
-                    </TableRow>
-                  );
-                })}
+                            {managed != null && (
+                              <Link
+                                to={`/traceroutes/map/coverage?feeder=${node.node_id}`}
+                                className="text-muted-foreground text-sm underline-offset-4 hover:text-primary hover:underline"
+                                data-testid={`infra-batt-coverage-link-${node.node_id}`}
+                              >
+                                Coverage map
+                              </Link>
+                            )}
+                          </div>
+                        </TableCell>
+                      </TableRow>
+                    );
+                  })
+                )}
               </TableBody>
             </Table>
           </CardContent>

--- a/src/pages/nodes/monitor.tsx
+++ b/src/pages/nodes/monitor.tsx
@@ -159,11 +159,15 @@ export default function MonitorNodesPage() {
             />
           </div>
 
-          <div className="bg-background rounded-lg border">
-            <MonitoredNodesBatteryChart nodes={nodesForCharts} />
-          </div>
-
-          <Accordion type="single" collapsible className="bg-background rounded-lg border px-2">
+          <Accordion type="multiple" className="bg-background rounded-lg border px-2">
+            <AccordionItem value="battery" className="border-0">
+              <AccordionTrigger className="py-3 text-sm font-medium hover:no-underline">
+                Battery voltage comparison
+              </AccordionTrigger>
+              <AccordionContent className="pb-4 pt-0">
+                <MonitoredNodesBatteryChart nodes={nodesForCharts} />
+              </AccordionContent>
+            </AccordionItem>
             <AccordionItem value="channel-util" className="border-0">
               <AccordionTrigger className="py-3 text-sm font-medium hover:no-underline">
                 Channel utilization


### PR DESCRIPTION
# Summary

Implements #244 and the follow-up Watches screen polish.

Mesh Infra:

* Adds low-battery table pill filters (default off) for stale readings, 0% battery, and no battery telemetry, with hidden-count lines.
* Stacks node IDs under node names in both Mesh Infra alert tables.
* Adds Mesh Infra map alert rings while preserving constellation fill colours. Rings apply to offline, active mesh battery alert, missing battery telemetry, 0%, or sub-threshold battery; stale battery readings with otherwise OK percentage do not get a ring.

Watches dashboard:

* Highlights low-battery node detail cards with an amber border/ring, matching the low-battery visual language.
* Hides embedded traceroutes for low-battery watches unless the node is offline, same as online nodes.
* Moves watch enable/notification controls into a settings modal behind a cog button, with a compact summary beside it and the Trigger traceroute button.
* Adds a per-watch 7-day mini battery chart using the bulk metrics query.
* Collapses Battery voltage comparison in an accordion alongside Channel utilization.

## Testing performed

* `npm test` (Vitest, all 242 tests)
* `npm run build`
* Added/updated unit tests in `infrastructure-low-battery.test.ts` and `WatchedNodesTable.test.tsx`

Closes #244