### PR TITLE
docs(meshcore): SP-02 comment-only protocol labelling (#309)

### DIFF
--- a/src/lib/api/meshtastic-api.ts
+++ b/src/lib/api/meshtastic-api.ts
@@ -118,7 +118,9 @@ export class MeshtasticApi extends BaseApi {
   // ===== Observed Nodes API =====
 
   /**
-   * Get a paginated list of observed nodes
+   * List observed nodes (`GET /nodes/observed-nodes/`) — mixed Meshtastic and MeshCore.
+   * Pass `protocol` to filter; nested `latest_*` metrics are Meshtastic-shaped when present.
+   * Detail by numeric id via {@link getNode} is Meshtastic-only (MeshCore: filter list/search).
    */
   async getNodes(
     params?: PaginationParams & { protocol?: 'meshtastic' | 'meshcore' }
@@ -155,7 +157,9 @@ export class MeshtasticApi extends BaseApi {
   }
 
   /**
-   * Get a single observed node by ID
+   * Get one observed node by Meshtastic numeric `node_id` (path `/nodes/observed-nodes/{id}/`).
+   * Not valid for MeshCore nodes until internal_id lookup exists — use {@link getNodes} with
+   * `protocol: 'meshcore'` or search instead.
    */
   async getNode(id: number): Promise<ObservedNode> {
     const node = await this.get<ObservedNode>(`/nodes/observed-nodes/${id}/`);

--- a/src/lib/models.ts
+++ b/src/lib/models.ts
@@ -82,22 +82,32 @@ export function isRfPropagationNone(r: RfPropagationPollResult): r is { status: 
   return r.status === 'none';
 }
 
-// ObservedNode from Meshflow API v2
+/**
+ * Observed node from Meshflow API (Meshtastic and MeshCore in one list resource).
+ * Use `protocol` on list queries to filter; detail by numeric `node_id` is Meshtastic-only today.
+ */
 export interface ObservedNode {
+  /** Stable UUID primary key (API returns string; parsed in api-utils). */
   internal_id: number;
   protocol?: MeshProtocol;
+  /** Meshtastic numeric node id; null/absent for MeshCore (use node_id_str / mc_pubkey*). */
   node_id: number;
+  /** Canonical display id: `!hex8` (Meshtastic) or `mc:prefix12` (MeshCore). */
   node_id_str: string;
   mc_pubkey?: string | null;
   mc_pubkey_prefix?: string | null;
+  /** Meshtastic nodeinfo MAC; usually null for MeshCore. */
   mac_addr: string | null;
   long_name: string | null;
   short_name: string | null;
   hw_model: string | null;
+  /** Meshtastic device public key (PKI); null for MeshCore. */
   public_key: string | null;
+  /** Meshtastic RoleSource enum integer; null for MeshCore. */
   role?: number | null;
   is_licensed?: boolean | null;
   is_unmessagable?: boolean | null;
+  /** Meshtastic-only: inferred max hops from hop_start; null for MeshCore. */
   inferred_max_hops?: number | null;
   environment_exposure?: EnvironmentExposureSlug;
   weather_use?: WeatherUseSlug;
@@ -110,11 +120,14 @@ export interface ObservedNode {
   /** True when battery alerting is enabled and a low-battery episode is confirmed (mesh monitoring). */
   battery_alert_active?: boolean;
   battery_alert_confirmed_at?: Date | string | null;
-  // Additional fields for UI compatibility
   last_heard?: Date | null;
+  /** Meshtastic protobuf-shaped telemetry; typically null for MeshCore nodes. */
   latest_device_metrics?: DeviceMetrics | null;
+  /** Meshtastic environment telemetry from NodeLatestStatus. */
   latest_environment_metrics?: LatestEnvironmentMetrics | null;
+  /** Meshtastic power telemetry from NodeLatestStatus. */
   latest_power_metrics?: LatestPowerMetrics | null;
+  /** Meshtastic position snapshot from NodeLatestStatus. */
   latest_position?: Position | null;
   owner?: NodeOwnerInfo | null;
   /** Current user's claim for this node, if any. Present when authenticated. */
@@ -302,6 +315,7 @@ export interface TextMessageResponse {
   results: TextMessage[];
 }
 
+/** Meshtastic device telemetry (nested under ObservedNode.latest_device_metrics). */
 export interface DeviceMetrics {
   reported_time: Date | null;
   logged_time: Date | null;


### PR DESCRIPTION
## Summary

SP-02 (#309): JSDoc and API client comments for mixed-protocol observed nodes.

- `src/lib/models.ts`: `ObservedNode` protocol labelling, MT-only nested metrics fields
- `src/lib/api/meshtastic-api.ts`: `getNodes` / `getNode` mixed resource + `protocol` filter notes

Related: meshflow-api [#321](https://github.com/pskillen/meshflow-api/pull/321), meshflow-bot PR (same branch name).

Part of #309 (tracking issue on meshflow-api).

## Testing performed

- `npm run format` (Prettier)
- Pre-commit: lint + vitest (250 tests passed)
- Doc-only; no UI behaviour change