### PR TITLE
chore: rename tidy — meshtastic-bot-ui → meshflow-ui

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,4 +1,4 @@
-# Meshtastic Bot UI – Agent Context
+# Meshflow UI – Agent Context
 
 React SPA frontend for the Meshflow system. Displays and manages a country-wide mesh of Meshtastic nodes. Works with the meshflow-api Django backend.
 

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
-# MeshtasticBotUI
+# Meshflow UI
 
-A React-based user interface for the MeshtasticBot project.
+A React-based user interface for the Meshflow system.
 
 ## Development
 
@@ -113,7 +113,7 @@ Images are automatically built and pushed to GitHub Container Registry (ghcr.io)
 ## Project Structure
 
 ```
-MeshtasticBotUI/
+MeshflowUI/
 ├── src/                # Source code
 │   ├── components/     # React components
 │   ├── types/         # TypeScript type definitions

--- a/docs/RELEASE.md
+++ b/docs/RELEASE.md
@@ -1,6 +1,6 @@
 # Release Process
 
-This document describes how Docker images are built and pushed to GitHub Container Registry (ghcr.io) for the Meshtastic Bot UI.
+This document describes how Docker images are built and pushed to GitHub Container Registry (ghcr.io) for Meshflow UI.
 
 ## Release Triggers
 
@@ -71,14 +71,14 @@ Use this to build and push from the current `main` branch without merging new co
 
 ```bash
 # Latest production
-docker pull ghcr.io/pskillen/meshtastic-bot-ui:latest
+docker pull ghcr.io/pskillen/meshflow-ui:latest
 
 # Specific version
-docker pull ghcr.io/pskillen/meshtastic-bot-ui:1.2.3
+docker pull ghcr.io/pskillen/meshflow-ui:1.2.3
 
 # Latest dev build
-docker pull ghcr.io/pskillen/meshtastic-bot-ui:latest-dev
+docker pull ghcr.io/pskillen/meshflow-ui:latest-dev
 
 # Latest release candidate
-docker pull ghcr.io/pskillen/meshtastic-bot-ui:latest-rc
+docker pull ghcr.io/pskillen/meshflow-ui:latest-rc
 ```

--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "meshtastic-bot-ui",
+  "name": "meshflow-ui",
   "private": true,
   "version": "0.0.0",
   "type": "module",

--- a/src/components/nodes/BotSetupInstructions.test.tsx
+++ b/src/components/nodes/BotSetupInstructions.test.tsx
@@ -6,7 +6,7 @@ function getEmbeddedDockerComposeContent(container: HTMLElement): string {
   const pres = container.querySelectorAll('pre');
   for (const pre of pres) {
     const text = pre.textContent || '';
-    if (text.includes('STORAGE_API_TOKEN=test-key') && text.includes('meshtastic-bot:')) {
+    if (text.includes('STORAGE_API_TOKEN=test-key') && text.includes('meshflow-bot:')) {
       return text;
     }
   }

--- a/src/components/nodes/BotSetupInstructions.tsx
+++ b/src/components/nodes/BotSetupInstructions.tsx
@@ -51,9 +51,9 @@ function generateDockerComposeEmbedded(apiBaseUrl: string, apiKey: string, botDe
   const botEnvBlock = botEnvLines.length > 0 ? '\n' + botEnvLines.join('\n') : '';
   return `---
 services:
-  meshtastic-bot:
-    image: ghcr.io/pskillen/meshtastic-bot:latest
-    container_name: meshtastic-bot
+  meshflow-bot:
+    image: ghcr.io/pskillen/meshflow-bot:latest
+    container_name: meshflow-bot
     restart: unless-stopped
     environment:
       - MESHTASTIC_IP=meshtastic.local   # Use hostname (e.g. meshtastic.local) or IP if your node has WiFi
@@ -73,7 +73,7 @@ services:
     restart: unless-stopped
     volumes:
       - /var/run/docker.sock:/var/run/docker.sock
-    command: --interval 3600 meshtastic-bot
+    command: --interval 3600 meshflow-bot
 `;
 }
 
@@ -81,9 +81,9 @@ function generateDockerComposeSeparate(): string {
   return `---
 # Place .env in this directory with STORAGE_API_ROOT, STORAGE_API_TOKEN, etc.
 services:
-  meshtastic-bot:
-    image: ghcr.io/pskillen/meshtastic-bot:latest
-    container_name: meshtastic-bot
+  meshflow-bot:
+    image: ghcr.io/pskillen/meshflow-bot:latest
+    container_name: meshflow-bot
     restart: unless-stopped
     env_file: .env
     volumes:
@@ -97,7 +97,7 @@ services:
     restart: unless-stopped
     volumes:
       - /var/run/docker.sock:/var/run/docker.sock
-    command: --interval 3600 meshtastic-bot
+    command: --interval 3600 meshflow-bot
 `;
 }
 
@@ -105,7 +105,7 @@ function generateEnvFile(apiBaseUrl: string, apiKey: string, botDefaults?: BotDe
   const wsUrl = deriveWsUrl(apiBaseUrl);
   const botEnvLines = buildBotEnvVarsForEnvFile(botDefaults);
   const botEnvBlock = botEnvLines.length > 0 ? '\n\n' + botEnvLines.join('\n') : '';
-  return `# Meshtastic Bot configuration
+  return `# Meshflow Bot configuration
 # Copy this file to .env in the same directory as docker-compose.yaml
 
 MESHTASTIC_IP=meshtastic.local
@@ -245,13 +245,13 @@ export function BotSetupInstructions({ apiKey, apiBaseUrl, botDefaults }: BotSet
 
       <div className="pt-2">
         <a
-          href="https://github.com/pskillen/meshtastic-bot"
+          href="https://github.com/pskillen/meshflow-bot"
           target="_blank"
           rel="noopener noreferrer"
           className="inline-flex items-center text-sm text-primary hover:underline"
         >
           <ExternalLink className="h-4 w-4 mr-1" />
-          Meshtastic Bot on GitHub
+          Meshflow Bot on GitHub
         </a>
       </div>
     </div>


### PR DESCRIPTION
## Summary

- Update `package.json` name: `meshtastic-bot-ui` → `meshflow-ui`
- Update `README.md` and `AGENTS.md` headings and descriptions to Meshflow branding
- Update `.github/workflows/docker-build.yaml` package name: `meshtastic-bot-ui` → `meshflow-ui`
- Update `.github/workflows/pull-request.yaml` container names (2×): `meshtastic-bot-ui` → `meshflow-ui`
- Update `docs/RELEASE.md` Docker pull examples (4×)
- Update `src/components/nodes/BotSetupInstructions.tsx` bot image/container names and GitHub link: `meshtastic-bot` → `meshflow-bot`
- Update `src/components/nodes/BotSetupInstructions.test.tsx` test strings to match

Part of the cleanup from the repo rename (`meshtastic-bot-ui` → `meshflow-ui`). Related: pskillen/meshflow-api#270.

## Testing performed

- `grep -r "meshtastic-bot" src/ package.json .github/ docs/` returns no matches
- Existing unit tests pass (`BotSetupInstructions.test.tsx` updated to match new image names)