### PR TITLE
chore(ci): add Dependabot grouped weekly updates

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,56 @@
+# Dependabot — tracked in https://github.com/pskillen/meshflow-ui/issues/59
+version: 2
+updates:
+  - package-ecosystem: npm
+    directory: /
+    schedule:
+      interval: weekly
+      day: monday
+      time: "09:00"
+      timezone: Europe/London
+    open-pull-requests-limit: 5
+    labels:
+      - dependencies
+    commit-message:
+      prefix: chore
+      include: scope
+    groups:
+      npm-dependencies:
+        patterns:
+          - "*"
+
+  - package-ecosystem: github-actions
+    directory: /
+    schedule:
+      interval: weekly
+      day: monday
+      time: "09:00"
+      timezone: Europe/London
+    open-pull-requests-limit: 5
+    labels:
+      - dependencies
+    commit-message:
+      prefix: chore
+      include: scope
+    groups:
+      github-actions:
+        patterns:
+          - "*"
+
+  - package-ecosystem: docker
+    directory: /
+    schedule:
+      interval: weekly
+      day: monday
+      time: "09:00"
+      timezone: Europe/London
+    open-pull-requests-limit: 5
+    labels:
+      - dependencies
+    commit-message:
+      prefix: chore
+      include: scope
+    groups:
+      docker:
+        patterns:
+          - "*"


### PR DESCRIPTION
## Summary

- Add `.github/dependabot.yml` for weekly grouped updates: npm (prod + dev), GitHub Actions, and Docker base images.
- Schedule: Mondays 09:00 Europe/London; one grouped PR per ecosystem per week.

Closes #59 (meshflow-ui — tracking issue for Dependabot across all Meshflow repos).

## Related PRs

- meshflow-api
- meshflow-bot
- meshflow-rf-propagation

## Testing performed

- Config only; Dependabot will validate on merge. No application code changes.