### PR TITLE
feat(meshcore): Phase 1 — MeshCore map and nodes list

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -30,6 +30,8 @@ import { ProtectedRoute } from '@/components/auth/ProtectedRoute';
 import { AppLayout } from '@/components/layouts/AppLayout';
 import MonitorNodes from '@/pages/nodes/monitor';
 import DxMonitoringPage from '@/pages/nodes/DxMonitoringPage';
+import { MeshCoreMap } from '@/pages/meshcore/MeshCoreMap';
+import { MeshCoreNodesList } from '@/pages/meshcore/MeshCoreNodesList';
 
 const ManagedNodesStatus = lazy(() => import('@/pages/nodes/ManagedNodesStatus'));
 
@@ -71,6 +73,8 @@ function App() {
                   <Route path="/nodes/:id/claim" element={<ClaimNode />} />
                   <Route path="/nodes/:id" element={<NodeDetails />} />
                   <Route path="/map" element={<NodeMap />} />
+                  <Route path="/meshcore/map" element={<MeshCoreMap />} />
+                  <Route path="/meshcore/nodes" element={<MeshCoreNodesList />} />
                   <Route path="/messages" element={<MessageHistory />} />
                   <Route path="/traceroutes/history" element={<TracerouteHistory />} />
                   <Route path="/traceroutes" element={<TraceroutesLanding />} />

--- a/src/components/nav-main.tsx
+++ b/src/components/nav-main.tsx
@@ -99,6 +99,15 @@ export function NavMain() {
         { title: 'Mesh infra', url: '/nodes/infrastructure', icon: ServerIcon },
       ],
     },
