### PR TITLE
feat(traceroutes): success rate by strategy chart (#199)

### DIFF
--- a/src/components/traceroutes/TracerouteStatsSection.tsx
+++ b/src/components/traceroutes/TracerouteStatsSection.tsx
@@ -1,7 +1,20 @@
 import { useMemo, useState } from 'react';
 import { Link } from 'react-router-dom';
 import { subHours, subDays } from 'date-fns';
-import { Cell, Legend, Line, LineChart, Pie, PieChart, XAxis, YAxis, Tooltip as RechartsTooltip } from 'recharts';
+import {
+  Bar,
+  BarChart,
+  CartesianGrid,
+  Cell,
+  Legend,
+  Line,
+  LineChart,
+  Pie,
+  PieChart,
+  XAxis,
+  YAxis,
+  Tooltip as RechartsTooltip,
+} from 'recharts';
 import { Card, CardContent, CardDescription, CardHeader, CardTitle } from '@/components/ui/card';
 import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from '@/components/ui/select';
 import { ChartConfig, ChartContainer, ChartTooltipContent } from '@/components/ui/chart';
@@ -10,6 +23,10 @@ import { Tooltip, TooltipContent, TooltipProvider, TooltipTrigger } from '@/comp
 import { HelpCircle } from 'lucide-react';
 import { useTracerouteStats } from '@/hooks/api/useTraceroutes';
 import { strategyLabel } from '@/lib/traceroute-strategy';
+import {
+  buildStrategySuccessBarChartData,
+  type StrategySuccessBarChartRow,
+} from '@/lib/traceroute-strategy-success-chart';
 
 const TR_STATS_TIMEFRAME_OPTIONS = [
   { key: '24h', label: '24 hours' },
@@ -52,11 +69,16 @@ const TOP_TARGETS_MIN_ATTEMPTS = 5;
 // Max distinct slices to show in "by node" pie charts before grouping into "Other".
 const PIE_TOP_N = 7;
 
-export function TracerouteStatsSection() {
+export type TracerouteStatsSectionProps = {
+  /** When set, stats (including this chart) are limited to traceroutes from this source mesh node id. */
+  sourceNodeId?: number | null;
+};
+
+export function TracerouteStatsSection({ sourceNodeId = null }: TracerouteStatsSectionProps) {
   const [timeframe, setTimeframe] = useState<TimeframeKey>('7d');
   const triggeredAtAfter = useMemo(() => getTriggeredAtAfter(timeframe), [timeframe]);
 
-  const { data, isLoading, error } = useTracerouteStats({ triggeredAtAfter });
+  const { data, isLoading, error } = useTracerouteStats({ triggeredAtAfter, sourceNodeId });
 
   const sourcesChartData = useMemo(() => {
     if (!data?.sources?.length) return [];
@@ -81,6 +103,23 @@ export function TracerouteStatsSection() {
       })
       .filter((d) => d.value > 0);
   }, [data?.by_strategy]);
+
+  const strategySuccessBarRows = useMemo(
+    () =>
+      buildStrategySuccessBarChartData(data?.by_strategy_excluding_external ?? data?.by_strategy).map((r, idx) => ({
+        ...r,
+        barHeight: r.success_pct ?? 0,
+        fill: CHART_COLORS[idx % CHART_COLORS.length],
+      })),
+    [data?.by_strategy_excluding_external, data?.by_strategy]
+  );
+
+  const sourceScopeHint = useMemo(() => {
+    if (sourceNodeId == null || !data?.by_source?.length) return null;
+    const row = data.by_source.find((r) => r.node_id === sourceNodeId);
+    if (!row) return 'Stats scoped to the selected source node.';
+    return `Stats scoped to source ${row.short_name ?? row.node_id_str ?? sourceNodeId}.`;
+  }, [sourceNodeId, data?.by_source]);
 
   const sentByNodeChartData = useMemo(() => {
     const rows = data?.by_source ?? [];
@@ -126,6 +165,10 @@ export function TracerouteStatsSection() {
     completed: { color: '#22c55e', label: 'Completed' },
     failed: { color: '#ef4444', label: 'Failed' },
     success_pct: { color: '#3b82f6', label: 'Success %' },
+  };
+
+  const strategyBarChartConfig: ChartConfig = {
+    barHeight: { label: 'Success %', color: '#3b82f6' },
   };
 
   const eligibleTargets = useMemo(
@@ -212,7 +255,7 @@ export function TracerouteStatsSection() {
           <CardHeader className="pb-2">
             <CardTitle className="text-sm">Strategy mix</CardTitle>
             <CardDescription className="text-xs text-muted-foreground">
-              Share of runs by target selection hypothesis (scheduled + manual when recorded).
+              Share of runs by target selection hypothesis (scheduled and manual when recorded).
             </CardDescription>
           </CardHeader>
           <CardContent>
@@ -366,6 +409,74 @@ export function TracerouteStatsSection() {
           </CardContent>
         </Card>
       </div>
+
+      <Card data-testid="traceroute-strategy-success-chart-card">
+        <CardHeader className="pb-2">
+          <CardTitle className="text-sm">Success rate by strategy</CardTitle>
+          <CardDescription className="text-xs text-muted-foreground">
+            Completed ÷ (completed + failed) for each target selection strategy. Rows with no recorded strategy are
+            grouped under Legacy. External mesh reports are omitted here only (they do not select a hypothesis). Pending
+            and in-flight runs count toward volume only, not the rate.
+            {sourceScopeHint ? ` ${sourceScopeHint}` : ''}
+          </CardDescription>
+        </CardHeader>
+        <CardContent>
+          {isLoading ? (
+            <div className="h-[220px] flex items-center justify-center text-muted-foreground text-sm">Loading…</div>
+          ) : (
+            <ChartContainer config={strategyBarChartConfig} className="aspect-auto h-[240px] w-full max-w-4xl">
+              <BarChart
+                data={strategySuccessBarRows}
+                margin={{ top: 8, right: 8, left: 4, bottom: 52 }}
+                accessibilityLayer
+              >
+                <CartesianGrid vertical={false} strokeDasharray="3 3" className="stroke-muted" />
+                <XAxis
+                  dataKey="label"
+                  tickLine={false}
+                  axisLine={false}
+                  tickMargin={8}
+                  interval={0}
+                  angle={-32}
+                  textAnchor="end"
+                  height={56}
+                  tick={{ fontSize: 11 }}
+                />
+                <YAxis
+                  tickLine={false}
+                  axisLine={false}
+                  domain={[0, 100]}
+                  width={36}
+                  tickFormatter={(v: number) => `${v}%`}
+                  tick={{ fontSize: 11 }}
+                />
+                <RechartsTooltip
+                  content={({ active, payload }) => {
+                    if (!active || !payload?.length) return null;
+                    const p = payload[0].payload as StrategySuccessBarChartRow;
+                    const finished = p.completed + p.failed;
+                    const rateLine =
+                      finished > 0
+                        ? `${p.success_pct != null ? p.success_pct.toFixed(0) : '—'}% (${p.completed} completed / ${p.failed} failed)`
+                        : `No finished runs (${p.pending} queued, ${p.sent} in flight)`;
+                    return (
+                      <div className="rounded-md border border-border/50 bg-background px-3 py-2 text-xs shadow-md">
+                        <div className="font-medium">{p.label}</div>
+                        <div className="mt-1 text-muted-foreground tabular-nums">{rateLine}</div>
+                      </div>
+                    );
+                  }}
+                />
+                <Bar dataKey="barHeight" radius={[4, 4, 0, 0]}>
+                  {strategySuccessBarRows.map((entry) => (
+                    <Cell key={entry.strategyKey} fill={entry.fill} />
+                  ))}
+                </Bar>
+              </BarChart>
+            </ChartContainer>
+          )}
+        </CardContent>
+      </Card>
 
       <TooltipProvider>
         <div className="grid gap-4 md:grid-cols-2">

--- a/src/hooks/api/useTraceroutes.ts
+++ b/src/hooks/api/useTraceroutes.ts
@@ -62,16 +62,20 @@ export function useTracerouteTriggerableNodes() {
 
 export interface UseTracerouteStatsParams {
   triggeredAtAfter?: Date;
+  /** Meshtastic node id of source managed node; same as traceroute list ``source_node``. */
+  sourceNodeId?: number | null;
 }
 
 export function useTracerouteStats(params?: UseTracerouteStatsParams) {
   const api = useMeshtasticApi();
   const triggeredAtAfter = params?.triggeredAtAfter?.toISOString();
+  const sourceNode = params?.sourceNodeId ?? undefined;
   return useQuery({
-    queryKey: ['traceroutes', 'stats', { triggeredAtAfter }],
+    queryKey: ['traceroutes', 'stats', { triggeredAtAfter, sourceNode }],
     queryFn: () =>
       api.getTracerouteStats({
         triggered_at_after: triggeredAtAfter,
+        source_node: sourceNode,
       }),
   });
 }

--- a/src/lib/api/meshtastic-api.ts
+++ b/src/lib/api/meshtastic-api.ts
@@ -808,7 +808,7 @@ export class MeshtasticApi extends BaseApi {
   /**
    * Get traceroute statistics (sources, success/failure, top routers, by source, success over time)
    */
-  async getTracerouteStats(params?: { triggered_at_after?: string }): Promise<{
+  async getTracerouteStats(params?: { triggered_at_after?: string; source_node?: number }): Promise<{
     sources: Array<{ trigger_type: number; count: number }>;
     success_failure: Array<{ status: string; count: number }>;
     top_routers: Array<{ node_id: number; node_id_str: string; short_name: string; count: number }>;
@@ -835,10 +835,17 @@ export class MeshtasticApi extends BaseApi {
     }>;
     success_over_time: Array<{ date: string; completed: number; failed: number }>;
     by_strategy: Record<string, { completed: number; failed: number; pending: number; sent: number }>;
+    by_strategy_excluding_external: Record<
+      string,
+      { completed: number; failed: number; pending: number; sent: number }
+    >;
   }> {
     const searchParams = new URLSearchParams();
     if (params?.triggered_at_after) {
       searchParams.append('triggered_at_after', params.triggered_at_after);
+    }
+    if (params?.source_node != null) {
+      searchParams.append('source_node', String(params.source_node));
     }
     return this.get('/traceroutes/stats/', searchParams);
   }

--- a/src/lib/traceroute-strategy-success-chart.test.ts
+++ b/src/lib/traceroute-strategy-success-chart.test.ts
@@ -1,0 +1,49 @@
+import { describe, expect, it } from 'vitest';
+import {
+  STRATEGY_SUCCESS_BAR_ORDER,
+  buildStrategySuccessBarChartData,
+  type TracerouteStrategyStatCounts,
+} from './traceroute-strategy-success-chart';
+
+describe('buildStrategySuccessBarChartData', () => {
+  it('returns rows in stable order with zeros when by_strategy is empty', () => {
+    const rows = buildStrategySuccessBarChartData({});
+    expect(rows.map((r) => r.strategyKey)).toEqual([...STRATEGY_SUCCESS_BAR_ORDER]);
+    for (const r of rows) {
+      expect(r.completed).toBe(0);
+      expect(r.failed).toBe(0);
+      expect(r.success_pct).toBeNull();
+    }
+  });
+
+  it('computes success_pct from completed and failed only', () => {
+    const by: Record<string, TracerouteStrategyStatCounts> = {
+      intra_zone: { completed: 3, failed: 1, pending: 2, sent: 0 },
+    };
+    const rows = buildStrategySuccessBarChartData(by);
+    const intra = rows.find((r) => r.strategyKey === 'intra_zone');
+    expect(intra?.success_pct).toBeCloseTo(75, 5);
+    expect(intra?.completed).toBe(3);
+    expect(intra?.failed).toBe(1);
+  });
+
+  it('appends unknown strategy keys after the canonical order', () => {
+    const by: Record<string, TracerouteStrategyStatCounts> = {
+      zz_future: { completed: 1, failed: 0, pending: 0, sent: 0 },
+      intra_zone: { completed: 1, failed: 0, pending: 0, sent: 0 },
+    };
+    const keys = buildStrategySuccessBarChartData(by).map((r) => r.strategyKey);
+    expect(keys.slice(0, STRATEGY_SUCCESS_BAR_ORDER.length)).toEqual([...STRATEGY_SUCCESS_BAR_ORDER]);
+    expect(keys[keys.length - 1]).toBe('zz_future');
+  });
+
+  it('returns null success_pct when there are no finished runs', () => {
+    const by: Record<string, TracerouteStrategyStatCounts> = {
+      manual: { completed: 0, failed: 0, pending: 1, sent: 1 },
+    };
+    const manual = buildStrategySuccessBarChartData(by).find((r) => r.strategyKey === 'manual');
+    expect(manual?.success_pct).toBeNull();
+    expect(manual?.pending).toBe(1);
+    expect(manual?.sent).toBe(1);
+  });
+});

--- a/src/lib/traceroute-strategy-success-chart.ts
+++ b/src/lib/traceroute-strategy-success-chart.ts
@@ -1,0 +1,58 @@
+import { strategyLabel, type TracerouteStrategyDisplayValue } from '@/lib/traceroute-strategy';
+
+/** Counts per strategy from GET /traceroutes/stats/ (e.g. ``by_strategy_excluding_external`` for success bars). */
+export type TracerouteStrategyStatCounts = {
+  completed: number;
+  failed: number;
+  pending: number;
+  sent: number;
+};
+
+/** Stable column order; null target_strategy is aggregated under ``legacy`` where present in the payload. */
+export const STRATEGY_SUCCESS_BAR_ORDER: TracerouteStrategyDisplayValue[] = [
+  'intra_zone',
+  'dx_across',
+  'dx_same_side',
+  'legacy',
+  'manual',
+];
+
+const ZERO: TracerouteStrategyStatCounts = { completed: 0, failed: 0, pending: 0, sent: 0 };
+
+export type StrategySuccessBarRow = {
+  strategyKey: string;
+  label: string;
+  success_pct: number | null;
+} & TracerouteStrategyStatCounts;
+
+/** Row passed to Recharts after adding bar geometry and colour. */
+export type StrategySuccessBarChartRow = StrategySuccessBarRow & { barHeight: number; fill: string };
+
+/**
+ * Rows for a bar chart: one column per known strategy (even when zero runs), then any extra keys from the API.
+ */
+export function buildStrategySuccessBarChartData(
+  by_strategy: Record<string, TracerouteStrategyStatCounts> | undefined | null
+): StrategySuccessBarRow[] {
+  const raw = by_strategy ?? {};
+  const keys: string[] = [...STRATEGY_SUCCESS_BAR_ORDER];
+  const extras = Object.keys(raw)
+    .filter((k) => !keys.includes(k))
+    .sort();
+  keys.push(...extras);
+
+  return keys.map((strategyKey) => {
+    const c = raw[strategyKey] ?? ZERO;
+    const finished = c.completed + c.failed;
+    const success_pct = finished > 0 ? (100 * c.completed) / finished : null;
+    return {
+      strategyKey,
+      label: strategyLabel(strategyKey),
+      success_pct,
+      completed: c.completed,
+      failed: c.failed,
+      pending: c.pending,
+      sent: c.sent,
+    };
+  });
+}

--- a/src/pages/traceroutes/TracerouteHistory.tsx
+++ b/src/pages/traceroutes/TracerouteHistory.tsx
@@ -218,7 +218,7 @@ export function TracerouteHistory() {
         )}
       </div>
 
-      <TracerouteStatsSection />
+      <TracerouteStatsSection sourceNodeId={sourceNodeId} />
 
       <Card>
         <CardHeader>


### PR DESCRIPTION
## Summary

Closes / implements [Traceroutes page: add column chart of TR success % broken down by target selection strategy #199](https://github.com/pskillen/meshtastic-bot-ui/issues/199).

- **Success rate by strategy** column chart (Recharts) from `by_strategy_excluding_external` (external mesh reports omitted — no hypothesis).
- **Strategy mix** pie still uses `by_strategy` (external included).
- Optional stats scoping: `useTracerouteStats({ sourceNodeId })` wired from `TracerouteHistory` URL `source_node`.
- `buildStrategySuccessBarChartData` helper + vitest.

**Depends on:** merge and deploy [meshflow-api#260](https://github.com/pskillen/meshflow-api/pull/260) first so `by_strategy_excluding_external` is present (UI falls back to `by_strategy` for the bar if absent).

## Testing performed

- `npm test`, `npm run build`