### PR TITLE
feat(traceroutes): split stats and history routes (#247)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -12,6 +12,7 @@ src/
 │   ├── nodes/                 # NodesList, NodeDetails, ClaimNode, MyNodes, monitor
 │   ├── messages/              # MessageHistory
 │   ├── map/                   # NodeMap
+│   ├── traceroutes/           # TracerouteStatsPage, TracerouteHistory, heatmap/coverage pages
 │   ├── user/                  # UserPage, NodeSettings
 │   └── auth/                  # LoginPage, OAuthCallback
 ├── components/                # Reusable UI

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,5 +1,6 @@
 import { Suspense, lazy } from 'react';
 import { TracerouteHistory } from '@/pages/traceroutes/TracerouteHistory';
+import { TraceroutesLanding } from '@/pages/traceroutes/TraceroutesLanding';
 import { TracerouteHeatmapPage } from '@/pages/traceroutes/TracerouteHeatmapPage';
 import { TracerouteTopologyPage } from '@/pages/traceroutes/TracerouteTopologyPage';
 import { FeederCoveragePage } from '@/pages/traceroutes/FeederCoveragePage';
@@ -71,7 +72,8 @@ function App() {
                   <Route path="/nodes/:id" element={<NodeDetails />} />
                   <Route path="/map" element={<NodeMap />} />
                   <Route path="/messages" element={<MessageHistory />} />
-                  <Route path="/traceroutes" element={<TracerouteHistory />} />
+                  <Route path="/traceroutes/history" element={<TracerouteHistory />} />
+                  <Route path="/traceroutes" element={<TraceroutesLanding />} />
                   <Route path="/traceroutes/heatmap" element={<Navigate to="/traceroutes/map/heat" replace />} />
                   <Route
                     path="/traceroutes/topology"

--- a/src/components/nav-main.tsx
+++ b/src/components/nav-main.tsx
@@ -9,6 +9,7 @@ import {
   NetworkIcon,
   RadioIcon,
   RouteIcon,
+  ListIcon,
   ScanSearchIcon,
   ServerIcon,
   Share2,
@@ -53,6 +54,8 @@ function isPathActive(pathname: string, url: string, exact: boolean) {
 
 function navSubItemActive(pathname: string, childUrl: string): boolean {
   switch (childUrl) {
+    case '/traceroutes/history':
+      return pathname === '/traceroutes/history' || pathname.startsWith('/traceroutes/history/');
     case '/traceroutes/map/heat':
       return pathname === '/traceroutes/map/heat' || pathname === '/traceroutes/map/snr';
     case '/traceroutes/map/topology/heat':
@@ -102,6 +105,7 @@ export function NavMain() {
       url: '/traceroutes',
       icon: RouteIcon,
       children: [
+        { title: 'History', url: '/traceroutes/history', icon: ListIcon },
         { title: 'Geographic', url: '/traceroutes/map/heat', icon: MapIcon },
         { title: 'Topology', url: '/traceroutes/map/topology/heat', icon: Share2 },
         { title: 'Coverage by node', url: '/traceroutes/map/coverage', icon: CircleDashedIcon },

--- a/src/components/nodes/NodeOutgoingTraceroutesSection.tsx
+++ b/src/components/nodes/NodeOutgoingTraceroutesSection.tsx
@@ -163,7 +163,7 @@ export function NodeOutgoingTraceroutesSection({ nodeId, managed }: NodeOutgoing
                 </Table>
                 <div className="text-right">
                   <Link
-                    to={`/traceroutes?source_node=${nodeId}`}
+                    to={`/traceroutes/history?source_node=${nodeId}`}
                     className="text-sm text-teal-600 hover:underline dark:text-teal-400"
                   >
                     View all traceroutes from this feeder →

--- a/src/components/nodes/NodeTracerouteHistorySection.test.tsx
+++ b/src/components/nodes/NodeTracerouteHistorySection.test.tsx
@@ -249,6 +249,6 @@ describe('NodeTracerouteHistorySection', () => {
     setupHooks({ traceroutes: [makeTraceroute({ source_node: managed })], triggerableNodes: [managed] });
     renderSection(observed);
     const link = screen.getByRole('link', { name: /view all traceroutes to this node/i });
-    expect(link).toHaveAttribute('href', '/traceroutes?target_node=100');
+    expect(link).toHaveAttribute('href', '/traceroutes/history?target_node=100');
   });
 });

--- a/src/components/nodes/NodeTracerouteHistorySection.tsx
+++ b/src/components/nodes/NodeTracerouteHistorySection.tsx
@@ -183,7 +183,7 @@ export function NodeTracerouteHistorySection({ nodeId, observedNode }: NodeTrace
               </Table>
               <div className="mt-4 text-right">
                 <Link
-                  to={`/traceroutes?target_node=${nodeId}`}
+                  to={`/traceroutes/history?target_node=${nodeId}`}
                   className="text-sm text-teal-600 dark:text-teal-400 hover:underline"
                 >
                   View all traceroutes to this node →

--- a/src/components/nodes/WatchedNodesTable.tsx
+++ b/src/components/nodes/WatchedNodesTable.tsx
@@ -341,7 +341,7 @@ function WatchCard({
             {status === 'battery_low' ? (
               <>
                 Low battery watch — traceroute history is hidden while the node is otherwise online.{' '}
-                <Link to="/traceroutes" className="text-teal-600 dark:text-teal-400 hover:underline">
+                <Link to="/traceroutes/history" className="text-teal-600 dark:text-teal-400 hover:underline">
                   Open full traceroute history
                 </Link>
                 .
@@ -349,7 +349,7 @@ function WatchCard({
             ) : (
               <>
                 Node is currently online; traceroute history is hidden here.{' '}
-                <Link to="/traceroutes" className="text-teal-600 dark:text-teal-400 hover:underline">
+                <Link to="/traceroutes/history" className="text-teal-600 dark:text-teal-400 hover:underline">
                   Open full traceroute history
                 </Link>
                 .
@@ -397,7 +397,7 @@ export function WatchedNodesTable({
         <CardTitle className="flex items-center gap-2">Watched nodes</CardTitle>
         <CardDescription>
           Mesh monitoring watches for your account, grouped by status. Offline and verifying nodes are listed first.{' '}
-          <Link to="/traceroutes" className="text-teal-600 dark:text-teal-400 hover:underline">
+          <Link to="/traceroutes/history" className="text-teal-600 dark:text-teal-400 hover:underline">
             Open full traceroute history
           </Link>
           .

--- a/src/components/traceroutes/TracerouteStatsSection.tsx
+++ b/src/components/traceroutes/TracerouteStatsSection.tsx
@@ -670,7 +670,7 @@ function TargetsRankingCard({
                   <TableRow key={row.node_id}>
                     <TableCell>
                       <Link
-                        to={`/traceroutes?target_node=${row.node_id}`}
+                        to={`/traceroutes/history?target_node=${row.node_id}`}
                         className="flex flex-col gap-0.5 min-w-0 hover:underline"
                       >
                         <span className="font-medium truncate" title={row.short_name ?? row.node_id_str}>

--- a/src/lib/dx-exploration.test.ts
+++ b/src/lib/dx-exploration.test.ts
@@ -10,11 +10,11 @@ describe('dx-exploration', () => {
 
   it('builds traceroute history links with optional source and trigger filter', () => {
     expect(buildDxTracerouteHistoryLink({ targetNodeId: 99, sourceNodeId: 1, triggerFilter: 'dx_watch' })).toBe(
-      `/traceroutes?target_node=99&source_node=1&trigger_type=${TRIGGER_TYPE_DX_WATCH}`
+      `/traceroutes/history?target_node=99&source_node=1&trigger_type=${TRIGGER_TYPE_DX_WATCH}`
     );
     expect(buildDxTracerouteHistoryLink({ targetNodeId: 99, triggerFilter: 'new_node_baseline' })).toBe(
-      `/traceroutes?target_node=99&trigger_type=${TRIGGER_TYPE_NEW_NODE_BASELINE}`
+      `/traceroutes/history?target_node=99&trigger_type=${TRIGGER_TYPE_NEW_NODE_BASELINE}`
     );
-    expect(buildDxTracerouteHistoryLink({ targetNodeId: 42 })).toBe('/traceroutes?target_node=42');
+    expect(buildDxTracerouteHistoryLink({ targetNodeId: 42 })).toBe('/traceroutes/history?target_node=42');
   });
 });

--- a/src/lib/dx-exploration.ts
+++ b/src/lib/dx-exploration.ts
@@ -36,5 +36,5 @@ export function buildDxTracerouteHistoryLink(params: {
   if (params.triggerFilter === 'new_node_baseline') {
     sp.set('trigger_type', String(TRIGGER_TYPE_NEW_NODE_BASELINE));
   }
-  return `/traceroutes?${sp.toString()}`;
+  return `/traceroutes/history?${sp.toString()}`;
 }

--- a/src/pages/traceroutes/FeederCoveragePage.tsx
+++ b/src/pages/traceroutes/FeederCoveragePage.tsx
@@ -340,7 +340,7 @@ export function FeederCoveragePage() {
                 <span>Failed to load coverage: {error instanceof Error ? error.message : 'Unknown error'}</span>
                 <Button type="button" variant="outline" size="sm" asChild>
                   <Link to="/traceroutes">
-                    <RouteIcon className="mr-1 h-4 w-4" /> Back to traceroutes
+                    <RouteIcon className="mr-1 h-4 w-4" /> Back to traceroute stats
                   </Link>
                 </Button>
               </div>

--- a/src/pages/traceroutes/TracerouteHistory.test.tsx
+++ b/src/pages/traceroutes/TracerouteHistory.test.tsx
@@ -16,10 +16,6 @@ vi.mock('@/hooks/api/useNodes', () => ({
   useManagedNodesSuspense: vi.fn(),
 }));
 
-vi.mock('@/components/traceroutes/TracerouteStatsSection', () => ({
-  TracerouteStatsSection: () => <div data-testid="stats-section" />,
-}));
-
 vi.mock('@/pages/traceroutes/TracerouteDetailModal', () => ({
   TracerouteDetailModal: ({ tracerouteId, open }: { tracerouteId: number | null; open: boolean }) =>
     open ? <div role="dialog" data-testid="detail-modal">Detail for {tracerouteId}</div> : null,
@@ -163,7 +159,7 @@ describe('TracerouteHistory', () => {
 
   it('hydrates target_node from the URL into the query params', () => {
     setupHooks();
-    renderAt('/traceroutes?target_node=1127903080');
+    renderAt('/traceroutes/history?target_node=1127903080');
     expect(mockedUseInfinite).toHaveBeenCalledWith(
       expect.objectContaining({ target_node: 1127903080 })
     );
@@ -171,7 +167,7 @@ describe('TracerouteHistory', () => {
 
   it('hydrates target_node and status (CSV) from the URL', () => {
     setupHooks();
-    renderAt('/traceroutes?target_node=42&status=completed,failed');
+    renderAt('/traceroutes/history?target_node=42&status=completed,failed');
     expect(mockedUseInfinite).toHaveBeenCalledWith(
       expect.objectContaining({ target_node: 42, status: 'completed,failed' })
     );
@@ -179,7 +175,7 @@ describe('TracerouteHistory', () => {
 
   it('hydrates trigger_type CSV from the URL', () => {
     setupHooks();
-    renderAt('/traceroutes?trigger_type=user,monitor');
+    renderAt('/traceroutes/history?trigger_type=user,monitor');
     expect(mockedUseInfinite).toHaveBeenCalledWith(
       expect.objectContaining({ trigger_type: 'user,monitor' })
     );
@@ -187,7 +183,7 @@ describe('TracerouteHistory', () => {
 
   it('hydrates strategy CSV from the URL into target_strategy', () => {
     setupHooks();
-    renderAt('/traceroutes?strategy=intra_zone,dx_across');
+    renderAt('/traceroutes/history?strategy=intra_zone,dx_across');
     expect(mockedUseInfinite).toHaveBeenCalledWith(
       expect.objectContaining({ target_strategy: 'intra_zone,dx_across' })
     );
@@ -195,7 +191,7 @@ describe('TracerouteHistory', () => {
 
   it('passes unknown filter values through to the API (graceful)', () => {
     setupHooks();
-    renderAt('/traceroutes?status=bogus_value&target_node=999999999');
+    renderAt('/traceroutes/history?status=bogus_value&target_node=999999999');
     expect(mockedUseInfinite).toHaveBeenCalledWith(
       expect.objectContaining({ status: 'bogus_value', target_node: 999999999 })
     );
@@ -203,29 +199,29 @@ describe('TracerouteHistory', () => {
 
   it('shows the Trigger CTA when the user has triggerable nodes', () => {
     setupHooks({}, [makeManagedNode()]);
-    renderAt('/traceroutes');
+    renderAt('/traceroutes/history');
     expect(screen.getByRole('button', { name: /trigger traceroute/i })).toBeInTheDocument();
   });
 
   it('hides the Trigger CTA when the user has no triggerable nodes', () => {
     setupHooks({}, []);
-    renderAt('/traceroutes');
+    renderAt('/traceroutes/history');
     expect(screen.queryByRole('button', { name: /^trigger traceroute$/i })).not.toBeInTheDocument();
   });
 
   it('shows a "Clear filters" button only when at least one filter is set', () => {
     setupHooks();
-    const { unmount } = renderAt('/traceroutes');
+    const { unmount } = renderAt('/traceroutes/history');
     expect(screen.queryByRole('button', { name: /clear filters/i })).not.toBeInTheDocument();
     unmount();
 
-    renderAt('/traceroutes?target_node=42');
+    renderAt('/traceroutes/history?target_node=42');
     expect(screen.getByRole('button', { name: /clear filters/i })).toBeInTheDocument();
   });
 
   it('renders Load more disabled when there is no next page', () => {
     setupHooks({ traceroutes: [makeTraceroute()], hasNextPage: false });
-    renderAt('/traceroutes');
+    renderAt('/traceroutes/history');
     const btn = screen.getByRole('button', { name: /no more results/i });
     expect(btn).toBeDisabled();
   });
@@ -237,20 +233,20 @@ describe('TracerouteHistory', () => {
       hasNextPage: true,
       fetchNextPage,
     });
-    renderAt('/traceroutes');
+    renderAt('/traceroutes/history');
     fireEvent.click(screen.getByRole('button', { name: /load more/i }));
     expect(fetchNextPage).toHaveBeenCalled();
   });
 
   it('shows the total count in the table title when available', () => {
     setupHooks({ traceroutes: [makeTraceroute()], totalCount: 73 });
-    renderAt('/traceroutes');
+    renderAt('/traceroutes/history');
     expect(screen.getByText('(73)')).toBeInTheDocument();
   });
 
   it('applies the "Show successful" preset to status filter when clicked', () => {
     setupHooks();
-    renderAt('/traceroutes');
+    renderAt('/traceroutes/history');
     fireEvent.click(screen.getByRole('button', { name: /show successful/i }));
     const lastCall = mockedUseInfinite.mock.calls.at(-1)?.[0];
     expect(lastCall).toEqual(expect.objectContaining({ status: 'completed,pending,sent' }));
@@ -258,7 +254,7 @@ describe('TracerouteHistory', () => {
 
   it('clears status when "Show successful" is clicked while already active', () => {
     setupHooks();
-    renderAt('/traceroutes?status=completed,pending,sent');
+    renderAt('/traceroutes/history?status=completed,pending,sent');
     fireEvent.click(screen.getByRole('button', { name: /show successful/i }));
     const lastCall = mockedUseInfinite.mock.calls.at(-1)?.[0];
     expect(lastCall?.status).toBeUndefined();
@@ -266,7 +262,7 @@ describe('TracerouteHistory', () => {
 
   it('applies the "Monitoring TRs" preset to trigger_type when clicked', () => {
     setupHooks();
-    renderAt('/traceroutes');
+    renderAt('/traceroutes/history');
     fireEvent.click(screen.getByRole('button', { name: /monitoring trs/i }));
     const lastCall = mockedUseInfinite.mock.calls.at(-1)?.[0];
     expect(lastCall).toEqual(expect.objectContaining({ trigger_type: '4' }));
@@ -274,7 +270,7 @@ describe('TracerouteHistory', () => {
 
   it('applies the "Manually triggered" preset to trigger_type when clicked', () => {
     setupHooks();
-    renderAt('/traceroutes');
+    renderAt('/traceroutes/history');
     fireEvent.click(screen.getByRole('button', { name: /manually triggered/i }));
     const lastCall = mockedUseInfinite.mock.calls.at(-1)?.[0];
     expect(lastCall).toEqual(expect.objectContaining({ trigger_type: '1' }));
@@ -287,7 +283,7 @@ describe('TracerouteHistory', () => {
       makeObservedNode({ node_id: 3, node_id_str: '!00000003', short_name: 'CCC', long_name: 'Charlie' }),
     ];
     setupHooks({}, [], nodes);
-    renderAt('/traceroutes');
+    renderAt('/traceroutes/history');
 
     fireEvent.click(screen.getByRole('button', { name: /target \(recipient\)/i }));
 
@@ -308,7 +304,7 @@ describe('TracerouteHistory', () => {
       makeObservedNode({ node_id: 555, node_id_str: '!0000022b', short_name: 'PICKME', long_name: 'Pick me' }),
     ];
     setupHooks({}, [], nodes);
-    renderAt('/traceroutes');
+    renderAt('/traceroutes/history');
 
     fireEvent.click(screen.getByRole('button', { name: /target \(recipient\)/i }));
     fireEvent.click(screen.getByRole('button', { name: /pickme/i }));
@@ -332,7 +328,7 @@ describe('TracerouteHistory', () => {
         }),
       ],
     });
-    renderAt('/traceroutes');
+    renderAt('/traceroutes/history');
     expect(screen.getByText('Queued')).toBeInTheDocument();
     expect(screen.getByText(/^Due /)).toBeInTheDocument();
   });
@@ -352,7 +348,7 @@ describe('TracerouteHistory', () => {
         }),
       ],
     });
-    renderAt('/traceroutes');
+    renderAt('/traceroutes/history');
     expect(screen.getByText('In flight')).toBeInTheDocument();
     expect(screen.getByText(/^Sent /)).toBeInTheDocument();
   });
@@ -360,7 +356,7 @@ describe('TracerouteHistory', () => {
   it('status filter dropdown uses Queued and In flight labels', async () => {
     const user = userEvent.setup();
     setupHooks();
-    renderAt('/traceroutes');
+    renderAt('/traceroutes/history');
     await user.click(screen.getByRole('button', { name: /^Status$/i }));
     expect(await screen.findByRole('menuitemcheckbox', { name: /^Queued$/i })).toBeInTheDocument();
     expect(screen.getByRole('menuitemcheckbox', { name: /^In flight$/i })).toBeInTheDocument();

--- a/src/pages/traceroutes/TracerouteHistory.tsx
+++ b/src/pages/traceroutes/TracerouteHistory.tsx
@@ -1,6 +1,6 @@
 import { useEffect, useMemo, useRef, useState } from 'react';
 import { format, subDays } from 'date-fns';
-import { useSearchParams } from 'react-router-dom';
+import { Link, useSearchParams } from 'react-router-dom';
 import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card';
 import { Button } from '@/components/ui/button';
 import { Input } from '@/components/ui/input';
@@ -21,7 +21,6 @@ import { useManagedNodesSuspense, useNodesSuspense } from '@/hooks/api/useNodes'
 import { TriggerTracerouteModal, TriggerMode } from './TriggerTracerouteModal';
 import { TracerouteDetailModal } from './TracerouteDetailModal';
 import { getTracerouteErrorMessage } from './tracerouteErrors';
-import { TracerouteStatsSection } from '@/components/traceroutes/TracerouteStatsSection';
 import { StrategyBadge } from '@/components/traceroutes/StrategyBadge';
 import { TracerouteQueueDispatchCell } from '@/components/traceroutes/TracerouteQueueDispatchCell';
 import { TracerouteStatusBadge } from '@/components/traceroutes/TracerouteStatusBadge';
@@ -205,20 +204,26 @@ export function TracerouteHistory() {
 
   return (
     <div className="container mx-auto py-6 space-y-6">
-      <div className="flex flex-row items-center justify-between gap-4">
+      <div className="flex flex-row items-center justify-between gap-4 flex-wrap">
         <h1 className="text-2xl font-semibold flex items-center gap-2">
           <RouteIcon className="h-6 w-6" />
           Traceroute history
         </h1>
-        {canTrigger && (
-          <Button size="default" onClick={() => setTriggerModalOpen(true)}>
-            <RouteIcon className="mr-2 h-4 w-4" />
-            Trigger traceroute
+        <div className="flex flex-wrap items-center gap-2">
+          <Button variant="outline" size="default" asChild>
+            <Link to="/traceroutes">
+              <RouteIcon className="mr-2 h-4 w-4" />
+              Statistics
+            </Link>
           </Button>
-        )}
+          {canTrigger && (
+            <Button size="default" onClick={() => setTriggerModalOpen(true)}>
+              <RouteIcon className="mr-2 h-4 w-4" />
+              Trigger traceroute
+            </Button>
+          )}
+        </div>
       </div>
-
-      <TracerouteStatsSection sourceNodeId={sourceNodeId} />
 
       <Card>
         <CardHeader>

--- a/src/pages/traceroutes/TracerouteStatsPage.tsx
+++ b/src/pages/traceroutes/TracerouteStatsPage.tsx
@@ -1,0 +1,119 @@
+import { useMemo, useState } from 'react';
+import { Link, useSearchParams } from 'react-router-dom';
+import { subDays } from 'date-fns';
+import { Button } from '@/components/ui/button';
+import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from '@/components/ui/select';
+import { toast } from 'sonner';
+import { ListIcon, RouteIcon } from 'lucide-react';
+import { TracerouteStatsSection } from '@/components/traceroutes/TracerouteStatsSection';
+import { useTracerouteTriggerableNodesSuspense, useTriggerTraceroute } from '@/hooks/api/useTraceroutes';
+import { useManagedNodesSuspense, useNodesSuspense } from '@/hooks/api/useNodes';
+import { TriggerTracerouteModal, TriggerMode } from './TriggerTracerouteModal';
+import { getTracerouteErrorMessage } from './tracerouteErrors';
+
+function parseNumberParam(raw: string | null): number | null {
+  if (!raw) return null;
+  const n = parseInt(raw, 10);
+  return Number.isFinite(n) ? n : null;
+}
+
+export function TracerouteStatsPage() {
+  const [searchParams, setSearchParams] = useSearchParams();
+  const sourceNodeId = parseNumberParam(searchParams.get('source_node'));
+
+  const setSourceNode = (id: number | null) => {
+    const next = new URLSearchParams(searchParams);
+    if (id == null) {
+      next.delete('source_node');
+    } else {
+      next.set('source_node', String(id));
+    }
+    setSearchParams(next, { replace: true });
+  };
+
+  const [triggerModalOpen, setTriggerModalOpen] = useState(false);
+
+  const { triggerableNodes } = useTracerouteTriggerableNodesSuspense();
+  const { managedNodes } = useManagedNodesSuspense({
+    pageSize: 500,
+    includeStatus: true,
+    includeGeoClassification: true,
+  });
+  const managedByMeshId = useMemo(() => new Map(managedNodes.map((m) => [m.node_id, m])), [managedNodes]);
+  const modalManagedNodes = useMemo(
+    () =>
+      triggerableNodes.map((t) => {
+        const full = managedByMeshId.get(t.node_id);
+        return full ? { ...t, ...full } : t;
+      }),
+    [triggerableNodes, managedByMeshId]
+  );
+  const canTrigger = triggerableNodes.length > 0;
+  const { nodes: observedNodes } = useNodesSuspense({
+    lastHeardAfter: subDays(new Date(), 7),
+    pageSize: 500,
+  });
+  const triggerMutation = useTriggerTraceroute();
+
+  return (
+    <div className="container mx-auto py-6 space-y-6">
+      <div className="flex flex-row items-center justify-between gap-4 flex-wrap">
+        <h1 className="text-2xl font-semibold flex items-center gap-2">
+          <RouteIcon className="h-6 w-6" />
+          Traceroute statistics
+        </h1>
+        <div className="flex flex-wrap items-center gap-2">
+          <Select
+            value={sourceNodeId != null ? String(sourceNodeId) : 'all'}
+            onValueChange={(v) => setSourceNode(v === 'all' ? null : parseInt(v, 10))}
+          >
+            <SelectTrigger className="w-[200px]">
+              <SelectValue placeholder="Source (stats scope)" />
+            </SelectTrigger>
+            <SelectContent>
+              <SelectItem value="all">All sources</SelectItem>
+              {triggerableNodes.map((n) => (
+                <SelectItem key={n.node_id} value={String(n.node_id)}>
+                  {n.short_name ?? n.node_id_str ?? String(n.node_id)}
+                </SelectItem>
+              ))}
+            </SelectContent>
+          </Select>
+          <Button variant="outline" size="default" asChild>
+            <Link to="/traceroutes/history">
+              <ListIcon className="mr-2 h-4 w-4" />
+              Traceroute history
+            </Link>
+          </Button>
+          {canTrigger && (
+            <Button size="default" onClick={() => setTriggerModalOpen(true)}>
+              <RouteIcon className="mr-2 h-4 w-4" />
+              Trigger traceroute
+            </Button>
+          )}
+        </div>
+      </div>
+
+      <TracerouteStatsSection sourceNodeId={sourceNodeId} />
+
+      <TriggerTracerouteModal
+        open={triggerModalOpen}
+        onOpenChange={setTriggerModalOpen}
+        mode={'user' as TriggerMode}
+        managedNodes={modalManagedNodes}
+        observedNodes={observedNodes}
+        onTrigger={async (managedNodeId, targetNodeId, targetStrategy) => {
+          try {
+            await triggerMutation.mutateAsync({ managedNodeId, targetNodeId, targetStrategy });
+            setTriggerModalOpen(false);
+          } catch (err) {
+            toast.error('Traceroute failed', {
+              description: getTracerouteErrorMessage(err),
+            });
+          }
+        }}
+        isSubmitting={triggerMutation.isPending}
+      />
+    </div>
+  );
+}

--- a/src/pages/traceroutes/TraceroutesLanding.test.tsx
+++ b/src/pages/traceroutes/TraceroutesLanding.test.tsx
@@ -1,0 +1,59 @@
+import { describe, it, expect, vi } from 'vitest';
+import { render, screen } from '@testing-library/react';
+import { MemoryRouter, Route, Routes } from 'react-router-dom';
+import { TraceroutesLanding } from './TraceroutesLanding';
+
+vi.mock('@/pages/traceroutes/TracerouteStatsPage', () => ({
+  TracerouteStatsPage: () => <div data-testid="stats-page">Stats</div>,
+}));
+
+describe('TraceroutesLanding', () => {
+  it('redirects legacy history query URLs to /traceroutes/history', () => {
+    render(
+      <MemoryRouter initialEntries={['/traceroutes?target_node=1']}>
+        <Routes>
+          <Route path="/traceroutes" element={<TraceroutesLanding />} />
+          <Route path="/traceroutes/history" element={<div data-testid="history-page">History</div>} />
+        </Routes>
+      </MemoryRouter>
+    );
+    expect(screen.getByTestId('history-page')).toBeInTheDocument();
+  });
+
+  it('renders stats page when there are no history filter query keys', () => {
+    render(
+      <MemoryRouter initialEntries={['/traceroutes']}>
+        <Routes>
+          <Route path="/traceroutes" element={<TraceroutesLanding />} />
+          <Route path="/traceroutes/history" element={<div data-testid="history-page">History</div>} />
+        </Routes>
+      </MemoryRouter>
+    );
+    expect(screen.getByTestId('stats-page')).toBeInTheDocument();
+  });
+
+  it('keeps stats page when only source_node is present (stats scope, not history redirect)', () => {
+    render(
+      <MemoryRouter initialEntries={['/traceroutes?source_node=42']}>
+        <Routes>
+          <Route path="/traceroutes" element={<TraceroutesLanding />} />
+          <Route path="/traceroutes/history" element={<div data-testid="history-page">History</div>} />
+        </Routes>
+      </MemoryRouter>
+    );
+    expect(screen.getByTestId('stats-page')).toBeInTheDocument();
+    expect(screen.queryByTestId('history-page')).not.toBeInTheDocument();
+  });
+
+  it('still redirects when source_node is combined with a history-only key', () => {
+    render(
+      <MemoryRouter initialEntries={['/traceroutes?source_node=1&target_node=2']}>
+        <Routes>
+          <Route path="/traceroutes" element={<TraceroutesLanding />} />
+          <Route path="/traceroutes/history" element={<div data-testid="history-page">History</div>} />
+        </Routes>
+      </MemoryRouter>
+    );
+    expect(screen.getByTestId('history-page')).toBeInTheDocument();
+  });
+});

--- a/src/pages/traceroutes/TraceroutesLanding.tsx
+++ b/src/pages/traceroutes/TraceroutesLanding.tsx
@@ -1,0 +1,28 @@
+import { Navigate, useLocation } from 'react-router-dom';
+import { TracerouteStatsPage } from '@/pages/traceroutes/TracerouteStatsPage';
+
+/**
+ * Query keys that imply the traceroute *history* table (legacy /traceroutes?… bookmarks).
+ * `source_node` is intentionally omitted: it scopes the stats page at `/traceroutes` and must not redirect.
+ */
+const HISTORY_QUERY_KEYS = new Set(['target_node', 'status', 'trigger_type', 'strategy']);
+
+function searchLooksLikeHistoryFilters(search: string): boolean {
+  const qs = new URLSearchParams(search.startsWith('?') ? search.slice(1) : search);
+  for (const key of qs.keys()) {
+    if (HISTORY_QUERY_KEYS.has(key)) return true;
+  }
+  return false;
+}
+
+/**
+ * `/traceroutes` root: stats landing, unless the URL carries history-table filter params
+ * (`target_node`, `status`, `trigger_type`, `strategy`); then redirect to `/traceroutes/history`.
+ */
+export function TraceroutesLanding() {
+  const { search } = useLocation();
+  if (search && searchLooksLikeHistoryFilters(search)) {
+    return <Navigate to={{ pathname: '/traceroutes/history', search }} replace />;
+  }
+  return <TracerouteStatsPage />;
+}


### PR DESCRIPTION
## Summary

Implements traceroute **statistics** vs **history** routing (#247):

- **`/traceroutes`** — Stats home: `TraceroutesLanding` renders `TracerouteStatsPage` with `TracerouteStatsSection`, optional `source_node` in the URL, and trigger modal. Legacy bookmarks that used **table-only** query keys (`target_node`, `status`, `trigger_type`, `strategy`) redirect to `/traceroutes/history` with the same search string. `source_node` alone stays on stats so the source filter does not bounce to history.
- **`/traceroutes/history`** — Infinite history table, filters, modals, and trigger; stats block removed; link to statistics on `/traceroutes`.
- **Sidebar** — Traceroutes parent unchanged; **History** child under Traceroutes.
- **Deep links** — `buildDxTracerouteHistoryLink` and node/watch UI links target `/traceroutes/history` where appropriate; Feeder coverage back link remains `/traceroutes` with clearer label.
- **`AGENTS.md`** — Documents `pages/traceroutes/`.

Closes #247.

## Testing performed

- `npm run format`
- `npm test` (250 tests, all passing)
- Commit hook ran `eslint` (warnings only, pre-existing) and `vitest`