+    {
+      title: 'MeshCore',
+      url: '/meshcore/map',
+      icon: RadioIcon,
+      children: [
+        { title: 'Map', url: '/meshcore/map', icon: MapIcon },
+        { title: 'Nodes', url: '/meshcore/nodes', icon: ListIcon },
+      ],
+    },
     { title: 'Weather', url: '/weather', icon: CloudRainIcon },
     {
       title: 'Traceroutes',

--- a/src/hooks/api/useMeshCore.ts
+++ b/src/hooks/api/useMeshCore.ts
@@ -1,0 +1,56 @@
+import { useSuspenseInfiniteQuery, useSuspenseQuery } from '@tanstack/react-query';
+import React from 'react';
+import { useMeshtasticApi } from './useApi';
+import { ObservedNode, PaginatedResponse } from '@/lib/models';
+
+export interface UseMeshCoreNodesOptions {
+  pageSize?: number;
+  lastHeardAfter?: Date;
+}
+
+export function useMeshCoreNodesSuspense(options?: UseMeshCoreNodesOptions) {
+  const api = useMeshtasticApi();
+  const pageSize = options?.pageSize ?? 500;
+  const lastHeardAfterKey = options?.lastHeardAfter
+    ? Math.floor(options.lastHeardAfter.getTime() / (5 * 60 * 1000)).toString()
+    : null;
+
+  const query = useSuspenseInfiniteQuery({
+    queryKey: ['meshcore-nodes', pageSize, lastHeardAfterKey],
+    queryFn: async ({ pageParam = 1 }) =>
+      api.getMeshCoreNodes({
+        page: pageParam,
+        page_size: pageSize,
+        last_heard_after: options?.lastHeardAfter,
+      }),
+    initialPageParam: 1,
+    getNextPageParam: (lastPage, allPages) => (lastPage.next ? allPages.length + 1 : undefined),
+  });
+
+  React.useEffect(() => {
+    if (query.hasNextPage && !query.isFetchingNextPage) {
+      query.fetchNextPage();
+    }
+  }, [query.hasNextPage, query.isFetchingNextPage]);
+
+  const nodes = React.useMemo(
+    () => query.data.pages.flatMap((p: PaginatedResponse<ObservedNode>) => p.results),
+    [query.data.pages]
+  );
+
+  return { nodes, ...query };
+}
+
+export function useMeshCoreManagedNodesSuspense(options?: { pageSize?: number }) {
+  const api = useMeshtasticApi();
+  const pageSize = options?.pageSize ?? 200;
+
+  const query = useSuspenseQuery({
+    queryKey: ['meshcore-managed-nodes', pageSize],
+    queryFn: () => api.getMeshCoreManagedNodes({ page_size: pageSize, includeStatus: true }),
+  });
+
+  const feeders = query.data.results;
+
+  return { feeders, ...query };
+}

--- a/src/lib/api/api-utils.ts
+++ b/src/lib/api/api-utils.ts
@@ -4,6 +4,7 @@ import { NodeWatch, ObservedNode } from '../models';
 export function parseObservedNodeFromAPI(node: ObservedNode): ObservedNode {
   return {
     ...node,
+    node_id: node.node_id ?? 0,
     last_heard: node.last_heard ? new Date(node.last_heard) : null,
     latest_position: node.latest_position
       ? {

--- a/src/lib/api/meshtastic-api.ts
+++ b/src/lib/api/meshtastic-api.ts
@@ -31,6 +31,7 @@ import {
   DxNodeExclusionResponse,
   DxNotificationSettings,
   DxNotificationSettingsWrite,
+  MeshCorePacketListItem,
 } from '../models';
 import {
   ApiConfig,
@@ -119,12 +120,17 @@ export class MeshtasticApi extends BaseApi {
   /**
    * Get a paginated list of observed nodes
    */
-  async getNodes(params?: PaginationParams): Promise<PaginatedResponse<ObservedNode>> {
+  async getNodes(
+    params?: PaginationParams & { protocol?: 'meshtastic' | 'meshcore' }
+  ): Promise<PaginatedResponse<ObservedNode>> {
     const searchParams = new URLSearchParams();
     if (params?.page) searchParams.append('page', params.page.toString());
     if (params?.page_size) searchParams.append('page_size', params.page_size.toString());
     if (params?.last_heard_after) {
       searchParams.append('last_heard_after', params.last_heard_after.toISOString());
+    }
+    if (params?.protocol) {
+      searchParams.append('protocol', params.protocol);
     }
 
     const response = await this.get<PaginatedResponse<ObservedNode>>('/nodes/observed-nodes/', searchParams);
@@ -431,6 +437,33 @@ export class MeshtasticApi extends BaseApi {
   /**
    * Get a paginated list of managed nodes
    */
+  async getMeshCoreNodes(
+    params?: PaginationParams & { last_heard_after?: Date }
+  ): Promise<PaginatedResponse<ObservedNode>> {
+    return this.getNodes({ ...params, protocol: 'meshcore' });
+  }
+
+  async getMeshCoreManagedNodes(
+    params?: PaginationParams & { includeStatus?: boolean }
+  ): Promise<PaginatedResponse<ManagedNode>> {
+    const response = await this.getManagedNodes(params);
+    return {
+      ...response,
+      results: response.results.filter((n) => n.protocol === 2),
+    };
+  }
+
+  async getMeshCorePackets(
+    params?: PaginationParams & { payload_type?: number; from_pubkey_prefix?: string }
+  ): Promise<PaginatedResponse<MeshCorePacketListItem>> {
+    const searchParams = new URLSearchParams();
+    if (params?.page) searchParams.append('page', params.page.toString());
+    if (params?.page_size) searchParams.append('page_size', params.page_size.toString());
+    if (params?.payload_type != null) searchParams.append('payload_type', String(params.payload_type));
+    if (params?.from_pubkey_prefix) searchParams.append('from_pubkey_prefix', params.from_pubkey_prefix);
+    return this.get('/meshcore/packets/', searchParams);
+  }
+
   async getManagedNodes(
     params?: PaginationParams & {
       includeStatus?: boolean;

--- a/src/lib/models.ts
+++ b/src/lib/models.ts
@@ -26,6 +26,9 @@ export type EnvironmentExposureSlug = 'unknown' | 'indoor' | 'outdoor' | 'shelte
 /** API slugs for ObservedNode.weather_use */
 export type WeatherUseSlug = 'unknown' | 'include' | 'exclude';
 
+/** API protocol discriminator: 1 = Meshtastic, 2 = MeshCore */
+export type MeshProtocol = 1 | 2;
+
 export type AntennaPattern = 'omni' | 'directional';
 
 /** RF propagation profile from GET/PATCH `/nodes/observed-nodes/{id}/rf-profile/` (snake_case from API). */
@@ -82,8 +85,11 @@ export function isRfPropagationNone(r: RfPropagationPollResult): r is { status: 
 // ObservedNode from Meshflow API v2
 export interface ObservedNode {
   internal_id: number;
+  protocol?: MeshProtocol;
   node_id: number;
   node_id_str: string;
+  mc_pubkey?: string | null;
+  mc_pubkey_prefix?: string | null;
   mac_addr: string | null;
   long_name: string | null;
   short_name: string | null;
@@ -133,8 +139,25 @@ export interface GeoClassification {
   };
 }
 
+export interface MeshCorePacketListItem {
+  id: string;
+  payload_type: number;
+  event_type: string;
+  from_pubkey: string | null;
+  from_pubkey_prefix: string | null;
+  pkt_hash: number | null;
+  rx_time: string;
+  rx_rssi: number | null;
+  rx_snr: number | null;
+  route_typename: string | null;
+  first_reported_time: string;
+  observer_name: string;
+  text: string | null;
+}
+
 // ManagedNode from Meshflow API v2
 export interface ManagedNode {
+  protocol?: MeshProtocol;
   node_id: number;
   long_name: string | null;
   short_name: string | null;

--- a/src/pages/meshcore/MeshCoreMap.tsx
+++ b/src/pages/meshcore/MeshCoreMap.tsx
@@ -1,0 +1,58 @@
+import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card';
+import { NodesMap } from '@/components/nodes/NodesMap';
+import { useMeshCoreManagedNodesSuspense, useMeshCoreNodesSuspense } from '@/hooks/api/useMeshCore';
+import { subDays } from 'date-fns';
+import { Suspense, useMemo } from 'react';
+
+function MeshCoreMapContent() {
+  const lastHeardAfter = useMemo(() => subDays(new Date(), 30), []);
+  const { nodes } = useMeshCoreNodesSuspense({ pageSize: 500, lastHeardAfter });
+  const { feeders } = useMeshCoreManagedNodesSuspense({ pageSize: 200 });
+
+  const nodesWithPosition = useMemo(
+    () => nodes.filter((n) => n.latest_position?.latitude != null && n.latest_position?.longitude != null),
+    [nodes]
+  );
+
+  const feedersWithPosition = feeders.filter((f) => f.position?.latitude != null && f.position?.longitude != null);
+
+  return (
+    <div className="space-y-4">
+      <Card>
+        <CardHeader>
+          <CardTitle>MeshCore map</CardTitle>
+        </CardHeader>
+        <CardContent className="space-y-4">
+          <p className="text-sm text-muted-foreground">
+            Observed MeshCore nodes with a known position (from ADVERT). Feeders with a default location are listed
+            below.
+          </p>
+          <div className="h-[480px] w-full">
+            <NodesMap nodes={nodesWithPosition} showMapLegend />
+          </div>
+          {feedersWithPosition.length > 0 && (
+            <div>
+              <h3 className="mb-2 text-sm font-medium">Feeders (default location)</h3>
+              <ul className="list-inside list-disc text-sm text-muted-foreground">
+                {feedersWithPosition.map((f) => (
+                  <li key={f.node_id}>
+                    {f.long_name || f.node_id_str} — {f.position.latitude?.toFixed(4)},{' '}
+                    {f.position.longitude?.toFixed(4)}
+                  </li>
+                ))}
+              </ul>
+            </div>
+          )}
+        </CardContent>
+      </Card>
+    </div>
+  );
+}
+
+export function MeshCoreMap() {
+  return (
+    <Suspense fallback={<div>Loading MeshCore map…</div>}>
+      <MeshCoreMapContent />
+    </Suspense>
+  );
+}

--- a/src/pages/meshcore/MeshCoreNodesList.tsx
+++ b/src/pages/meshcore/MeshCoreNodesList.tsx
@@ -1,0 +1,97 @@
+import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card';
+import { Table, TableBody, TableCell, TableHead, TableHeader, TableRow } from '@/components/ui/table';
+import { useMeshCoreNodesSuspense } from '@/hooks/api/useMeshCore';
+import { ObservedNode } from '@/lib/models';
+import { formatDistanceToNow } from 'date-fns';
+import { Suspense, useMemo } from 'react';
+
+function formatPosition(node: ObservedNode): string {
+  const lat = node.latest_position?.latitude;
+  const lon = node.latest_position?.longitude;
+  if (lat == null || lon == null) return '—';
+  return `${lat.toFixed(4)}, ${lon.toFixed(4)}`;
+}
+
+function NodeTable({ title, nodes }: { title: string; nodes: ObservedNode[] }) {
+  return (
+    <Card>
+      <CardHeader>
+        <CardTitle>{title}</CardTitle>
+      </CardHeader>
+      <CardContent>
+        <Table>
+          <TableHeader>
+            <TableRow>
+              <TableHead>ID</TableHead>
+              <TableHead>Name</TableHead>
+              <TableHead>Prefix</TableHead>
+              <TableHead>Position</TableHead>
+              <TableHead>Last heard</TableHead>
+            </TableRow>
+          </TableHeader>
+          <TableBody>
+            {nodes.length === 0 ? (
+              <TableRow>
+                <TableCell colSpan={5} className="text-muted-foreground">
+                  No nodes in this section yet.
+                </TableCell>
+              </TableRow>
+            ) : (
+              nodes.map((node) => (
+                <TableRow key={String(node.internal_id)}>
+                  <TableCell className="font-mono text-xs">{node.node_id_str}</TableCell>
+                  <TableCell>
+                    {node.long_name || '—'} / {node.short_name || '—'}
+                  </TableCell>
+                  <TableCell className="font-mono text-xs">{node.mc_pubkey_prefix || '—'}</TableCell>
+                  <TableCell>{formatPosition(node)}</TableCell>
+                  <TableCell>
+                    {node.last_heard ? formatDistanceToNow(node.last_heard, { addSuffix: true }) : '—'}
+                  </TableCell>
+                </TableRow>
+              ))
+            )}
+          </TableBody>
+        </Table>
+      </CardContent>
+    </Card>
+  );
+}
+
+function MeshCoreNodesListContent() {
+  const { nodes } = useMeshCoreNodesSuspense({ pageSize: 500 });
+
+  const { withLocation, identityOnly } = useMemo(() => {
+    const withLoc: ObservedNode[] = [];
+    const noLoc: ObservedNode[] = [];
+    for (const n of nodes) {
+      if (n.latest_position?.latitude != null && n.latest_position?.longitude != null) {
+        withLoc.push(n);
+      } else {
+        noLoc.push(n);
+      }
+    }
+    return { withLocation: withLoc, identityOnly: noLoc };
+  }, [nodes]);
+
+  return (
+    <div className="space-y-6">
+      <div>
+        <h1 className="text-2xl font-semibold">MeshCore nodes</h1>
+        <p className="text-sm text-muted-foreground">
+          All observed MeshCore nodes (separate from the Meshtastic node list).
+        </p>
+      </div>
+      <NodeTable title={`With location (${withLocation.length})`} nodes={withLocation} />
+      <NodeTable title={`Identity only / no position (${identityOnly.length})`} nodes={identityOnly} />
+    </div>
+  );
+}
+
+export function MeshCoreNodesList() {
+  return (
+    <Suspense fallback={<div>Loading MeshCore nodes…</div>}>
+      <MeshCoreNodesListContent />
+    </Suspense>
+  );
+}


### PR DESCRIPTION
## Summary

MeshCore Phase 1 UI: API client hooks for `protocol=meshcore` observed nodes and MC managed feeders; new **MeshCore** sidebar section with map (`/meshcore/map`) and nodes list (`/meshcore/nodes`). Separate from existing Meshtastic map/list.

Part of epic meshflow-api#265. Related: [meshflow-api#293](https://github.com/pskillen/meshflow-api/pull/293), meshflow-bot PR (same branch name).

## Background

Read-only surfaces to prove MC ingestion: map shows observed nodes with position; list splits nodes with/without location; feeders with default location listed on map page.

## Testing performed

- [x] `npm run build`
- [x] `npm test` (pre-commit hook)
- [x] Manual: with API running and MC data ingested, verify map and list populate

Closes #250