### PR TITLE
refactor(ui): SP-03 meshtastic_node_id API field rename

### DIFF
--- a/.cursor/skills/meshflow-git-workflow/SKILL.md
+++ b/.cursor/skills/meshflow-git-workflow/SKILL.md
@@ -112,11 +112,30 @@ fix(api): correct timezone handling in packet ingestion
 refactor(storage): extract packet parsing into service
 ```
 
-Note: `git commit` does not work in the sandbox, so skip the sandbox attempt
+---
+
+## 5. Running git in Cursor agents
+
+When the agent **Shell** tool runs `git` (or other commands) in a Meshflow repo:
+
+1. **Always set `working_directory`** to the repository root (absolute path), e.g. `/Users/you/git_personal/meshflow-ui`. Commands that only `cd` inside the command string often return **empty output** even when they succeed (exit code 0).
+
+2. **Good pattern**
+
+   ```text
+   working_directory: /Users/you/git_personal/meshflow-ui
+   command:            git fetch origin && git status -sb
+   ```
+
+3. **Permissions**: use `required_permissions: ["git_write"]` for checkout/commit; add `"network"` for `fetch` / `push`.
+
+4. **PRs and issues**: use the `github-personal` MCP. The `gh` CLI is not available on Meshflow dev machines.
+
+5. **Long pre-commit hooks**: meshflow-ui runs eslint + vitest on commit; use `block_until_ms` of 60–90s when committing.
 
 ---
 
-## 5. Pull Requests
+## 6. Pull Requests
 
 When the work is done:
 
@@ -135,5 +154,5 @@ When the work is done:
 | Plan       | Issue in relevant repo(s); parent in meshflow-api if multi-repo                               |
 | Branch     | `{issue-repo-prefix}-{num}/{author}/{description}` (prefix = repo where the issue lives)      |
 | Pre-commit | meshflow-api/meshtastic-bot: venv + black, isort, flake8; meshtastic-bot-ui: `npm run format` |
-| Commit     | Conventional commits, no "enhance"                                                            |
+| Commit     | Conventional commits, no "enhance"; Shell `working_directory` = repo root                     |
 | PR         | Open in all affected repos, link issues and related PRs                                       |

--- a/src/components/NeighbourPieChart.tsx
+++ b/src/components/NeighbourPieChart.tsx
@@ -217,8 +217,8 @@ export function NeighbourPieChart({
                       <div className="flex flex-wrap gap-1 mt-1">
                         {item.candidates.map((c) => (
                           <Link
-                            key={c.node_id}
-                            to={`/nodes/${c.node_id}`}
+                            key={c.meshtastic_node_id}
+                            to={`/nodes/${c.meshtastic_node_id}`}
                             className="text-xs text-teal-600 dark:text-teal-400 hover:underline px-1.5 py-0.5 rounded bg-muted"
                           >
                             {c.short_name || c.node_id_str}

--- a/src/components/NodeActivityTable.tsx
+++ b/src/components/NodeActivityTable.tsx
@@ -25,7 +25,7 @@ const columns: ColumnDef<ObservedNode>[] = [
     cell: ({ row }) => {
       const node = row.original;
       return (
-        <Link to={`/nodes/${node.node_id}`}>
+        <Link to={`/nodes/${node.meshtastic_node_id}`}>
           <div>
             <div className="font-medium">{node.short_name}</div>
             <div className="text-sm text-muted-foreground">{node.long_name}</div>
@@ -77,7 +77,7 @@ const columns: ColumnDef<ObservedNode>[] = [
     accessorKey: 'id',
     header: 'Node ID',
     cell: ({ row }) => {
-      return <span className="font-mono text-sm">{meshtasticIdToHex(row.original.node_id)}</span>;
+      return <span className="font-mono text-sm">{meshtasticIdToHex(row.original.meshtastic_node_id)}</span>;
     },
   },
 ];

--- a/src/components/NodeSearch.tsx
+++ b/src/components/NodeSearch.tsx
@@ -114,13 +114,13 @@ export function NodeSearch({ onNodeSelect, displayValue, onClearSelection, lastH
               {filteredSearchResults.map((node) => (
                 <li key={node.internal_id}>
                   <Link
-                    to={onNodeSelect ? '#' : `/nodes/${node.node_id}`}
+                    to={onNodeSelect ? '#' : `/nodes/${node.meshtastic_node_id}`}
                     className="block px-4 py-2 hover:bg-accent"
                     onClick={() => {
                       setIsOpen(false);
                       setQuery('');
                       if (onNodeSelect) {
-                        onNodeSelect(node.node_id, node);
+                        onNodeSelect(node.meshtastic_node_id, node);
                       }
                     }}
                   >

--- a/src/components/map/FeederIconLayer.tsx
+++ b/src/components/map/FeederIconLayer.tsx
@@ -27,7 +27,7 @@ const FEEDER_ICON_DESCRIPTOR = {
 
 export type FeederIconDatum = Pick<
   FeederReachFeeder,
-  'lat' | 'lng' | 'node_id' | 'node_id_str' | 'short_name' | 'long_name' | 'managed_node_id'
+  'lat' | 'lng' | 'meshtastic_node_id' | 'node_id_str' | 'short_name' | 'long_name' | 'managed_node_id'
 > & { lat: number; lng: number };
 
 export function buildFeederIconLayer<T extends FeederIconDatum>(

--- a/src/components/messages/MessageItem.tsx
+++ b/src/components/messages/MessageItem.tsx
@@ -42,7 +42,10 @@ function HeardDialog({
         <div className="space-y-4 mt-4">
           {observations?.length ? (
             observations.map((observation) => (
-              <div key={observation.observer.node_id} className="flex items-start space-x-4 p-2 border rounded-md">
+              <div
+                key={observation.observer.meshtastic_node_id}
+                className="flex items-start space-x-4 p-2 border rounded-md"
+              >
                 <div className="flex-1">
                   <div className="font-semibold">
                     {observation.observer.short_name || observation.observer.node_id_str}
@@ -86,7 +89,7 @@ interface MessageItemProps {
   continuationMessages?: Array<{ message: TextMessage; replies: TextMessage[]; emojiReactions: TextMessage[] }>;
 }
 
-/** Parse node_id_str (!hex) to numeric node_id for routing */
+/** Parse node_id_str (!hex) to numeric meshtastic_node_id for routing */
 function parseNodeId(nodeIdStr: string): number | null {
   const match = nodeIdStr?.replace(/^!/, '').match(/^[0-9a-fA-F]+$/);
   return match ? parseInt(match[0], 16) : null;

--- a/src/components/nodes/InfrastructureNodeCard.test.tsx
+++ b/src/components/nodes/InfrastructureNodeCard.test.tsx
@@ -15,7 +15,7 @@ vi.mock('@/hooks/api/useRfPropagation', () => ({
 
 function minimalManaged(nodeId: number): ManagedNode {
   return {
-    node_id: nodeId,
+    meshtastic_node_id: nodeId,
     long_name: null,
     short_name: null,
     last_heard: null,
@@ -40,7 +40,7 @@ function renderCard(node: ObservedNode, opts?: { managedNode?: ManagedNode | nul
 function makeNode(overrides: Partial<ObservedNode> = {}): ObservedNode {
   return {
     internal_id: 1,
-    node_id: 100,
+    meshtastic_node_id: 100,
     node_id_str: '!00000064',
     mac_addr: null,
     long_name: 'Hilltop',
@@ -56,18 +56,18 @@ function makeNode(overrides: Partial<ObservedNode> = {}): ObservedNode {
 
 describe('InfrastructureNodeCard', () => {
   it('renders Coverage map link only when the infra node is a managed feeder', () => {
-    renderCard(makeNode({ node_id: 4242 }), { managedNode: minimalManaged(4242) });
+    renderCard(makeNode({ meshtastic_node_id: 4242 }), { managedNode: minimalManaged(4242) });
     const link = screen.getByTestId('infra-coverage-link-4242');
     expect(link.getAttribute('href')).toBe('/traceroutes/map/coverage?feeder=4242');
   });
 
   it('does not render Coverage map link for unmanaged infrastructure nodes', () => {
-    renderCard(makeNode({ node_id: 4242 }));
+    renderCard(makeNode({ meshtastic_node_id: 4242 }));
     expect(screen.queryByTestId('infra-coverage-link-4242')).not.toBeInTheDocument();
   });
 
-  it('also renders the Open node details link to /nodes/<node_id>', () => {
-    renderCard(makeNode({ node_id: 7 }));
+  it('also renders the Open node details link to /nodes/<meshtastic_node_id>', () => {
+    renderCard(makeNode({ meshtastic_node_id: 7 }));
     const detailsLink = screen.getByRole('link', { name: /open node details/i });
     expect(detailsLink.getAttribute('href')).toBe('/nodes/7');
   });
@@ -77,7 +77,7 @@ describe('InfrastructureNodeCard', () => {
     const { rerender } = render(
       <QueryClientProvider client={client}>
         <MemoryRouter>
-          <InfrastructureNodeCard node={makeNode({ node_id: 9, has_ready_rf_render: false })} />
+          <InfrastructureNodeCard node={makeNode({ meshtastic_node_id: 9, has_ready_rf_render: false })} />
         </MemoryRouter>
       </QueryClientProvider>
     );
@@ -85,7 +85,7 @@ describe('InfrastructureNodeCard', () => {
     rerender(
       <QueryClientProvider client={client}>
         <MemoryRouter>
-          <InfrastructureNodeCard node={makeNode({ node_id: 9, has_ready_rf_render: true })} />
+          <InfrastructureNodeCard node={makeNode({ meshtastic_node_id: 9, has_ready_rf_render: true })} />
         </MemoryRouter>
       </QueryClientProvider>
     );

--- a/src/components/nodes/InfrastructureNodeCard.tsx
+++ b/src/components/nodes/InfrastructureNodeCard.tsx
@@ -62,7 +62,7 @@ function InfrastructureNodeCardInner({
                 e.preventDefault();
                 const newState = !compareSelected;
                 setCompareSelected(newState);
-                onCompareToggle?.(node.node_id, newState);
+                onCompareToggle?.(node.meshtastic_node_id, newState);
               }}
             >
               <span
@@ -147,7 +147,7 @@ function InfrastructureNodeCardInner({
               node={node}
               watch={watch}
               watchesQuery={watchesQuery}
-              idPrefix={`infra-card-${node.node_id}`}
+              idPrefix={`infra-card-${node.meshtastic_node_id}`}
               compact
             />
           </div>
@@ -156,9 +156,9 @@ function InfrastructureNodeCardInner({
       <div className="mt-auto flex justify-end gap-3 pt-3">
         {managedNode != null && (
           <Link
-            to={`/traceroutes/map/coverage?feeder=${node.node_id}`}
+            to={`/traceroutes/map/coverage?feeder=${node.meshtastic_node_id}`}
             className="text-sm text-muted-foreground underline-offset-4 hover:text-primary hover:underline"
-            data-testid={`infra-coverage-link-${node.node_id}`}
+            data-testid={`infra-coverage-link-${node.meshtastic_node_id}`}
           >
             Coverage map
           </Link>
@@ -168,7 +168,7 @@ function InfrastructureNodeCardInner({
             <button
               type="button"
               className="text-sm text-muted-foreground underline-offset-4 hover:text-primary hover:underline"
-              data-testid={`infra-propagation-map-${node.node_id}`}
+              data-testid={`infra-propagation-map-${node.meshtastic_node_id}`}
               onClick={() => setPropagationMapOpen(true)}
             >
               Propagation map
@@ -176,13 +176,13 @@ function InfrastructureNodeCardInner({
             <RfPropagationMapModal
               open={propagationMapOpen}
               onOpenChange={setPropagationMapOpen}
-              nodeId={node.node_id}
+              nodeId={node.meshtastic_node_id}
               shortLabel={node.short_name}
             />
           </>
         )}
         <Link
-          to={`/nodes/${node.node_id}`}
+          to={`/nodes/${node.meshtastic_node_id}`}
           className="inline-flex items-center gap-1.5 text-sm text-primary hover:underline"
         >
           Open node details

--- a/src/components/nodes/MonitoredNodesBatteryChart.tsx
+++ b/src/components/nodes/MonitoredNodesBatteryChart.tsx
@@ -86,7 +86,7 @@ export function MonitoredNodesBatteryChart({
     const allTimestamps = Array.from(
       new Set(
         nodes.flatMap((node) => {
-          const metrics = metricsMap[node.node_id] || [];
+          const metrics = metricsMap[node.meshtastic_node_id] || [];
           return metrics.filter((m) => m.reported_time != null).map((m) => new Date(m.reported_time!).getTime());
         })
       )
@@ -95,7 +95,7 @@ export function MonitoredNodesBatteryChart({
     // 2. Build a lookup for each node
     const nodeLookups: Record<string, Record<number, number>> = {};
     nodes.forEach((node) => {
-      const metrics = metricsMap[node.node_id] || [];
+      const metrics = metricsMap[node.meshtastic_node_id] || [];
       const lookup: Record<number, number> = {};
       metrics
         .filter((m) => m.reported_time != null)
@@ -164,20 +164,20 @@ export function MonitoredNodesBatteryChart({
     const allTimestamps = pivotedData.map((row) => row.timestamp);
     const nodeLookups: Record<string, Record<number, number>> = {};
     nodes.forEach((node) => {
-      const metrics = metricsMap[node.node_id] || [];
+      const metrics = metricsMap[node.meshtastic_node_id] || [];
       const lookup: Record<number, number> = {};
       metrics
         .filter((m) => m.reported_time != null)
         .forEach((m) => {
           lookup[new Date(m.reported_time!).getTime()] = m.battery_level;
         });
-      const name = node.short_name || node.node_id_str || String(node.node_id);
+      const name = node.short_name || node.node_id_str || String(node.meshtastic_node_id);
       nodeLookups[name] = lookup;
     });
     return allTimestamps.map((timestamp) => {
       const row: Record<string, number | null> = { timestamp };
       for (const node of nodes) {
-        const name = node.short_name || node.node_id_str || String(node.node_id);
+        const name = node.short_name || node.node_id_str || String(node.meshtastic_node_id);
         if (timestamp !== undefined && timestamp !== null) {
           row[name] = nodeLookups[name][timestamp] ?? null;
         } else {

--- a/src/components/nodes/MonitoredNodesChannelUtilChart.tsx
+++ b/src/components/nodes/MonitoredNodesChannelUtilChart.tsx
@@ -71,7 +71,7 @@ export function MonitoredNodesChannelUtilChart({
     const allTimestamps = Array.from(
       new Set(
         nodes.flatMap((node) => {
-          const metrics = metricsMap[node.node_id] || [];
+          const metrics = metricsMap[node.meshtastic_node_id] || [];
           return metrics.filter((m) => m.reported_time != null).map((m) => new Date(m.reported_time!).getTime());
         })
       )
@@ -79,7 +79,7 @@ export function MonitoredNodesChannelUtilChart({
 
     const nodeLookups: Record<string, Record<number, number>> = {};
     nodes.forEach((node) => {
-      const metrics = metricsMap[node.node_id] || [];
+      const metrics = metricsMap[node.meshtastic_node_id] || [];
       const lookup: Record<number, number> = {};
       metrics
         .filter((m) => m.reported_time != null)

--- a/src/components/nodes/MonitoredNodesTable.tsx
+++ b/src/components/nodes/MonitoredNodesTable.tsx
@@ -46,7 +46,7 @@ export function MonitoredNodesTable({
           </TableHeader>
           <TableBody>
             {nodes.map((node) => (
-              <TableRow key={node.node_id}>
+              <TableRow key={node.meshtastic_node_id}>
                 <TableCell>
                   <div>
                     {node.short_name || node.node_id_str}
@@ -90,7 +90,12 @@ export function MonitoredNodesTable({
                 </TableCell>
                 <TableCell>
                   {editable && (
-                    <Button variant="ghost" size="icon" onClick={() => onRemoveNode(node.node_id)} className="h-8 w-8">
+                    <Button
+                      variant="ghost"
+                      size="icon"
+                      onClick={() => onRemoveNode(node.meshtastic_node_id)}
+                      className="h-8 w-8"
+                    >
                       <X className="h-4 w-4" />
                     </Button>
                   )}

--- a/src/components/nodes/MyNodeCard.test.tsx
+++ b/src/components/nodes/MyNodeCard.test.tsx
@@ -18,7 +18,7 @@ vi.mock('@/components/nodes/MeshWatchControls', () => ({
 function makeNode(overrides: Partial<ObservedNode> = {}): ObservedNode {
   return {
     internal_id: 1,
-    node_id: 100,
+    meshtastic_node_id: 100,
     node_id_str: '!00000064',
     mac_addr: null,
     long_name: 'Long',

--- a/src/components/nodes/MyNodeCard.tsx
+++ b/src/components/nodes/MyNodeCard.tsx
@@ -220,12 +220,12 @@ export function MyNodeCard({
             node={node}
             watch={watch}
             watchesQuery={watchesQuery}
-            idPrefix={`my-nodes-card-${node.node_id}`}
+            idPrefix={`my-nodes-card-${node.meshtastic_node_id}`}
             compact
           />
         </div>
         <Button asChild className="w-full">
-          <Link to={`/nodes/${node.node_id}`} className="inline-flex items-center justify-center gap-1.5">
+          <Link to={`/nodes/${node.meshtastic_node_id}`} className="inline-flex items-center justify-center gap-1.5">
             <Settings className="h-4 w-4 shrink-0" aria-hidden />
             Node details
             <ChevronRight className="h-4 w-4 shrink-0 opacity-70" aria-hidden />

--- a/src/components/nodes/NodeCard.tsx
+++ b/src/components/nodes/NodeCard.tsx
@@ -45,8 +45,8 @@ export function NodeCard({ node }: NodeCardProps) {
 
   return (
     <Link
-      key={node.node_id}
-      to={`/nodes/${node.node_id}`}
+      key={node.meshtastic_node_id}
+      to={`/nodes/${node.meshtastic_node_id}`}
       className="block p-5 bg-white dark:bg-slate-800 rounded-lg shadow-md hover:shadow-lg transition-shadow duration-200 border border-slate-200 dark:border-slate-700"
     >
       <div className="flex justify-between items-start gap-3 mb-3">

--- a/src/components/nodes/NodeDetailContent.tabs.test.tsx
+++ b/src/components/nodes/NodeDetailContent.tabs.test.tsx
@@ -57,7 +57,7 @@ const mockedUseManagedNodesSuspense = vi.mocked(useManagedNodesSuspense);
 
 const minimalNode: ObservedNode = {
   internal_id: 1,
-  node_id: 100,
+  meshtastic_node_id: 100,
   node_id_str: '!00000064',
   mac_addr: null,
   long_name: 'Long Name',

--- a/src/components/nodes/NodeDetailContent.tsx
+++ b/src/components/nodes/NodeDetailContent.tsx
@@ -250,10 +250,13 @@ export function NodeDetailContent({ nodeId, compact = false, activeTab, onTabCha
   const { managedNodes } = useManagedNodesSuspense({ includeGeoClassification: true });
 
   const isManagedNode = useMemo(() => {
-    return managedNodes.some((managedNode) => managedNode.node_id === nodeId);
+    return managedNodes.some((managedNode) => managedNode.meshtastic_node_id === nodeId);
   }, [managedNodes, nodeId]);
 
-  const managedForThisNode = useMemo(() => managedNodes.find((m) => m.node_id === nodeId), [managedNodes, nodeId]);
+  const managedForThisNode = useMemo(
+    () => managedNodes.find((m) => m.meshtastic_node_id === nodeId),
+    [managedNodes, nodeId]
+  );
 
   useEffect(() => {
     if (node) {
@@ -528,11 +531,11 @@ export function NodeDetailContent({ nodeId, compact = false, activeTab, onTabCha
           <div className="mb-2 text-sm text-slate-500 dark:text-slate-400">Recently viewed:</div>
           <div className="flex flex-wrap gap-2">
             {recentNodes
-              .filter((recentNode) => recentNode.node_id !== nodeId)
+              .filter((recentNode) => recentNode.meshtastic_node_id !== nodeId)
               .map((recentNode) => (
                 <Link
-                  key={recentNode.node_id}
-                  to={`/nodes/${recentNode.node_id}`}
+                  key={recentNode.meshtastic_node_id}
+                  to={`/nodes/${recentNode.meshtastic_node_id}`}
                   replace={true}
                   className="rounded-full bg-slate-100 px-3 py-1 text-sm text-teal-600 hover:bg-slate-200 dark:bg-slate-800 dark:text-teal-400 dark:hover:bg-slate-700"
                 >

--- a/src/components/nodes/NodeMeshMonitoringSection.tsx
+++ b/src/components/nodes/NodeMeshMonitoringSection.tsx
@@ -59,7 +59,7 @@ export function NodeMeshMonitoringSection({ node }: { node: ObservedNode }) {
               node={node}
               watch={watch}
               watchesQuery={watchesQuery}
-              idPrefix={`detail-${node.node_id}`}
+              idPrefix={`detail-${node.meshtastic_node_id}`}
             />
           </div>
 
@@ -131,7 +131,7 @@ export function NodeMeshMonitoringSection({ node }: { node: ObservedNode }) {
         open={settingsOpen}
         onOpenChange={setSettingsOpen}
         observedNodeId={observedUuid}
-        nodeId={node.node_id}
+        nodeId={node.meshtastic_node_id}
       />
     </div>
   );

--- a/src/components/nodes/NodeOutgoingTraceroutesSection.test.tsx
+++ b/src/components/nodes/NodeOutgoingTraceroutesSection.test.tsx
@@ -28,7 +28,7 @@ vi.mock('@/hooks/api/useTraceroutes', () => ({
 
 function makeManaged(overrides: Partial<ManagedNode> = {}): ManagedNode {
   return {
-    node_id: 42,
+    meshtastic_node_id: 42,
     long_name: 'Feeder',
     short_name: 'F1',
     last_heard: null,
@@ -49,7 +49,7 @@ function renderSection(managed: ManagedNode) {
   const client = new QueryClient({ defaultOptions: { queries: { retry: false } } });
   return render(
     <QueryClientProvider client={client}>
-      <NodeOutgoingTraceroutesSection nodeId={managed.node_id} managed={managed} />
+      <NodeOutgoingTraceroutesSection nodeId={managed.meshtastic_node_id} managed={managed} />
     </QueryClientProvider>
   );
 }

--- a/src/components/nodes/NodeOutgoingTraceroutesSection.tsx
+++ b/src/components/nodes/NodeOutgoingTraceroutesSection.tsx
@@ -51,8 +51,8 @@ export function NodeOutgoingTraceroutesSection({ nodeId, managed }: NodeOutgoing
   const handleRepeat = (tr: AutoTraceRoute) => {
     triggerMutation.mutate(
       {
-        managedNodeId: tr.source_node.node_id,
-        targetNodeId: tr.target_node.node_id,
+        managedNodeId: tr.source_node.meshtastic_node_id,
+        targetNodeId: tr.target_node.meshtastic_node_id,
         targetStrategy:
           tr.target_strategy === 'intra_zone' ||
           tr.target_strategy === 'dx_across' ||
@@ -116,7 +116,9 @@ export function NodeOutgoingTraceroutesSection({ nodeId, managed }: NodeOutgoing
                   </TableHeader>
                   <TableBody>
                     {traceroutes.map((tr) => {
-                      const canRepeat = triggerableNodes.some((n) => n.node_id === tr.source_node.node_id);
+                      const canRepeat = triggerableNodes.some(
+                        (n) => n.meshtastic_node_id === tr.source_node.meshtastic_node_id
+                      );
                       return (
                         <TableRow
                           key={tr.id}

--- a/src/components/nodes/NodeSelector.tsx
+++ b/src/components/nodes/NodeSelector.tsx
@@ -18,7 +18,7 @@ export function NodeSelector({ nodes, onSelect, onCancel, excludeNodes = [] }: N
   const [showDebug, setShowDebug] = useState(false);
 
   // First filter: exclude already selected nodes
-  const nodesAfterExclusion = nodes.filter((node) => !excludeNodes.includes(node.node_id));
+  const nodesAfterExclusion = nodes.filter((node) => !excludeNodes.includes(node.meshtastic_node_id));
 
   // Second filter: search query
   const availableNodes = nodesAfterExclusion.filter((node) => {
@@ -77,7 +77,7 @@ export function NodeSelector({ nodes, onSelect, onCancel, excludeNodes = [] }: N
             </TableHeader>
             <TableBody>
               {availableNodes.map((node) => (
-                <TableRow key={node.node_id}>
+                <TableRow key={node.meshtastic_node_id}>
                   <TableCell>
                     <div>
                       {node.short_name || node.node_id_str}
@@ -90,7 +90,7 @@ export function NodeSelector({ nodes, onSelect, onCancel, excludeNodes = [] }: N
                     {node.latest_device_metrics?.battery_level ? `${node.latest_device_metrics.battery_level}%` : '-'}
                   </TableCell>
                   <TableCell>
-                    <Button variant="secondary" size="sm" onClick={() => onSelect(node.node_id)}>
+                    <Button variant="secondary" size="sm" onClick={() => onSelect(node.meshtastic_node_id)}>
                       Monitor
                     </Button>
                   </TableCell>

--- a/src/components/nodes/NodeTracerouteHistorySection.test.tsx
+++ b/src/components/nodes/NodeTracerouteHistorySection.test.tsx
@@ -69,7 +69,7 @@ const mockedUseManagedNodes = vi.mocked(useManagedNodesSuspense);
 function makeObservedNode(overrides: Partial<ObservedNode> = {}): ObservedNode {
   return {
     internal_id: 1,
-    node_id: 100,
+    meshtastic_node_id: 100,
     node_id_str: '!00000064',
     mac_addr: null,
     long_name: 'Target node',
@@ -82,7 +82,7 @@ function makeObservedNode(overrides: Partial<ObservedNode> = {}): ObservedNode {
 
 function makeManagedNode(overrides: Partial<ManagedNode> = {}): ManagedNode {
   return {
-    node_id: 200,
+    meshtastic_node_id: 200,
     long_name: 'Source node',
     short_name: 'SRC',
     last_heard: null,
@@ -161,7 +161,7 @@ function setupHooks(options: {
 function renderSection(observedNode: ObservedNode = makeObservedNode()) {
   return render(
     <MemoryRouter>
-      <NodeTracerouteHistorySection nodeId={observedNode.node_id} observedNode={observedNode} />
+      <NodeTracerouteHistorySection nodeId={observedNode.meshtastic_node_id} observedNode={observedNode} />
     </MemoryRouter>
   );
 }
@@ -219,7 +219,7 @@ describe('NodeTracerouteHistorySection', () => {
 
   it('opens the trigger modal with fixedTargetNode when the header button is clicked', () => {
     const managed = makeManagedNode();
-    const observed = makeObservedNode({ node_id: 555, node_id_str: '!0000022b' });
+    const observed = makeObservedNode({ meshtastic_node_id: 555, node_id_str: '!0000022b' });
     setupHooks({ traceroutes: [], triggerableNodes: [managed] });
     renderSection(observed);
     fireEvent.click(screen.getByRole('button', { name: /trigger traceroute to this node/i }));
@@ -227,8 +227,8 @@ describe('NodeTracerouteHistorySection', () => {
   });
 
   it('calls the trigger mutation with source + target when the repeat button is clicked', () => {
-    const managed = makeManagedNode({ node_id: 777 });
-    const observed = makeObservedNode({ node_id: 888 });
+    const managed = makeManagedNode({ meshtastic_node_id: 777 });
+    const observed = makeObservedNode({ meshtastic_node_id: 888 });
     const mutate = vi.fn();
     setupHooks({
       traceroutes: [makeTraceroute({ source_node: managed, target_node: observed })],
@@ -245,7 +245,7 @@ describe('NodeTracerouteHistorySection', () => {
 
   it('renders a View all link pointing at the traceroute history filtered by target', () => {
     const managed = makeManagedNode();
-    const observed = makeObservedNode({ node_id: 100 });
+    const observed = makeObservedNode({ meshtastic_node_id: 100 });
     setupHooks({ traceroutes: [makeTraceroute({ source_node: managed })], triggerableNodes: [managed] });
     renderSection(observed);
     const link = screen.getByRole('link', { name: /view all traceroutes to this node/i });

--- a/src/components/nodes/NodeTracerouteHistorySection.tsx
+++ b/src/components/nodes/NodeTracerouteHistorySection.tsx
@@ -50,11 +50,11 @@ export function NodeTracerouteHistorySection({ nodeId, observedNode }: NodeTrace
     includeStatus: true,
     includeGeoClassification: true,
   });
-  const managedByMeshId = useMemo(() => new Map(managedNodes.map((m) => [m.node_id, m])), [managedNodes]);
+  const managedByMeshId = useMemo(() => new Map(managedNodes.map((m) => [m.meshtastic_node_id, m])), [managedNodes]);
   const modalManagedNodes = useMemo(
     () =>
       triggerableNodes.map((t) => {
-        const full = managedByMeshId.get(t.node_id);
+        const full = managedByMeshId.get(t.meshtastic_node_id);
         return full ? { ...t, ...full } : t;
       }),
     [triggerableNodes, managedByMeshId]
@@ -67,8 +67,8 @@ export function NodeTracerouteHistorySection({ nodeId, observedNode }: NodeTrace
   const handleRepeat = (tr: AutoTraceRoute) => {
     triggerMutation.mutate(
       {
-        managedNodeId: tr.source_node.node_id,
-        targetNodeId: tr.target_node.node_id,
+        managedNodeId: tr.source_node.meshtastic_node_id,
+        targetNodeId: tr.target_node.meshtastic_node_id,
         targetStrategy:
           tr.target_strategy === 'intra_zone' ||
           tr.target_strategy === 'dx_across' ||
@@ -136,7 +136,9 @@ export function NodeTracerouteHistorySection({ nodeId, observedNode }: NodeTrace
                 </TableHeader>
                 <TableBody>
                   {traceroutes.map((tr) => {
-                    const canRepeat = triggerableNodes.some((n) => n.node_id === tr.source_node.node_id);
+                    const canRepeat = triggerableNodes.some(
+                      (n) => n.meshtastic_node_id === tr.source_node.meshtastic_node_id
+                    );
                     return (
                       <TableRow
                         key={tr.id}

--- a/src/components/nodes/NodeTracerouteLinksMap.test.tsx
+++ b/src/components/nodes/NodeTracerouteLinksMap.test.tsx
@@ -32,7 +32,7 @@ vi.mock('@/components/map/DeckMapboxMap', () => ({
 }));
 
 const nodeA: NodeTracerouteLinkNode = {
-  node_id: 0x11a,
+  meshtastic_node_id: 0x11a,
   node_id_str: '!0000011a',
   short_name: 'A',
   long_name: 'Node A',
@@ -41,7 +41,7 @@ const nodeA: NodeTracerouteLinkNode = {
 };
 
 const nodeB: NodeTracerouteLinkNode = {
-  node_id: 0x11b,
+  meshtastic_node_id: 0x11b,
   node_id_str: '!0000011b',
   short_name: 'B',
   long_name: 'Node B',
@@ -50,8 +50,8 @@ const nodeB: NodeTracerouteLinkNode = {
 };
 
 const edge: NodeTracerouteLinkEdge = {
-  from_node_id: nodeA.node_id,
-  to_node_id: nodeB.node_id,
+  from_node_id: nodeA.meshtastic_node_id,
+  to_node_id: nodeB.meshtastic_node_id,
   from_lng: -4.2,
   from_lat: 55.9,
   to_lng: -4.15,
@@ -69,7 +69,7 @@ describe('NodeTracerouteLinksMap', () => {
   it('passes lon/lat/zoom initialViewState when multiple nodes have positions (not bounds)', () => {
     render(
       <MemoryRouter>
-        <NodeTracerouteLinksMap edges={[edge]} nodes={[nodeA, nodeB]} focusNodeId={nodeA.node_id} />
+        <NodeTracerouteLinksMap edges={[edge]} nodes={[nodeA, nodeB]} focusNodeId={nodeA.meshtastic_node_id} />
       </MemoryRouter>
     );
 

--- a/src/components/nodes/NodeTracerouteLinksMap.tsx
+++ b/src/components/nodes/NodeTracerouteLinksMap.tsx
@@ -33,7 +33,7 @@ export interface NodeTracerouteLinksMapProps {
 }
 
 function getNodeLabel(node: NodeTracerouteLinkNode): string {
-  return node.short_name || node.long_name || node.node_id_str || `!${node.node_id.toString(16)}`;
+  return node.short_name || node.long_name || node.node_id_str || `!${node.meshtastic_node_id.toString(16)}`;
 }
 
 export function NodeTracerouteLinksMap({ edges, nodes, focusNodeId, showLabels = true }: NodeTracerouteLinksMapProps) {
@@ -45,7 +45,7 @@ export function NodeTracerouteLinksMap({ edges, nodes, focusNodeId, showLabels =
       if (info.object && (info.layer?.id === 'links-nodes' || info.layer?.id === 'links-node-labels')) {
         const node = info.object as NodeTracerouteLinkNode;
         setSelectedNode(node);
-        setSelectedEdge(edges.find((e) => e.to_node_id === node.node_id) ?? null);
+        setSelectedEdge(edges.find((e) => e.to_node_id === node.meshtastic_node_id) ?? null);
       } else {
         setSelectedNode(null);
         setSelectedEdge(null);
@@ -89,8 +89,8 @@ export function NodeTracerouteLinksMap({ edges, nodes, focusNodeId, showLabels =
       id: 'links-nodes',
       data: nodes,
       getPosition: (d) => [d.lng, d.lat],
-      getFillColor: (d) => (d.node_id === focusNodeId ? FOCUS_NODE_COLOR : PEER_NODE_COLOR),
-      getRadius: (d) => (d.node_id === focusNodeId ? 150 : 100),
+      getFillColor: (d) => (d.meshtastic_node_id === focusNodeId ? FOCUS_NODE_COLOR : PEER_NODE_COLOR),
+      getRadius: (d) => (d.meshtastic_node_id === focusNodeId ? 150 : 100),
       radiusMinPixels: 4,
       radiusMaxPixels: 12,
       pickable: true,
@@ -136,7 +136,7 @@ export function NodeTracerouteLinksMap({ edges, nodes, focusNodeId, showLabels =
       ];
       return viewStateFromLngLatBBox(bbox, { padding: 40, maxZoom: 14 });
     }
-    const focusNode = nodes.find((n) => n.node_id === focusNodeId);
+    const focusNode = nodes.find((n) => n.meshtastic_node_id === focusNodeId);
     if (focusNode && focusNode.lat != null && focusNode.lng != null) {
       return { longitude: focusNode.lng, latitude: focusNode.lat, zoom: 10 };
     }
@@ -178,7 +178,7 @@ export function NodeTracerouteLinksMap({ edges, nodes, focusNodeId, showLabels =
                   : getNodeLabel(selectedNode)}
               </div>
               <div className="mt-0.5 text-xs text-slate-400">
-                {selectedNode.node_id_str || `!${selectedNode.node_id.toString(16)}`}
+                {selectedNode.node_id_str || `!${selectedNode.meshtastic_node_id.toString(16)}`}
               </div>
               {selectedEdge && (
                 <div className="mt-1 space-y-0.5 text-xs">
@@ -195,7 +195,7 @@ export function NodeTracerouteLinksMap({ edges, nodes, focusNodeId, showLabels =
                 </div>
               )}
               <Link
-                to={`/nodes/${selectedNode.node_id}`}
+                to={`/nodes/${selectedNode.meshtastic_node_id}`}
                 className="mt-1 inline-block text-xs text-emerald-400 hover:text-emerald-300 hover:underline"
               >
                 Open details

--- a/src/components/nodes/NodesAndConstellationsMap.test.tsx
+++ b/src/components/nodes/NodesAndConstellationsMap.test.tsx
@@ -45,7 +45,7 @@ vi.mock('leaflet', () => ({
 
 function managedWithConstellation(): ManagedNode {
   return {
-    node_id: 1,
+    meshtastic_node_id: 1,
     node_id_str: '!00000001',
     long_name: 'A',
     short_name: 'A',

--- a/src/components/nodes/NodesAndConstellationsMap.tsx
+++ b/src/components/nodes/NodesAndConstellationsMap.tsx
@@ -23,7 +23,7 @@ const UNCERTAINTY_THRESHOLD_M = 200;
 export type MapNode = ObservedNode | ManagedNode;
 
 function getNodeId(node: MapNode): number {
-  return node.node_id;
+  return node.meshtastic_node_id;
 }
 
 function getNodePosition(node: MapNode): { lat: number; lng: number } | null {
@@ -268,7 +268,7 @@ export function NodesAndConstellationsMap({
     markersRef.current.forEach((m) => m.remove());
     markersRef.current = [];
 
-    const managedNodeIds = new Set(managedNodes.map((n) => n.node_id));
+    const managedNodeIds = new Set(managedNodes.map((n) => n.meshtastic_node_id));
     const filteredManaged =
       filterConstellationIds != null && filterConstellationIds.length > 0
         ? managedNodes.filter((n) => n.constellation && filterConstellationIds.includes(n.constellation.id))
@@ -403,13 +403,13 @@ export function NodesAndConstellationsMap({
     // When !showConstellation: draw all observed nodes (including managed) with role colors
     const observedLayer = showConstellation
       ? showUnmanagedNodes
-        ? observedNodes.filter((o) => !managedNodeIds.has(o.node_id))
+        ? observedNodes.filter((o) => !managedNodeIds.has(o.meshtastic_node_id))
         : []
       : observedNodes;
 
     const managedNodeConstellationMap = new Map<number, string>();
     filteredManaged.forEach((n) => {
-      if (n.constellation?.name) managedNodeConstellationMap.set(n.node_id, n.constellation.name);
+      if (n.constellation?.name) managedNodeConstellationMap.set(n.meshtastic_node_id, n.constellation.name);
     });
 
     const hasSelection = selectedNodeId != null;
@@ -417,7 +417,7 @@ export function NodesAndConstellationsMap({
       const pos = getNodePosition(node);
       if (!pos) return;
       const position: L.LatLngExpression = [pos.lat, pos.lng];
-      const isSelected = selectedNodeId === node.node_id;
+      const isSelected = selectedNodeId === node.meshtastic_node_id;
       const label = getMarkerLabel
         ? getMarkerLabel(node as ObservedNode)
         : node.short_name || node.node_id_str?.toString().slice(-4) || '?';
@@ -444,12 +444,12 @@ export function NodesAndConstellationsMap({
             dimmed,
             opacity,
             grayscale,
-            getNodeAlertRing?.(node.node_id) ?? undefined
+            getNodeAlertRing?.(node.meshtastic_node_id) ?? undefined
           );
       const marker = L.marker(position, { icon });
       marker.on('click', () => handleMarkerClick(node));
       if (enableBubbles) {
-        const constellationName = managedNodeConstellationMap.get(node.node_id) ?? null;
+        const constellationName = managedNodeConstellationMap.get(node.meshtastic_node_id) ?? null;
         marker.bindPopup(buildNodePopupHtml({ ...node, constellationName }));
       }
       marker.addTo(map);
@@ -463,7 +463,7 @@ export function NodesAndConstellationsMap({
         c.nodes.forEach((node) => {
           if (node.position?.latitude == null || node.position?.longitude == null) return;
           const position: L.LatLngExpression = [node.position.latitude, node.position.longitude];
-          const isSelected = selectedNodeId === node.node_id;
+          const isSelected = selectedNodeId === node.meshtastic_node_id;
           const marker = L.marker(position, {
             icon: createNodeIcon(
               node.short_name || node.node_id_str?.slice(4, 8) || '?',
@@ -472,7 +472,7 @@ export function NodesAndConstellationsMap({
               hasSelection && !isSelected,
               undefined,
               undefined,
-              getNodeAlertRing?.(node.node_id) ?? undefined
+              getNodeAlertRing?.(node.meshtastic_node_id) ?? undefined
             ),
           });
           marker.on('click', () => handleMarkerClick(node));

--- a/src/components/nodes/NodesMap.test.tsx
+++ b/src/components/nodes/NodesMap.test.tsx
@@ -56,7 +56,7 @@ function nodeWithPosition(
 ): ObservedNode {
   return {
     internal_id: id,
-    node_id: id,
+    meshtastic_node_id: id,
     node_id_str: `!${id.toString(16).padStart(8, '0')}`,
     mac_addr: null,
     long_name: 'A',

--- a/src/components/nodes/NodesMap.tsx
+++ b/src/components/nodes/NodesMap.tsx
@@ -12,7 +12,7 @@ interface NodesMapProps {
   nodes: ObservedNode[];
   /** Default true: role-colour key for marker pins. */
   showMapLegend?: boolean;
-  /** When set, marker pins use these colours by `node_id` instead of Meshtastic role. */
+  /** When set, marker pins use these colours by `meshtastic_node_id` instead of Meshtastic role. */
   markerColorsByNodeId?: ReadonlyMap<number, string> | Record<number, string>;
   /** Legend rows when using `markerColorsByNodeId` (e.g. watch monitoring status). */
   mapLegendStatusSwatches?: RoleLegendSwatch[];
@@ -169,7 +169,7 @@ export function NodesMap({
     nodesWithPosition.forEach((node) => {
       const position: L.LatLngExpression = [node.latest_position!.latitude!, node.latest_position!.longitude!];
 
-      const pinColor = colorByNodeId?.get(node.node_id) ?? getRoleColor(node.role);
+      const pinColor = colorByNodeId?.get(node.meshtastic_node_id) ?? getRoleColor(node.role);
 
       const marker = L.marker(position, {
         icon: createNodeIcon(node.short_name || node.node_id_str.toString(), pinColor, false),

--- a/src/components/nodes/RfProfileModal.test.tsx
+++ b/src/components/nodes/RfProfileModal.test.tsx
@@ -30,7 +30,7 @@ vi.mock('@/hooks/api/useRfPropagation', () => ({
 function makeNode(overrides: Partial<ObservedNode> = {}): ObservedNode {
   return {
     internal_id: 1,
-    node_id: 55,
+    meshtastic_node_id: 55,
     node_id_str: '!00000037',
     mac_addr: null,
     long_name: 'N',

--- a/src/components/nodes/RfProfileModal.tsx
+++ b/src/components/nodes/RfProfileModal.tsx
@@ -56,7 +56,7 @@ const inputSurfaceClass = 'border border-slate-300 bg-background shadow-sm dark:
 const FREQ_BAND_UNSET = '__freq_unset__';
 
 export function RfProfileModal({ open, onOpenChange, node }: RfProfileModalProps) {
-  const nodeId = node.node_id;
+  const nodeId = node.meshtastic_node_id;
   const { data: profile, isLoading } = useRfProfile(nodeId, { enabled: open });
   const updateMutation = useUpdateRfProfile(nodeId);
   const recomputeMutation = useRecomputeRfPropagation(nodeId);

--- a/src/components/nodes/RfPropagationSection.test.tsx
+++ b/src/components/nodes/RfPropagationSection.test.tsx
@@ -21,7 +21,7 @@ vi.mock('@/hooks/api/useRfPropagation', () => ({
 function makeNode(overrides: Partial<ObservedNode> = {}): ObservedNode {
   return {
     internal_id: 1,
-    node_id: 200,
+    meshtastic_node_id: 200,
     node_id_str: '!000000c8',
     mac_addr: null,
     long_name: 'Tower',

--- a/src/components/nodes/RfPropagationSection.tsx
+++ b/src/components/nodes/RfPropagationSection.tsx
@@ -21,7 +21,7 @@ export interface RfPropagationSectionProps {
 }
 
 export function RfPropagationSection({ node, className = 'mb-6' }: RfPropagationSectionProps) {
-  const nodeId = node.node_id;
+  const nodeId = node.meshtastic_node_id;
   const canEdit = node.rf_profile_editable === true;
   const hasProfile = node.has_rf_profile === true;
   const showSection = canEdit || hasProfile;

--- a/src/components/nodes/SetupManagedNode.tsx
+++ b/src/components/nodes/SetupManagedNode.tsx
@@ -37,7 +37,7 @@ interface SetupManagedNodeProps {
 function formatManagedNodeCreateError(err: unknown): string {
   if (axios.isAxiosError(err) && err.response?.data && typeof err.response.data === 'object') {
     const data = err.response.data as Record<string, unknown>;
-    const nid = data.node_id;
+    const nid = data.meshtastic_node_id;
     if (Array.isArray(nid) && nid.length > 0) {
       return String(nid[0]);
     }
@@ -110,7 +110,7 @@ export function SetupManagedNode({ node, isOpen, onClose }: SetupManagedNodeProp
   });
 
   // Get the node's observed node data to check for existing location
-  const observedNode = useNodeSuspense(node.node_id);
+  const observedNode = useNodeSuspense(node.meshtastic_node_id);
 
   // Reset state when dialog opens
   useEffect(() => {
@@ -296,23 +296,29 @@ export function SetupManagedNode({ node, isOpen, onClose }: SetupManagedNodeProp
 
     try {
       // Create the managed node with location and channel mappings
-      const managedNode = await api.createManagedNode(node.node_id, selectedConstellation, nodeName, user.id, {
-        defaultLocationLatitude: nodeLocation?.lat,
-        defaultLocationLongitude: nodeLocation?.lng,
-        channels: channelMappings,
-      });
+      const managedNode = await api.createManagedNode(
+        node.meshtastic_node_id,
+        selectedConstellation,
+        nodeName,
+        user.id,
+        {
+          defaultLocationLatitude: nodeLocation?.lat,
+          defaultLocationLongitude: nodeLocation?.lng,
+          channels: channelMappings,
+        }
+      );
 
       // Handle API key
       if (apiKeyOption === 'existing' && selectedApiKey) {
         // Add node to existing API key
-        await api.addNodeToApiKey(selectedApiKey, managedNode.node_id);
+        await api.addNodeToApiKey(selectedApiKey, managedNode.meshtastic_node_id);
       } else if (apiKeyOption === 'new' && newApiKeyName) {
         // Create new API key
         const apiKey = await api.createApiKey(newApiKeyName, selectedConstellation);
         setCreatedApiKey(apiKey);
 
         // Add node to new API key
-        await api.addNodeToApiKey(apiKey.id, managedNode.node_id);
+        await api.addNodeToApiKey(apiKey.id, managedNode.meshtastic_node_id);
       }
 
       // Move to instructions step
@@ -628,7 +634,7 @@ export function SetupManagedNode({ node, isOpen, onClose }: SetupManagedNodeProp
         <Button variant="outline" onClick={onClose}>
           Close
         </Button>
-        <Button onClick={() => navigate(`/nodes/${node.node_id}`)}>Go to Node Details</Button>
+        <Button onClick={() => navigate(`/nodes/${node.meshtastic_node_id}`)}>Go to Node Details</Button>
       </DialogFooter>
     </>
   );

--- a/src/components/nodes/WatchDashboardSummary.test.tsx
+++ b/src/components/nodes/WatchDashboardSummary.test.tsx
@@ -8,7 +8,7 @@ import { countWatchesByMonitoringStatus } from '@/lib/watch-monitoring-status';
 function makeNode(overrides: Partial<ObservedNode> = {}): ObservedNode {
   return {
     internal_id: 1,
-    node_id: 50,
+    meshtastic_node_id: 50,
     node_id_str: '!00000032',
     mac_addr: null,
     long_name: null,
@@ -24,7 +24,7 @@ function makeNode(overrides: Partial<ObservedNode> = {}): ObservedNode {
 function makeWatch(id: number, node: Partial<ObservedNode>): NodeWatch {
   return {
     id,
-    observed_node: makeNode({ internal_id: id, node_id: 50 + id, ...node }) as NodeWatch['observed_node'],
+    observed_node: makeNode({ internal_id: id, meshtastic_node_id: 50 + id, ...node }) as NodeWatch['observed_node'],
     offline_after: 3600,
     enabled: true,
     offline_notifications_enabled: true,

--- a/src/components/nodes/WatchedNodesTable.test.tsx
+++ b/src/components/nodes/WatchedNodesTable.test.tsx
@@ -35,7 +35,7 @@ vi.mock('@/hooks/api/useMultiNodeMetrics', () => ({
 function makeObservedNode(overrides: Partial<ObservedNodeWatchSummary> = {}): ObservedNode {
   return {
     internal_id: 1,
-    node_id: 100,
+    meshtastic_node_id: 100,
     node_id_str: '!00000064',
     mac_addr: null,
     long_name: 'Long',
@@ -53,7 +53,7 @@ function makeWatch(overrides: Partial<NodeWatch> & { node?: Partial<ObservedNode
   const id = idOverride ?? 1;
   const node = makeObservedNode({
     internal_id: id,
-    node_id: 100 + id,
+    meshtastic_node_id: 100 + id,
     short_name: `SN${id}`,
     ...nodeOverrides,
   });
@@ -78,7 +78,7 @@ function renderTable(props: Partial<ComponentProps<typeof WatchedNodesTable>> & 
       makeWatch({
         id: 1,
         node: {
-          node_id: 1,
+          meshtastic_node_id: 1,
           internal_id: 10,
           node_id_str: '!00000001',
           short_name: 'OnlineN',
@@ -90,7 +90,7 @@ function renderTable(props: Partial<ComponentProps<typeof WatchedNodesTable>> & 
       makeWatch({
         id: 2,
         node: {
-          node_id: 2,
+          meshtastic_node_id: 2,
           internal_id: 20,
           node_id_str: '!00000002',
           short_name: 'OffN',
@@ -138,7 +138,7 @@ describe('WatchedNodesTable', () => {
         makeWatch({
           id: 1,
           node: {
-            node_id: 1,
+            meshtastic_node_id: 1,
             short_name: 'LowBatt',
             last_heard: recent,
             monitoring_offline_confirmed_at: null,
@@ -159,7 +159,7 @@ describe('WatchedNodesTable', () => {
         makeWatch({
           id: 1,
           node: {
-            node_id: 1,
+            meshtastic_node_id: 1,
             short_name: 'OnlyOnline',
             last_heard: recent,
             monitoring_offline_confirmed_at: null,
@@ -176,7 +176,7 @@ describe('WatchedNodesTable', () => {
     const tr: AutoTraceRoute = {
       id: 50,
       source_node: {
-        node_id: 200,
+        meshtastic_node_id: 200,
         short_name: 'SRC',
         node_id_str: '!c8',
         long_name: null,
@@ -186,7 +186,7 @@ describe('WatchedNodesTable', () => {
         allow_auto_traceroute: true,
         position: { latitude: null, longitude: null },
       },
-      target_node: makeObservedNode({ node_id: 2 }),
+      target_node: makeObservedNode({ meshtastic_node_id: 2 }),
       trigger_type: 4,
       trigger_type_label: 'Node Watch',
       triggered_by: null,
@@ -211,7 +211,7 @@ describe('WatchedNodesTable', () => {
         makeWatch({
           id: 2,
           node: {
-            node_id: 2,
+            meshtastic_node_id: 2,
             short_name: 'OffOnly',
             monitoring_offline_confirmed_at: '2026-04-21T11:00:00Z',
           },
@@ -235,7 +235,7 @@ describe('WatchedNodesTable', () => {
         makeWatch({
           id: 3,
           node: {
-            node_id: 3,
+            meshtastic_node_id: 3,
             short_name: 'Trig',
             monitoring_offline_confirmed_at: '2026-04-21T11:00:00Z',
           },
@@ -245,7 +245,7 @@ describe('WatchedNodesTable', () => {
     });
     await user.click(screen.getByRole('button', { name: /Trigger traceroute/i }));
     expect(onTrigger).toHaveBeenCalledTimes(1);
-    expect(onTrigger.mock.calls[0][0].node_id).toBe(3);
+    expect(onTrigger.mock.calls[0][0].meshtastic_node_id).toBe(3);
   });
 
   it('disables trigger button when canTriggerTraceroute is false', () => {
@@ -256,7 +256,7 @@ describe('WatchedNodesTable', () => {
         makeWatch({
           id: 99,
           node: {
-            node_id: 99,
+            meshtastic_node_id: 99,
             short_name: 'Solo',
             last_heard: recent,
             monitoring_offline_confirmed_at: null,

--- a/src/components/nodes/WatchedNodesTable.tsx
+++ b/src/components/nodes/WatchedNodesTable.tsx
@@ -285,7 +285,10 @@ function WatchCard({
       <div className="grid gap-6 sm:grid-cols-2 lg:grid-cols-4">
         <div>
           <FieldLabel>Node</FieldLabel>
-          <Link to={`/nodes/${node.node_id}`} className="font-medium text-teal-600 dark:text-teal-400 hover:underline">
+          <Link
+            to={`/nodes/${node.meshtastic_node_id}`}
+            className="font-medium text-teal-600 dark:text-teal-400 hover:underline"
+          >
             {node.short_name || node.node_id_str}
           </Link>
           <div className="text-xs text-muted-foreground font-mono mt-0.5">{node.node_id_str}</div>
@@ -330,7 +333,10 @@ function WatchCard({
                 </TableRow>
               </TableHeader>
               <TableBody>
-                <WatchTracerouteHistoryRows targetNodeId={node.node_id} onOpenTraceroute={onOpenTraceroute} />
+                <WatchTracerouteHistoryRows
+                  targetNodeId={node.meshtastic_node_id}
+                  onOpenTraceroute={onOpenTraceroute}
+                />
               </TableBody>
             </Table>
           </div>
@@ -421,7 +427,7 @@ export function WatchedNodesTable({
                     onOpenTraceroute={onOpenTraceroute}
                     onRequestTriggerTraceroute={onRequestTriggerTraceroute}
                     canTriggerTraceroute={canTriggerTraceroute}
-                    metrics={metricsMap[watch.observed_node.node_id] ?? []}
+                    metrics={metricsMap[watch.observed_node.meshtastic_node_id] ?? []}
                     chartDateRange={chartDateRange}
                     metricsLoading={metricsLoading}
                   />

--- a/src/components/nodes/WeatherNodeCard.tsx
+++ b/src/components/nodes/WeatherNodeCard.tsx
@@ -49,7 +49,7 @@ function WeatherNodeCardInner({ node, metrics, dateRange }: WeatherNodeCardProps
       </div>
       <div className="mt-auto flex justify-end pt-3">
         <Link
-          to={`/nodes/${node.node_id}`}
+          to={`/nodes/${node.meshtastic_node_id}`}
           className="inline-flex items-center gap-1.5 text-sm text-primary hover:underline"
         >
           Open node details

--- a/src/components/nodes/map-constellation-colors.test.ts
+++ b/src/components/nodes/map-constellation-colors.test.ts
@@ -8,7 +8,7 @@ function makeManaged(
   constellation: { id: number; name?: string; map_color?: string }
 ): ManagedNode {
   return {
-    node_id: nodeId,
+    meshtastic_node_id: nodeId,
     long_name: null,
     short_name: 'S',
     last_heard: null,

--- a/src/components/nodes/map-utils.ts
+++ b/src/components/nodes/map-utils.ts
@@ -130,7 +130,7 @@ function percentileSorted(sorted: number[], p: number): number {
 
 /** Minimal node fields for popup content */
 export interface NodePopupData {
-  node_id: number;
+  meshtastic_node_id: number;
   node_id_str?: string;
   long_name: string | null;
   short_name: string | null;
@@ -148,9 +148,9 @@ export function buildNodePopupHtml(node: NodePopupData): string {
   const displayName =
     node.long_name && node.short_name
       ? `${node.long_name} (${node.short_name})`
-      : node.long_name || node.short_name || node.node_id_str || `Node ${node.node_id}`;
+      : node.long_name || node.short_name || node.node_id_str || `Node ${node.meshtastic_node_id}`;
   const lastSeen = node.last_heard != null ? new Date(node.last_heard).toLocaleString() : 'Never';
-  const detailsUrl = `/nodes/${node.node_id}`;
+  const detailsUrl = `/nodes/${node.meshtastic_node_id}`;
   const constellationLine =
     node.constellationName != null && node.constellationName !== ''
       ? `Constellation: ${escapeHtml(node.constellationName)}`

--- a/src/components/traceroutes/AutoTargetPreviewMap.test.tsx
+++ b/src/components/traceroutes/AutoTargetPreviewMap.test.tsx
@@ -28,7 +28,7 @@ function sampleGeo(overrides: Partial<GeoClassification> = {}): GeoClassificatio
 
 function makeFeeder(overrides: Partial<ManagedNode> = {}): ManagedNode {
   return {
-    node_id: 7,
+    meshtastic_node_id: 7,
     long_name: 'Source',
     short_name: 'SRC',
     last_heard: null,
@@ -45,7 +45,7 @@ function makeFeeder(overrides: Partial<ManagedNode> = {}): ManagedNode {
 const now = new Date();
 const candidate: ObservedNode = {
   internal_id: 1,
-  node_id: 99,
+  meshtastic_node_id: 99,
   node_id_str: '!00000063',
   mac_addr: null,
   long_name: 'Obs',

--- a/src/components/traceroutes/AutoTargetPreviewMap.tsx
+++ b/src/components/traceroutes/AutoTargetPreviewMap.tsx
@@ -28,7 +28,7 @@ const DX_SAME_FILL: [number, number, number, number] = [245, 158, 11, 55];
 const DX_SAME_LINE: [number, number, number, number] = [217, 119, 6, 220];
 
 function nodeLabel(n: ObservedNode): string {
-  return n.short_name ?? n.long_name ?? n.node_id_str ?? String(n.node_id);
+  return n.short_name ?? n.long_name ?? n.node_id_str ?? String(n.meshtastic_node_id);
 }
 
 function reasonLabel(r: ExclusionReason): string {
@@ -89,14 +89,14 @@ export function AutoTargetPreviewMap({
     const hours = mergedGeo.selector_params!.last_heard_within_hours;
     const cutoff = new Date(Date.now() - hours * 60 * 60 * 1000);
     return {
-      feederNodeId: feeder.node_id,
+      feederNodeId: feeder.meshtastic_node_id,
       managedNodeIds,
       lastHeardCutoff: cutoff,
       geo: mergedGeo,
       feederLat,
       feederLon: feederLng,
     };
-  }, [feeder.node_id, feederLat, feederLng, geo, managedNodeIds]);
+  }, [feeder.meshtastic_node_id, feederLat, feederLng, geo, managedNodeIds]);
 
   const { envelope, centroid } = useMemo(() => {
     const env = geo?.envelope ?? null;
@@ -184,10 +184,10 @@ export function AutoTargetPreviewMap({
       .filter((x): x is PlotRow => x != null);
   }, [excludedData, includedData]);
 
-  const includedSet = useMemo(() => new Set(includedData.map((n) => n.node_id)), [includedData]);
+  const includedSet = useMemo(() => new Set(includedData.map((n) => n.meshtastic_node_id)), [includedData]);
 
   const excludedLayer = useMemo(() => {
-    const data = positions.filter((p) => !includedSet.has(p.node.node_id));
+    const data = positions.filter((p) => !includedSet.has(p.node.meshtastic_node_id));
     if (data.length === 0) return null;
     return new ScatterplotLayer<PlotRow>({
       id: 'auto-target-excluded',
@@ -204,7 +204,7 @@ export function AutoTargetPreviewMap({
   }, [includedSet, positions]);
 
   const includedLayer = useMemo(() => {
-    const data = positions.filter((p) => includedSet.has(p.node.node_id));
+    const data = positions.filter((p) => includedSet.has(p.node.meshtastic_node_id));
     if (data.length === 0) return null;
     return new ScatterplotLayer<PlotRow>({
       id: 'auto-target-included',
@@ -243,11 +243,11 @@ export function AutoTargetPreviewMap({
         {
           lat: feederLat,
           lng: feederLng,
-          node_id: feeder.node_id,
+          meshtastic_node_id: feeder.meshtastic_node_id,
           node_id_str: feeder.node_id_str,
           short_name: feeder.short_name,
           long_name: feeder.long_name,
-          managed_node_id: String(feeder.node_id),
+          managed_node_id: String(feeder.meshtastic_node_id),
         },
       ],
       { id: 'auto-target-feeder-icons', size: 36, pickable: true }

--- a/src/components/traceroutes/ConstellationCoverageMap.tsx
+++ b/src/components/traceroutes/ConstellationCoverageMap.tsx
@@ -26,15 +26,15 @@ export interface SmoothedHex extends ConstellationCoverageHex {
 }
 
 function getTargetLabel(t: ConstellationCoverageTarget): string {
-  return t.short_name || t.long_name || t.node_id_str || `!${t.node_id.toString(16)}`;
+  return t.short_name || t.long_name || t.node_id_str || `!${t.meshtastic_node_id.toString(16)}`;
 }
 
 function feederLabel(f: FeederIconDatum): string {
-  return f.short_name || f.long_name || f.node_id_str || `!${f.node_id.toString(16)}`;
+  return f.short_name || f.long_name || f.node_id_str || `!${f.meshtastic_node_id.toString(16)}`;
 }
 
 function ghostLabel(g: CoverageHeardGhost): string {
-  return g.short_name || g.long_name || g.node_id_str || `!${g.node_id.toString(16)}`;
+  return g.short_name || g.long_name || g.node_id_str || `!${g.meshtastic_node_id.toString(16)}`;
 }
 
 export interface ConstellationCoverageMapProps {
@@ -204,10 +204,10 @@ export function ConstellationCoverageMap({
               </div>
               <div className="mt-0.5 font-semibold">{ghostLabel(selectedHeardGhost)}</div>
               <div className="mt-0.5 text-xs text-slate-400">
-                {selectedHeardGhost.node_id_str || `!${selectedHeardGhost.node_id.toString(16)}`}
+                {selectedHeardGhost.node_id_str || `!${selectedHeardGhost.meshtastic_node_id.toString(16)}`}
               </div>
               <Link
-                to={`/nodes/${selectedHeardGhost.node_id}`}
+                to={`/nodes/${selectedHeardGhost.meshtastic_node_id}`}
                 className="mt-1 inline-block text-xs text-emerald-400 hover:text-emerald-300 hover:underline"
               >
                 Open details
@@ -278,7 +278,7 @@ export function ConstellationCoverageMap({
                   : getTargetLabel(selectedTarget)}
               </div>
               <div className="mt-0.5 text-xs text-slate-400">
-                {selectedTarget.node_id_str || `!${selectedTarget.node_id.toString(16)}`}
+                {selectedTarget.node_id_str || `!${selectedTarget.meshtastic_node_id.toString(16)}`}
               </div>
               <div className="mt-1 text-xs">
                 {selectedTarget.successes} / {selectedTarget.attempts} (
@@ -295,7 +295,7 @@ export function ConstellationCoverageMap({
                 {selectedTarget.contributing_feeders === 1 ? '' : 's'}
               </div>
               <Link
-                to={`/nodes/${selectedTarget.node_id}`}
+                to={`/nodes/${selectedTarget.meshtastic_node_id}`}
                 className="mt-1 inline-block text-xs text-emerald-400 hover:text-emerald-300 hover:underline"
               >
                 Open details
@@ -328,10 +328,10 @@ export function ConstellationCoverageMap({
               <div className="text-xs font-medium uppercase tracking-wide text-amber-400">Managed node (feeder)</div>
               <div className="mt-0.5 font-semibold">{feederLabel(selectedFeeder)}</div>
               <div className="mt-0.5 text-xs text-slate-400">
-                {selectedFeeder.node_id_str || `!${selectedFeeder.node_id.toString(16)}`}
+                {selectedFeeder.node_id_str || `!${selectedFeeder.meshtastic_node_id.toString(16)}`}
               </div>
               <Link
-                to={`/nodes/${selectedFeeder.node_id}`}
+                to={`/nodes/${selectedFeeder.meshtastic_node_id}`}
                 className="mt-1 inline-block text-xs text-emerald-400 hover:text-emerald-300 hover:underline"
               >
                 Open details

--- a/src/components/traceroutes/FeederCoverageMap.tsx
+++ b/src/components/traceroutes/FeederCoverageMap.tsx
@@ -29,11 +29,11 @@ const POLYGON_STROKE: [number, number, number, number] = [99, 102, 241, 200];
 const H3_RESOLUTION = 6;
 
 function getTargetLabel(t: FeederReachTarget): string {
-  return t.short_name || t.long_name || t.node_id_str || `!${t.node_id.toString(16)}`;
+  return t.short_name || t.long_name || t.node_id_str || `!${t.meshtastic_node_id.toString(16)}`;
 }
 
 function feederPopupTitle(f: FeederReachFeeder): string {
-  return f.short_name || f.long_name || f.node_id_str || `!${f.node_id.toString(16)}`;
+  return f.short_name || f.long_name || f.node_id_str || `!${f.meshtastic_node_id.toString(16)}`;
 }
 
 interface HexBin {
@@ -52,7 +52,7 @@ export interface FeederCoverageMapProps {
 }
 
 function ghostLabel(g: CoverageHeardGhost): string {
-  return g.short_name || g.long_name || g.node_id_str || `!${g.node_id.toString(16)}`;
+  return g.short_name || g.long_name || g.node_id_str || `!${g.meshtastic_node_id.toString(16)}`;
 }
 
 export function FeederCoverageMap({
@@ -253,7 +253,7 @@ export function FeederCoverageMap({
                   : getTargetLabel(selectedTarget)}
               </div>
               <div className="mt-0.5 text-xs text-slate-400">
-                {selectedTarget.node_id_str || `!${selectedTarget.node_id.toString(16)}`}
+                {selectedTarget.node_id_str || `!${selectedTarget.meshtastic_node_id.toString(16)}`}
               </div>
               <div className="mt-1 text-xs">
                 {selectedTarget.successes} / {selectedTarget.attempts} (
@@ -266,7 +266,7 @@ export function FeederCoverageMap({
                 Smoothed: {(smoothedRate(selectedTarget.successes, selectedTarget.attempts) * 100).toFixed(0)}%
               </div>
               <Link
-                to={`/nodes/${selectedTarget.node_id}`}
+                to={`/nodes/${selectedTarget.meshtastic_node_id}`}
                 className="mt-1 inline-block text-xs text-emerald-400 hover:text-emerald-300 hover:underline"
               >
                 Open details
@@ -301,10 +301,10 @@ export function FeederCoverageMap({
               </div>
               <div className="mt-0.5 font-semibold">{ghostLabel(selectedHeardGhost)}</div>
               <div className="mt-0.5 text-xs text-slate-400">
-                {selectedHeardGhost.node_id_str || `!${selectedHeardGhost.node_id.toString(16)}`}
+                {selectedHeardGhost.node_id_str || `!${selectedHeardGhost.meshtastic_node_id.toString(16)}`}
               </div>
               <Link
-                to={`/nodes/${selectedHeardGhost.node_id}`}
+                to={`/nodes/${selectedHeardGhost.meshtastic_node_id}`}
                 className="mt-1 inline-block text-xs text-emerald-400 hover:text-emerald-300 hover:underline"
               >
                 Open details
@@ -337,10 +337,10 @@ export function FeederCoverageMap({
               <div className="text-xs font-medium uppercase tracking-wide text-amber-400">Managed node (feeder)</div>
               <div className="mt-0.5 font-semibold">{feederPopupTitle(selectedFeederMarker)}</div>
               <div className="mt-0.5 text-xs text-slate-400">
-                {selectedFeederMarker.node_id_str || `!${selectedFeederMarker.node_id.toString(16)}`}
+                {selectedFeederMarker.node_id_str || `!${selectedFeederMarker.meshtastic_node_id.toString(16)}`}
               </div>
               <Link
-                to={`/nodes/${selectedFeederMarker.node_id}`}
+                to={`/nodes/${selectedFeederMarker.meshtastic_node_id}`}
                 className="mt-1 inline-block text-xs text-emerald-400 hover:text-emerald-300 hover:underline"
               >
                 Open details

--- a/src/components/traceroutes/TracerouteFlowDiagram.tsx
+++ b/src/components/traceroutes/TracerouteFlowDiagram.tsx
@@ -26,7 +26,7 @@ function FlowEndpointBadge({
 }
 
 function NodeBadge({ node }: { node: TracerouteRouteNode }) {
-  const isPlaceholderUnknown = node.node_id === UNKNOWN_NODE_ID;
+  const isPlaceholderUnknown = node.meshtastic_node_id === UNKNOWN_NODE_ID;
   const useMutedStyle = isPlaceholderUnknown || !node.position;
   const label = node.short_name ?? node.node_id_str;
   const badge = (
@@ -50,7 +50,7 @@ function NodeBadge({ node }: { node: TracerouteRouteNode }) {
 
   return (
     <Link
-      to={`/nodes/${node.node_id}`}
+      to={`/nodes/${node.meshtastic_node_id}`}
       onClick={(e) => e.stopPropagation()}
       className="inline-flex max-w-full rounded-md focus:outline-none focus:ring-2 focus:ring-ring focus:ring-offset-2"
     >
@@ -78,7 +78,7 @@ function FlowRow({
     <div className="flex flex-wrap items-center gap-1">
       <FlowEndpointBadge label={startLabel} nodeId={startNodeId} directionColor={directionColor} />
       {nodes.map((node, i) => (
-        <span key={`${node.node_id}-${i}`} className="flex items-center gap-1">
+        <span key={`${node.meshtastic_node_id}-${i}`} className="flex items-center gap-1">
           <ArrowRight className="h-4 w-4 shrink-0 text-muted-foreground" />
           <NodeBadge node={node} />
         </span>
@@ -94,8 +94,8 @@ export function TracerouteFlowDiagram({ traceroute }: { traceroute: AutoTraceRou
   const routeBackNodes = traceroute.route_back_nodes ?? [];
   const sourceLabel = traceroute.source_node?.short_name ?? traceroute.source_node?.node_id_str ?? 'Source';
   const targetLabel = traceroute.target_node?.short_name ?? traceroute.target_node?.node_id_str ?? 'Target';
-  const sourceNodeId = traceroute.source_node.node_id;
-  const targetNodeId = traceroute.target_node.node_id;
+  const sourceNodeId = traceroute.source_node.meshtastic_node_id;
+  const targetNodeId = traceroute.target_node.meshtastic_node_id;
 
   if (routeNodes.length === 0 && routeBackNodes.length === 0) {
     if (traceroute.status !== 'completed') {

--- a/src/components/traceroutes/TracerouteHeatmapBackboneRelayTable.tsx
+++ b/src/components/traceroutes/TracerouteHeatmapBackboneRelayTable.tsx
@@ -47,12 +47,14 @@ function RoleNodeTable({ nodes }: { nodes: HeatmapNode[] }) {
       </TableHeader>
       <TableBody>
         {nodes.map((n) => (
-          <TableRow key={n.node_id}>
+          <TableRow key={n.meshtastic_node_id}>
             <TableCell>
-              <Link to={`/nodes/${n.node_id}`} className="font-medium text-primary hover:underline">
+              <Link to={`/nodes/${n.meshtastic_node_id}`} className="font-medium text-primary hover:underline">
                 {getHeatmapNodeLabel(n)}
               </Link>
-              <div className="text-muted-foreground text-xs">{n.node_id_str ?? `!${n.node_id.toString(16)}`}</div>
+              <div className="text-muted-foreground text-xs">
+                {n.node_id_str ?? `!${n.meshtastic_node_id.toString(16)}`}
+              </div>
             </TableCell>
             <TableCell className="text-right tabular-nums">
               {n.centrality != null ? `${(n.centrality * 100).toFixed(1)}%` : '—'}

--- a/src/components/traceroutes/TracerouteHeatmapChrome.tsx
+++ b/src/components/traceroutes/TracerouteHeatmapChrome.tsx
@@ -190,8 +190,8 @@ export function TracerouteHeatmapChrome({
           <SelectContent>
             <SelectItem value="all">All sources</SelectItem>
             {managedNodes.map((n) => (
-              <SelectItem key={n.node_id} value={String(n.node_id)}>
-                {n.short_name ?? n.node_id_str ?? String(n.node_id)}
+              <SelectItem key={n.meshtastic_node_id} value={String(n.meshtastic_node_id)}>
+                {n.short_name ?? n.node_id_str ?? String(n.meshtastic_node_id)}
               </SelectItem>
             ))}
           </SelectContent>

--- a/src/components/traceroutes/TracerouteHeatmapMap.test.tsx
+++ b/src/components/traceroutes/TracerouteHeatmapMap.test.tsx
@@ -51,7 +51,7 @@ vi.mock('@/components/map/DeckMapboxMap', () => ({
 }));
 
 const nodeA: HeatmapNode = {
-  node_id: 0x11a,
+  meshtastic_node_id: 0x11a,
   node_id_str: '!0000011a',
   short_name: 'A',
   long_name: 'Node A',
@@ -60,7 +60,7 @@ const nodeA: HeatmapNode = {
 };
 
 const nodeB: HeatmapNode = {
-  node_id: 0x11b,
+  meshtastic_node_id: 0x11b,
   node_id_str: '!0000011b',
   short_name: 'B',
   long_name: 'Node B',
@@ -69,8 +69,8 @@ const nodeB: HeatmapNode = {
 };
 
 const edge: HeatmapEdge = {
-  from_node_id: nodeA.node_id,
-  to_node_id: nodeB.node_id,
+  from_node_id: nodeA.meshtastic_node_id,
+  to_node_id: nodeB.meshtastic_node_id,
   from_lng: -4.2,
   from_lat: 55.9,
   to_lng: -4.15,
@@ -80,7 +80,7 @@ const edge: HeatmapEdge = {
 };
 
 const hub: HeatmapNode = {
-  node_id: 0x11c,
+  meshtastic_node_id: 0x11c,
   node_id_str: '!0000011c',
   short_name: 'Hub',
   long_name: 'Hub',
@@ -92,7 +92,7 @@ const hub: HeatmapNode = {
 };
 
 const spoke: HeatmapNode = {
-  node_id: 0x11d,
+  meshtastic_node_id: 0x11d,
   node_id_str: '!0000011d',
   short_name: 'Spoke',
   long_name: 'Spoke',
@@ -104,7 +104,7 @@ const spoke: HeatmapNode = {
 };
 
 const peer: HeatmapNode = {
-  node_id: 0x11e,
+  meshtastic_node_id: 0x11e,
   node_id_str: '!0000011e',
   short_name: 'Peer',
   long_name: 'Peer',
@@ -116,8 +116,8 @@ const peer: HeatmapNode = {
 };
 
 const edgeHubSpoke: HeatmapEdge = {
-  from_node_id: hub.node_id,
-  to_node_id: spoke.node_id,
+  from_node_id: hub.meshtastic_node_id,
+  to_node_id: spoke.meshtastic_node_id,
   from_lng: hub.lng,
   from_lat: hub.lat,
   to_lng: spoke.lng,
@@ -127,8 +127,8 @@ const edgeHubSpoke: HeatmapEdge = {
 };
 
 const edgeHubPeer: HeatmapEdge = {
-  from_node_id: hub.node_id,
-  to_node_id: peer.node_id,
+  from_node_id: hub.meshtastic_node_id,
+  to_node_id: peer.meshtastic_node_id,
   from_lng: hub.lng,
   from_lat: hub.lat,
   to_lng: peer.lng,

--- a/src/components/traceroutes/TracerouteHeatmapMap.tsx
+++ b/src/components/traceroutes/TracerouteHeatmapMap.tsx
@@ -84,7 +84,7 @@ export function TracerouteHeatmapMap({
 
   const roleById = useMemo(() => {
     const m = new Map<number, HeatmapNode['role']>();
-    for (const n of nodes) m.set(n.node_id, n.role);
+    for (const n of nodes) m.set(n.meshtastic_node_id, n.role);
     return m;
   }, [nodes]);
 

--- a/src/components/traceroutes/TracerouteHeatmapNodePanel.tsx
+++ b/src/components/traceroutes/TracerouteHeatmapNodePanel.tsx
@@ -48,7 +48,9 @@ export function TracerouteHeatmapNodePanel({
         <div className="font-semibold">
           {node.long_name && node.short_name ? `${node.long_name} (${node.short_name})` : getHeatmapNodeLabel(node)}
         </div>
-        <div className="mt-0.5 text-xs text-slate-400">{node.node_id_str || `!${node.node_id.toString(16)}`}</div>
+        <div className="mt-0.5 text-xs text-slate-400">
+          {node.node_id_str || `!${node.meshtastic_node_id.toString(16)}`}
+        </div>
         {(node.centrality != null || node.degree != null) && (
           <dl className="mt-2 space-y-0.5 text-xs text-slate-300">
             {node.centrality != null && (
@@ -75,7 +77,7 @@ export function TracerouteHeatmapNodePanel({
           Last seen: <span className="text-slate-300">{formatRecency(node.last_seen)}</span>
         </div>
         <Link
-          to={`/nodes/${node.node_id}`}
+          to={`/nodes/${node.meshtastic_node_id}`}
           className="mt-1 inline-block text-xs text-emerald-400 hover:text-emerald-300 hover:underline"
         >
           Open details

--- a/src/components/traceroutes/TracerouteMap.test.tsx
+++ b/src/components/traceroutes/TracerouteMap.test.tsx
@@ -6,7 +6,7 @@ import type { AutoTraceRoute, ManagedNode, ObservedNode } from '@/lib/models';
 
 function makeSource(): ManagedNode {
   return {
-    node_id: 1,
+    meshtastic_node_id: 1,
     long_name: 'Source',
     short_name: 'SRC',
     last_heard: null,
@@ -21,7 +21,7 @@ function makeSource(): ManagedNode {
 function makeTarget(): ObservedNode {
   return {
     internal_id: 2,
-    node_id: 2,
+    meshtastic_node_id: 2,
     node_id_str: '!00000002',
     mac_addr: null,
     long_name: 'Target',

--- a/src/components/traceroutes/TracerouteMap.tsx
+++ b/src/components/traceroutes/TracerouteMap.tsx
@@ -268,8 +268,12 @@ export function TracerouteMap({ traceroute }: { traceroute: AutoTraceRoute }) {
 
       const intermediateByNodeId = new Map<number, { pos: LatLng; label: string }>();
       for (const node of [...routeNodes, ...routeBackNodes]) {
-        if (node.position && node.node_id !== UNKNOWN_NODE_ID && !intermediateByNodeId.has(node.node_id)) {
-          intermediateByNodeId.set(node.node_id, {
+        if (
+          node.position &&
+          node.meshtastic_node_id !== UNKNOWN_NODE_ID &&
+          !intermediateByNodeId.has(node.meshtastic_node_id)
+        ) {
+          intermediateByNodeId.set(node.meshtastic_node_id, {
             pos: [node.position.latitude, node.position.longitude],
             label: node.short_name ?? node.node_id_str,
           });

--- a/src/components/traceroutes/TracerouteStatsSection.tsx
+++ b/src/components/traceroutes/TracerouteStatsSection.tsx
@@ -137,7 +137,7 @@ export function TracerouteStatsSection({ sourceNodeId = null }: TracerouteStatsS
 
   const sourceScopeHint = useMemo(() => {
     if (sourceNodeId == null || !data?.by_source?.length) return null;
-    const row = data.by_source.find((r) => r.node_id === sourceNodeId);
+    const row = data.by_source.find((r) => r.meshtastic_node_id === sourceNodeId);
     if (!row) return 'Stats scoped to the selected source node.';
     return `Stats scoped to source ${row.short_name ?? row.node_id_str ?? sourceNodeId}.`;
   }, [sourceNodeId, data?.by_source]);
@@ -650,7 +650,7 @@ export function TracerouteStatsSection({ sourceNodeId = null }: TracerouteStatsS
 }
 
 interface TargetRow {
-  node_id: number;
+  meshtastic_node_id: number;
   node_id_str: string;
   short_name: string | null;
   long_name: string | null;
@@ -698,10 +698,10 @@ function TargetsRankingCard({
               </TableHeader>
               <TableBody>
                 {rows.map((row) => (
-                  <TableRow key={row.node_id}>
+                  <TableRow key={row.meshtastic_node_id}>
                     <TableCell>
                       <Link
-                        to={`/traceroutes/history?target_node=${row.node_id}`}
+                        to={`/traceroutes/history?target_node=${row.meshtastic_node_id}`}
                         className="flex flex-col gap-0.5 min-w-0 hover:underline"
                       >
                         <span className="font-medium truncate" title={row.short_name ?? row.node_id_str}>

--- a/src/components/traceroutes/TracerouteTopologyGraph.tsx
+++ b/src/components/traceroutes/TracerouteTopologyGraph.tsx
@@ -87,7 +87,7 @@ export function TracerouteTopologyGraph({
 
   const roleById = useMemo(() => {
     const m = new Map<number, HeatmapNode['role']>();
-    for (const n of nodes) m.set(n.node_id, n.role);
+    for (const n of nodes) m.set(n.meshtastic_node_id, n.role);
     return m;
   }, [nodes]);
 
@@ -104,7 +104,7 @@ export function TracerouteTopologyGraph({
     return m;
   }, [edges]);
 
-  const sortedIds = useMemo(() => [...nodes.map((n) => n.node_id)].sort((a, b) => a - b), [nodes]);
+  const sortedIds = useMemo(() => [...nodes.map((n) => n.meshtastic_node_id)].sort((a, b) => a - b), [nodes]);
 
   const simulationNodesRef = useRef<SimNode[]>([]);
   const simulationLinksRef = useRef<GraphLink[]>([]);
@@ -134,10 +134,10 @@ export function TracerouteTopologyGraph({
       return;
     }
 
-    const byId = new Map(nodes.map((n) => [n.node_id, { ...n } as SimNode]));
+    const byId = new Map(nodes.map((n) => [n.meshtastic_node_id, { ...n } as SimNode]));
     const simNodes: SimNode[] = nodes.map((n) => {
-      const prev = warmRef.current.get(n.node_id);
-      const seed = deterministicSeedXY(n.node_id, width, height);
+      const prev = warmRef.current.get(n.meshtastic_node_id);
+      const seed = deterministicSeedXY(n.meshtastic_node_id, width, height);
       return {
         ...n,
         x: prev?.x ?? seed.x,
@@ -146,7 +146,7 @@ export function TracerouteTopologyGraph({
     });
 
     for (const sn of simNodes) {
-      byId.set(sn.node_id, sn);
+      byId.set(sn.meshtastic_node_id, sn);
     }
 
     const linkObjs: GraphLink[] = [];
@@ -165,7 +165,7 @@ export function TracerouteTopologyGraph({
         'link',
         d3
           .forceLink<SimNode, GraphLink>(linkObjs)
-          .id((d) => d.node_id)
+          .id((d) => d.meshtastic_node_id)
           .distance((d) => {
             if (!enc) return (minD + maxD) / 2;
             const t = linkStrengthValue(d.edge, enc);
@@ -197,7 +197,7 @@ export function TracerouteTopologyGraph({
 
     for (const n of simNodes) {
       if (n.x != null && n.y != null) {
-        warmRef.current.set(n.node_id, { x: n.x, y: n.y });
+        warmRef.current.set(n.meshtastic_node_id, { x: n.x, y: n.y });
       }
     }
 
@@ -249,8 +249,9 @@ export function TracerouteTopologyGraph({
       const a = L.source;
       const b = L.target;
       if (a.x == null || a.y == null || b.x == null || b.y == null) continue;
-      const alphaMul = edgeFade(a.node_id, b.node_id);
-      const touchesLeaf = roleById.get(a.node_id) === 'leaf' || roleById.get(b.node_id) === 'leaf';
+      const alphaMul = edgeFade(a.meshtastic_node_id, b.meshtastic_node_id);
+      const touchesLeaf =
+        roleById.get(a.meshtastic_node_id) === 'leaf' || roleById.get(b.meshtastic_node_id) === 'leaf';
       let stroke: [number, number, number, number];
       let lw: number;
       if (touchesLeaf) {
@@ -276,8 +277,8 @@ export function TracerouteTopologyGraph({
 
     const nodeDrawOrder = [...simNodes].sort((u, v) => {
       if (highlight == null) return 0;
-      if (u.node_id === highlight) return 1;
-      if (v.node_id === highlight) return -1;
+      if (u.meshtastic_node_id === highlight) return 1;
+      if (v.meshtastic_node_id === highlight) return -1;
       return 0;
     });
 
@@ -286,7 +287,7 @@ export function TracerouteTopologyGraph({
       const r = hasSignal ? nodeRadiusPixels(n.centrality, cExt.min, cExt.max) : 9;
       const fill = hasSignal ? degreeFillColor(n, dExt.min, dExt.max, nowMs, staleMs) : HEATMAP_NODE_COLOR_FALLBACK;
       const strokeCol = nodeLineColor(fill);
-      const fade = nodeFade(n.node_id);
+      const fade = nodeFade(n.meshtastic_node_id);
       ctx.beginPath();
       ctx.arc(n.x, n.y, r, 0, Math.PI * 2);
       ctx.fillStyle = `rgba(${fill[0]},${fill[1]},${fill[2]},${(fill[3] / 255) * fade})`;
@@ -309,7 +310,7 @@ export function TracerouteTopologyGraph({
       const gx = n.x * transform.k + transform.x;
       const gy = n.y * transform.k + transform.y;
       const rPx = (hasSignal ? nodeRadiusPixels(n.centrality, cExt.min, cExt.max) : 9) * transform.k;
-      const fade = nodeFade(n.node_id);
+      const fade = nodeFade(n.meshtastic_node_id);
       const label = truncateTopologyLabel(getHeatmapNodeLabel(n));
       const ty = gy + rPx + labelPx * 0.65 + 2;
       ctx.strokeStyle = `rgba(15, 23, 42, ${0.92 * fade})`;
@@ -373,7 +374,7 @@ export function TracerouteTopologyGraph({
   const onPointerMove = useCallback(
     (e: React.PointerEvent) => {
       const n = pickNode(e.clientX, e.clientY);
-      setHoverId(n?.node_id ?? null);
+      setHoverId(n?.meshtastic_node_id ?? null);
     },
     [pickNode]
   );
@@ -384,7 +385,7 @@ export function TracerouteTopologyGraph({
     (e: React.MouseEvent) => {
       const n = pickNode(e.clientX, e.clientY);
       onSelectedNodeChange(n);
-      if (n) setLiveMsg(`${n.short_name ?? n.node_id_str ?? n.node_id} selected`);
+      if (n) setLiveMsg(`${n.short_name ?? n.node_id_str ?? n.meshtastic_node_id} selected`);
     },
     [pickNode, onSelectedNodeChange]
   );
@@ -401,9 +402,9 @@ export function TracerouteTopologyGraph({
       } else if (e.key === 'Enter' || e.key === ' ') {
         e.preventDefault();
         const id = sortedIds[focusIndex];
-        const node = nodes.find((n) => n.node_id === id) ?? null;
+        const node = nodes.find((n) => n.meshtastic_node_id === id) ?? null;
         onSelectedNodeChange(node);
-        if (node) setLiveMsg(`${node.short_name ?? node.node_id_str ?? node.node_id} selected`);
+        if (node) setLiveMsg(`${node.short_name ?? node.node_id_str ?? node.meshtastic_node_id} selected`);
       }
     },
     [sortedIds, focusIndex, nodes, onSelectedNodeChange]
@@ -411,7 +412,7 @@ export function TracerouteTopologyGraph({
 
   useEffect(() => {
     const id = sortedIds[focusIndex];
-    const node = nodes.find((n) => n.node_id === id);
+    const node = nodes.find((n) => n.meshtastic_node_id === id);
     if (node && document.activeElement?.getAttribute('data-testid') === 'topology-canvas') {
       setLiveMsg(`Focused ${node.short_name ?? node.node_id_str ?? id}`);
     }
@@ -440,7 +441,7 @@ export function TracerouteTopologyGraph({
       )}
       <ul className="sr-only" aria-hidden>
         {nodes.map((n) => (
-          <li key={n.node_id}>{n.short_name ?? n.node_id_str ?? n.node_id}</li>
+          <li key={n.meshtastic_node_id}>{n.short_name ?? n.node_id_str ?? n.meshtastic_node_id}</li>
         ))}
       </ul>
       <div className="sr-only" aria-live="polite">

--- a/src/components/traceroutes/heatmapEncoding.test.ts
+++ b/src/components/traceroutes/heatmapEncoding.test.ts
@@ -48,7 +48,7 @@ describe('heatmapEncoding', () => {
     const nowMs = Date.parse('2026-01-15T12:00:00.000Z');
     const fill = degreeFillColor(
       {
-        node_id: 1,
+        meshtastic_node_id: 1,
         node_id_str: '!1',
         lat: 0,
         lng: 0,

--- a/src/components/traceroutes/heatmapEncoding.ts
+++ b/src/components/traceroutes/heatmapEncoding.ts
@@ -1,7 +1,7 @@
 import type { HeatmapEdge, HeatmapNode } from '@/hooks/api/useHeatmapEdges';
 
 export function getHeatmapNodeLabel(node: HeatmapNode): string {
-  return node.short_name || node.long_name || node.node_id_str || `!${node.node_id.toString(16)}`;
+  return node.short_name || node.long_name || node.node_id_str || `!${node.meshtastic_node_id.toString(16)}`;
 }
 
 /** Fallback fill when API omits centrality/degree */

--- a/src/hooks/api/README.md
+++ b/src/hooks/api/README.md
@@ -80,7 +80,7 @@ function NodeDetail({ nodeId }) {
   return (
     <div>
       <h2>{node.short_name || node.node_id_str}</h2>
-      <p>Node ID: {node.node_id}</p>
+      <p>Node ID: {node.meshtastic_node_id}</p>
       <p>Last heard: {node.last_heard ? new Date(node.last_heard).toLocaleString() : 'Never'}</p>
     </div>
   );

--- a/src/hooks/api/useDxMonitoring.ts
+++ b/src/hooks/api/useDxMonitoring.ts
@@ -70,7 +70,7 @@ export function useDxNodeExclusionMutation() {
   const api = useMeshtasticApi();
   const queryClient = useQueryClient();
   return useMutation({
-    mutationFn: (body: { node_id: number; exclude_from_detection: boolean; exclude_notes?: string }) =>
+    mutationFn: (body: { meshtastic_node_id: number; exclude_from_detection: boolean; exclude_notes?: string }) =>
       api.postDxNodeExclusion(body),
     onSuccess: () => {
       queryClient.invalidateQueries({ queryKey: ['dx'] });

--- a/src/hooks/api/useHeatmapEdges.ts
+++ b/src/hooks/api/useHeatmapEdges.ts
@@ -15,7 +15,7 @@ export interface HeatmapEdge {
 export type HeatmapNodeRole = 'backbone' | 'relay' | 'leaf' | 'offline';
 
 export interface HeatmapNode {
-  node_id: number;
+  meshtastic_node_id: number;
   node_id_str: string;
   lat: number;
   lng: number;

--- a/src/hooks/api/useMultiNodeEnvironmentMetrics.ts
+++ b/src/hooks/api/useMultiNodeEnvironmentMetrics.ts
@@ -5,17 +5,17 @@ import { DateRangeParams } from '@/lib/types';
 import { getKeyValue, roundDateParams } from './hooks-utils';
 
 /**
- * Transform flat bulk response into metricsMap keyed by node_id.
- * Strips node_id, node_id_str, short_name from each item for EnvironmentMetrics shape.
+ * Transform flat bulk response into metricsMap keyed by meshtastic_node_id.
+ * Strips meshtastic_node_id, node_id_str, short_name from each item for EnvironmentMetrics shape.
  */
 function bulkResultsToMetricsMap(
-  results: Array<EnvironmentMetrics & { node_id: number; node_id_str?: string; short_name?: string | null }>
+  results: Array<EnvironmentMetrics & { meshtastic_node_id: number; node_id_str?: string; short_name?: string | null }>
 ): Record<number, EnvironmentMetrics[]> {
   const map: Record<number, EnvironmentMetrics[]> = {};
   for (const item of results) {
-    const { node_id, ...metric } = item;
-    if (!map[node_id]) map[node_id] = [];
-    map[node_id].push(metric as EnvironmentMetrics);
+    const { meshtastic_node_id, ...metric } = item;
+    if (!map[meshtastic_node_id]) map[meshtastic_node_id] = [];
+    map[meshtastic_node_id].push(metric as EnvironmentMetrics);
   }
   // Sort each node's metrics by reported_time ascending (for chart ordering)
   for (const nodeId of Object.keys(map)) {
@@ -36,7 +36,7 @@ function bulkResultsToMetricsMap(
  */
 export function useMultiNodeEnvironmentMetrics(nodes: ObservedNode[], dateRange?: DateRangeParams) {
   const api = useMeshtasticApi();
-  const nodeIds = nodes.map((n) => n.node_id);
+  const nodeIds = nodes.map((n) => n.meshtastic_node_id);
   const params = roundDateParams(dateRange);
   const keyValue = getKeyValue(params);
   const queryKey = ['nodes', 'environment-metrics-bulk', nodeIds.sort().join(','), keyValue];
@@ -67,7 +67,7 @@ export function useMultiNodeEnvironmentMetrics(nodes: ObservedNode[], dateRange?
 export function useMultiNodeEnvironmentMetricsSuspense(nodes: ObservedNode[], params?: DateRangeParams) {
   const api = useMeshtasticApi();
   const roundedParams = roundDateParams(params);
-  const nodeIds = nodes.map((n) => n.node_id);
+  const nodeIds = nodes.map((n) => n.meshtastic_node_id);
   const keyValue = getKeyValue(roundedParams);
   const queryKey = ['nodes', 'environment-metrics-bulk', nodeIds.sort().join(','), keyValue];
 

--- a/src/hooks/api/useMultiNodeMetrics.ts
+++ b/src/hooks/api/useMultiNodeMetrics.ts
@@ -6,17 +6,17 @@ import { getKeyValue } from './hooks-utils';
 import { roundDateParams } from './hooks-utils';
 
 /**
- * Transform flat bulk response into metricsMap keyed by node_id.
- * Strips node_id, node_id_str, short_name from each item for DeviceMetrics shape.
+ * Transform flat bulk response into metricsMap keyed by meshtastic_node_id.
+ * Strips meshtastic_node_id, node_id_str, short_name from each item for DeviceMetrics shape.
  */
 function bulkResultsToMetricsMap(
-  results: Array<DeviceMetrics & { node_id: number; node_id_str?: string; short_name?: string | null }>
+  results: Array<DeviceMetrics & { meshtastic_node_id: number; node_id_str?: string; short_name?: string | null }>
 ): Record<number, DeviceMetrics[]> {
   const map: Record<number, DeviceMetrics[]> = {};
   for (const item of results) {
-    const { node_id, ...metric } = item;
-    if (!map[node_id]) map[node_id] = [];
-    map[node_id].push(metric as DeviceMetrics);
+    const { meshtastic_node_id, ...metric } = item;
+    if (!map[meshtastic_node_id]) map[meshtastic_node_id] = [];
+    map[meshtastic_node_id].push(metric as DeviceMetrics);
   }
   // Sort each node's metrics by reported_time ascending (for chart ordering)
   for (const nodeId of Object.keys(map)) {
@@ -37,7 +37,7 @@ function bulkResultsToMetricsMap(
  */
 export function useMultiNodeMetrics(nodes: ObservedNode[], dateRange?: DateRangeParams) {
   const api = useMeshtasticApi();
-  const nodeIds = nodes.map((n) => n.node_id);
+  const nodeIds = nodes.map((n) => n.meshtastic_node_id);
   const params = roundDateParams(dateRange);
   const keyValue = getKeyValue(params);
   const queryKey = ['nodes', 'metrics-bulk', nodeIds.sort().join(','), keyValue];
@@ -68,7 +68,7 @@ export function useMultiNodeMetrics(nodes: ObservedNode[], dateRange?: DateRange
 export function useMultiNodeMetricsSuspense(nodes: ObservedNode[], params?: DateRangeParams) {
   const api = useMeshtasticApi();
   const roundedParams = roundDateParams(params);
-  const nodeIds = nodes.map((n) => n.node_id);
+  const nodeIds = nodes.map((n) => n.meshtastic_node_id);
   const keyValue = getKeyValue(roundedParams);
   const queryKey = ['nodes', 'metrics-bulk', nodeIds.sort().join(','), keyValue];
 

--- a/src/hooks/api/useNodeTracerouteLinks.ts
+++ b/src/hooks/api/useNodeTracerouteLinks.ts
@@ -14,7 +14,7 @@ export interface NodeTracerouteLinkEdge {
 }
 
 export interface NodeTracerouteLinkNode {
-  node_id: number;
+  meshtastic_node_id: number;
   node_id_str?: string;
   lat: number;
   lng: number;

--- a/src/hooks/useRecentNodes.ts
+++ b/src/hooks/useRecentNodes.ts
@@ -4,7 +4,7 @@ import { ObservedNode } from '@/lib/models';
 // Type for storing recent nodes in local storage
 interface RecentNode {
   internal_id: number; // internal_id from ObservedNode
-  node_id: number; // node_id from ObservedNode
+  meshtastic_node_id: number; // meshtastic_node_id from ObservedNode
   node_id_str: string; // node_id_str from ObservedNode
   short_name: string | null;
   long_name: string | null;
@@ -53,7 +53,7 @@ export function useRecentNodes() {
       // Create a new node entry
       const newNode: RecentNode = {
         internal_id: node.internal_id,
-        node_id: node.node_id,
+        meshtastic_node_id: node.meshtastic_node_id,
         node_id_str: node.node_id_str,
         short_name: node.short_name,
         long_name: node.long_name,

--- a/src/lib/api/api-utils.ts
+++ b/src/lib/api/api-utils.ts
@@ -4,7 +4,7 @@ import { NodeWatch, ObservedNode } from '../models';
 export function parseObservedNodeFromAPI(node: ObservedNode): ObservedNode {
   return {
     ...node,
-    node_id: node.node_id ?? 0,
+    meshtastic_node_id: node.meshtastic_node_id ?? 0,
     last_heard: node.last_heard ? new Date(node.last_heard) : null,
     latest_position: node.latest_position
       ? {

--- a/src/lib/api/meshtastic-api.ts
+++ b/src/lib/api/meshtastic-api.ts
@@ -46,7 +46,7 @@ import type { RfProfile, RfProfileUpdateBody, RfPropagationPollResult, RfPropaga
 
 export interface FeederReachFeeder {
   managed_node_id: string;
-  node_id: number;
+  meshtastic_node_id: number;
   node_id_str: string;
   short_name?: string | null;
   long_name?: string | null;
@@ -55,7 +55,7 @@ export interface FeederReachFeeder {
 }
 
 export interface FeederReachTarget {
-  node_id: number;
+  meshtastic_node_id: number;
   node_id_str: string;
   short_name?: string | null;
   long_name?: string | null;
@@ -88,7 +88,7 @@ export interface ConstellationCoverageHex {
 
 /** Per-target aggregate across all feeders (when `include_targets=1`). */
 export interface ConstellationCoverageTarget {
-  node_id: number;
+  meshtastic_node_id: number;
   node_id_str: string;
   short_name: string | null;
   long_name: string | null;
@@ -157,7 +157,7 @@ export class MeshtasticApi extends BaseApi {
   }
 
   /**
-   * Get one observed node by Meshtastic numeric `node_id` (path `/nodes/observed-nodes/{id}/`).
+   * Get one observed node by Meshtastic numeric `meshtastic_node_id` (path `/nodes/observed-nodes/{id}/`).
    * Not valid for MeshCore nodes until internal_id lookup exists — use {@link getNodes} with
    * `protocol: 'meshcore'` or search instead.
    */
@@ -287,12 +287,12 @@ export class MeshtasticApi extends BaseApi {
 
   /**
    * Get device metrics for multiple nodes in one request (bulk).
-   * Returns flat list; frontend groups by node_id for per-node charts.
+   * Returns flat list; frontend groups by meshtastic_node_id for per-node charts.
    */
   async getDeviceMetricsBulk(
     nodeIds: number[],
     params?: DateRangeParams
-  ): Promise<Array<DeviceMetrics & { node_id: number; node_id_str: string; short_name: string | null }>> {
+  ): Promise<Array<DeviceMetrics & { meshtastic_node_id: number; node_id_str: string; short_name: string | null }>> {
     if (nodeIds.length === 0) return [];
     const searchParams = new URLSearchParams();
     searchParams.append('node_ids', nodeIds.join(','));
@@ -300,7 +300,7 @@ export class MeshtasticApi extends BaseApi {
     if (params?.endDate) searchParams.append('end_date', params.endDate.toISOString());
 
     const response = await this.get<{
-      results: Array<DeviceMetrics & { node_id: number; node_id_str: string; short_name: string | null }>;
+      results: Array<DeviceMetrics & { meshtastic_node_id: number; node_id_str: string; short_name: string | null }>;
     }>('/nodes/device-metrics-bulk/', searchParams);
     return (response.results || []).map((metric) => ({
       ...metric,
@@ -327,12 +327,14 @@ export class MeshtasticApi extends BaseApi {
 
   /**
    * Get environment metrics for multiple nodes in one request (bulk).
-   * Returns flat list; frontend groups by node_id for per-node charts.
+   * Returns flat list; frontend groups by meshtastic_node_id for per-node charts.
    */
   async getEnvironmentMetricsBulk(
     nodeIds: number[],
     params?: DateRangeParams
-  ): Promise<Array<EnvironmentMetrics & { node_id: number; node_id_str: string; short_name: string | null }>> {
+  ): Promise<
+    Array<EnvironmentMetrics & { meshtastic_node_id: number; node_id_str: string; short_name: string | null }>
+  > {
     if (nodeIds.length === 0) return [];
     const searchParams = new URLSearchParams();
     searchParams.append('node_ids', nodeIds.join(','));
@@ -340,7 +342,9 @@ export class MeshtasticApi extends BaseApi {
     if (params?.endDate) searchParams.append('end_date', params.endDate.toISOString());
 
     const response = await this.get<{
-      results: Array<EnvironmentMetrics & { node_id: number; node_id_str: string; short_name: string | null }>;
+      results: Array<
+        EnvironmentMetrics & { meshtastic_node_id: number; node_id_str: string; short_name: string | null }
+      >;
     }>('/nodes/environment-metrics-bulk/', searchParams);
     return (response.results || []).map((metric) => ({
       ...metric,
@@ -544,7 +548,7 @@ export class MeshtasticApi extends BaseApi {
     }
   ): Promise<OwnedManagedNode> {
     const data: CreateManagedNode = {
-      node_id: nodeId,
+      meshtastic_node_id: nodeId,
       constellation_id: constellationId,
       name: name,
       owner_id: ownerId,
@@ -597,14 +601,14 @@ export class MeshtasticApi extends BaseApi {
    * Add a node to an API key
    */
   async addNodeToApiKey(apiKeyId: string, nodeId: number): Promise<NodeApiKey> {
-    return this.post<NodeApiKey>(`/nodes/api-keys/${apiKeyId}/add_node/`, { node_id: nodeId });
+    return this.post<NodeApiKey>(`/nodes/api-keys/${apiKeyId}/add_node/`, { meshtastic_node_id: nodeId });
   }
 
   /**
    * Remove a node from an API key
    */
   async removeNodeFromApiKey(apiKeyId: string, nodeId: number): Promise<NodeApiKey> {
-    return this.post<NodeApiKey>(`/nodes/api-keys/${apiKeyId}/remove_node/`, { node_id: nodeId });
+    return this.post<NodeApiKey>(`/nodes/api-keys/${apiKeyId}/remove_node/`, { meshtastic_node_id: nodeId });
   }
 
   /**
@@ -848,10 +852,10 @@ export class MeshtasticApi extends BaseApi {
   async getTracerouteStats(params?: { triggered_at_after?: string; source_node?: number }): Promise<{
     sources: Array<{ trigger_type: number; count: number }>;
     success_failure: Array<{ status: string; count: number }>;
-    top_routers: Array<{ node_id: number; node_id_str: string; short_name: string; count: number }>;
+    top_routers: Array<{ meshtastic_node_id: number; node_id_str: string; short_name: string; count: number }>;
     by_source: Array<{
       managed_node_id: string;
-      node_id: number;
+      meshtastic_node_id: number;
       node_id_str: string;
       name: string;
       short_name: string;
@@ -861,7 +865,7 @@ export class MeshtasticApi extends BaseApi {
       success_rate: number | null;
     }>;
     by_target?: Array<{
-      node_id: number;
+      meshtastic_node_id: number;
       node_id_str: string;
       short_name: string | null;
       long_name: string | null;
@@ -909,7 +913,7 @@ export class MeshtasticApi extends BaseApi {
       avg_snr?: number;
     }>;
     nodes: Array<{
-      node_id: number;
+      meshtastic_node_id: number;
       node_id_str: string;
       lat: number;
       lng: number;
@@ -1026,7 +1030,7 @@ export class MeshtasticApi extends BaseApi {
       count: number;
     }>;
     nodes: Array<{
-      node_id: number;
+      meshtastic_node_id: number;
       node_id_str?: string;
       lat: number;
       lng: number;
@@ -1156,7 +1160,7 @@ export class MeshtasticApi extends BaseApi {
   }
 
   async postDxNodeExclusion(body: {
-    node_id: number;
+    meshtastic_node_id: number;
     exclude_from_detection: boolean;
     exclude_notes?: string;
   }): Promise<DxNodeExclusionResponse> {

--- a/src/lib/coverageHeardGhosts.test.ts
+++ b/src/lib/coverageHeardGhosts.test.ts
@@ -8,7 +8,7 @@ describe('observedNodesToCoverageGhosts', () => {
     const nodes: ObservedNode[] = [
       {
         internal_id: 1,
-        node_id: 10,
+        meshtastic_node_id: 10,
         node_id_str: '!a',
         mac_addr: null,
         long_name: 'A',
@@ -19,7 +19,7 @@ describe('observedNodesToCoverageGhosts', () => {
       },
       {
         internal_id: 2,
-        node_id: 20,
+        meshtastic_node_id: 20,
         node_id_str: '!b',
         mac_addr: null,
         long_name: null,
@@ -37,7 +37,7 @@ describe('observedNodesToCoverageGhosts', () => {
     const nodes: ObservedNode[] = [
       {
         internal_id: 3,
-        node_id: 30,
+        meshtastic_node_id: 30,
         node_id_str: '!c',
         mac_addr: null,
         long_name: 'Ghost',
@@ -49,7 +49,7 @@ describe('observedNodesToCoverageGhosts', () => {
     ];
     const g = observedNodesToCoverageGhosts(nodes, new Set());
     expect(g).toHaveLength(1);
-    expect(g[0].node_id).toBe(30);
+    expect(g[0].meshtastic_node_id).toBe(30);
     expect(g[0].lat).toBe(55.1);
     expect(g[0].lng).toBe(-4.1);
   });

--- a/src/lib/coverageHeardGhosts.ts
+++ b/src/lib/coverageHeardGhosts.ts
@@ -2,7 +2,7 @@ import type { ObservedNode } from '@/lib/models';
 
 /** Observed node with position, not shown as a traceroute target or feeder marker. */
 export interface CoverageHeardGhost {
-  node_id: number;
+  meshtastic_node_id: number;
   node_id_str: string;
   short_name: string | null;
   long_name: string | null;
@@ -17,11 +17,11 @@ export function observedNodesToCoverageGhosts(
 ): CoverageHeardGhost[] {
   const out: CoverageHeardGhost[] = [];
   for (const n of nodes) {
-    if (representedNodeIds.has(n.node_id)) continue;
+    if (representedNodeIds.has(n.meshtastic_node_id)) continue;
     const p = n.latest_position;
     if (p == null || p.latitude == null || p.longitude == null) continue;
     out.push({
-      node_id: n.node_id,
+      meshtastic_node_id: n.meshtastic_node_id,
       node_id_str: n.node_id_str,
       short_name: n.short_name ?? null,
       long_name: n.long_name ?? null,

--- a/src/lib/infrastructure-low-battery.test.ts
+++ b/src/lib/infrastructure-low-battery.test.ts
@@ -11,7 +11,7 @@ import {
 function node(partial: Partial<ObservedNode>): ObservedNode {
   return {
     internal_id: 1,
-    node_id: 1,
+    meshtastic_node_id: 1,
     node_id_str: '!00000001',
     mac_addr: null,
     long_name: 'A',
@@ -30,7 +30,7 @@ function node(partial: Partial<ObservedNode>): ObservedNode {
 describe('partitionMeshInfraLowBatteryTableNodes', () => {
   it('includes nodes with battery_alert_active even when not in heuristic low-battery list', () => {
     const okBattery = node({
-      node_id: 1,
+      meshtastic_node_id: 1,
       latest_device_metrics: {
         battery_level: 90,
         reported_time: new Date(),
@@ -39,7 +39,7 @@ describe('partitionMeshInfraLowBatteryTableNodes', () => {
       battery_alert_active: false,
     });
     const alertOnly = node({
-      node_id: 2,
+      meshtastic_node_id: 2,
       latest_device_metrics: {
         battery_level: 90,
         reported_time: new Date(),
@@ -48,7 +48,7 @@ describe('partitionMeshInfraLowBatteryTableNodes', () => {
       battery_alert_active: true,
     });
     const low = node({
-      node_id: 3,
+      meshtastic_node_id: 3,
       latest_device_metrics: {
         battery_level: 10,
         reported_time: new Date(),
@@ -56,10 +56,10 @@ describe('partitionMeshInfraLowBatteryTableNodes', () => {
       } as ObservedNode['latest_device_metrics'],
     });
     const out = partitionMeshInfraLowBatteryTableNodes([okBattery, alertOnly, low]);
-    expect(out.map((n) => n.node_id)).toContain(2);
-    expect(out.map((n) => n.node_id)).toContain(3);
-    expect(out[0].node_id).toBe(2);
-    expect(partitionLowBatteryNodes([okBattery, alertOnly, low]).some((n) => n.node_id === 2)).toBe(false);
+    expect(out.map((n) => n.meshtastic_node_id)).toContain(2);
+    expect(out.map((n) => n.meshtastic_node_id)).toContain(3);
+    expect(out[0].meshtastic_node_id).toBe(2);
+    expect(partitionLowBatteryNodes([okBattery, alertOnly, low]).some((n) => n.meshtastic_node_id === 2)).toBe(false);
   });
 });
 
@@ -71,7 +71,7 @@ describe('isLowBatteryTableRowVisible', () => {
   };
 
   it('hides no-telemetry rows by default', () => {
-    const n = node({ node_id: 1, latest_device_metrics: null });
+    const n = node({ meshtastic_node_id: 1, latest_device_metrics: null });
     expect(isLowBatteryTableRowVisible(n, baseFilters)).toBe(false);
     expect(isLowBatteryTableRowVisible(n, { ...baseFilters, showNoTelemetry: true })).toBe(true);
   });
@@ -79,7 +79,7 @@ describe('isLowBatteryTableRowVisible', () => {
   it('hides stale-reading rows by default', () => {
     const old = new Date(Date.now() - 10 * 24 * 60 * 60 * 1000);
     const n = node({
-      node_id: 2,
+      meshtastic_node_id: 2,
       latest_device_metrics: {
         battery_level: 90,
         reported_time: old,
@@ -93,7 +93,7 @@ describe('isLowBatteryTableRowVisible', () => {
 
   it('shows mesh-alert-only rows regardless of battery filters', () => {
     const n = node({
-      node_id: 3,
+      meshtastic_node_id: 3,
       latest_device_metrics: {
         battery_level: 90,
         reported_time: new Date(),
@@ -109,7 +109,7 @@ describe('hasMeshInfraMapBatteryOrPresenceAlert', () => {
   it('returns false for stale-but-ok percentage', () => {
     const old = new Date(Date.now() - 10 * 24 * 60 * 60 * 1000);
     const n = node({
-      node_id: 1,
+      meshtastic_node_id: 1,
       last_heard: new Date(),
       latest_device_metrics: {
         battery_level: 88,
@@ -123,7 +123,7 @@ describe('hasMeshInfraMapBatteryOrPresenceAlert', () => {
   it('returns true for low percent with stale reading', () => {
     const old = new Date(Date.now() - 10 * 24 * 60 * 60 * 1000);
     const n = node({
-      node_id: 2,
+      meshtastic_node_id: 2,
       last_heard: new Date(),
       latest_device_metrics: {
         battery_level: 12,

--- a/src/lib/infrastructure-low-battery.ts
+++ b/src/lib/infrastructure-low-battery.ts
@@ -123,10 +123,10 @@ function lastHeardTime(node: ObservedNode): number {
  */
 export function partitionMeshInfraLowBatteryTableNodes(nodes: ObservedNode[], now: Date = new Date()): ObservedNode[] {
   const base = partitionLowBatteryNodes(nodes, now);
-  const inBase = new Set(base.map((n) => n.node_id));
+  const inBase = new Set(base.map((n) => n.meshtastic_node_id));
   const additions: ObservedNode[] = [];
   for (const n of nodes) {
-    if (inBase.has(n.node_id)) continue;
+    if (inBase.has(n.meshtastic_node_id)) continue;
     if (n.battery_alert_active) additions.push(n);
   }
   additions.sort((a, b) => lastHeardTime(b) - lastHeardTime(a));
@@ -140,9 +140,9 @@ export function partitionLowBatteryNodes(nodes: ObservedNode[], now: Date = new 
   const seen = new Set<number>();
   const candidates: ObservedNode[] = [];
   for (const n of nodes) {
-    if (seen.has(n.node_id)) continue;
+    if (seen.has(n.meshtastic_node_id)) continue;
     if (!qualifiesLowBatterySection(n, now)) continue;
-    seen.add(n.node_id);
+    seen.add(n.meshtastic_node_id);
     candidates.push(n);
   }
 

--- a/src/lib/managed-node-status.test.ts
+++ b/src/lib/managed-node-status.test.ts
@@ -49,7 +49,7 @@ describe('hasManagedNodeEverFedData', () => {
 
 describe('filterManagedNodesForMapDisplay', () => {
   const base: ManagedNode = {
-    node_id: 1,
+    meshtastic_node_id: 1,
     long_name: null,
     short_name: 'A',
     last_heard: null,
@@ -61,8 +61,8 @@ describe('filterManagedNodesForMapDisplay', () => {
   };
 
   it('drops nodes with no ingestion timestamp', () => {
-    const fed: ManagedNode = { ...base, node_id: 2, last_packet_ingested_at: new Date() };
-    const never: ManagedNode = { ...base, node_id: 3 };
+    const fed: ManagedNode = { ...base, meshtastic_node_id: 2, last_packet_ingested_at: new Date() };
+    const never: ManagedNode = { ...base, meshtastic_node_id: 3 };
     expect(filterManagedNodesForMapDisplay([fed, never])).toEqual([fed]);
   });
 });

--- a/src/lib/models.ts
+++ b/src/lib/models.ts
@@ -84,14 +84,14 @@ export function isRfPropagationNone(r: RfPropagationPollResult): r is { status: 
 
 /**
  * Observed node from Meshflow API (Meshtastic and MeshCore in one list resource).
- * Use `protocol` on list queries to filter; detail by numeric `node_id` is Meshtastic-only today.
+ * Use `protocol` on list queries to filter; detail by numeric `meshtastic_node_id` is Meshtastic-only today.
  */
 export interface ObservedNode {
   /** Stable UUID primary key (API returns string; parsed in api-utils). */
   internal_id: number;
   protocol?: MeshProtocol;
   /** Meshtastic numeric node id; null/absent for MeshCore (use node_id_str / mc_pubkey*). */
-  node_id: number;
+  meshtastic_node_id: number;
   /** Canonical display id: `!hex8` (Meshtastic) or `mc:prefix12` (MeshCore). */
   node_id_str: string;
   mc_pubkey?: string | null;
@@ -171,7 +171,7 @@ export interface MeshCorePacketListItem {
 // ManagedNode from Meshflow API v2
 export interface ManagedNode {
   protocol?: MeshProtocol;
-  node_id: number;
+  meshtastic_node_id: number;
   long_name: string | null;
   short_name: string | null;
   last_heard: Date | null;
@@ -216,7 +216,7 @@ export interface OwnedManagedNode extends ManagedNode {
 }
 
 export interface CreateManagedNode {
-  node_id: number;
+  meshtastic_node_id: number;
   constellation_id: number;
   name: string;
   owner_id: number | null;
@@ -234,7 +234,7 @@ export interface CreateManagedNode {
 
 /** Enriched route node with position for map display (from API route_nodes/route_back_nodes) */
 export interface TracerouteRouteNode {
-  node_id: number;
+  meshtastic_node_id: number;
   node_id_str: string;
   short_name: string | null;
   position: { latitude: number; longitude: number } | null;
@@ -263,8 +263,8 @@ export interface AutoTraceRoute {
   /** Last dispatch/channel error while pending, if any. */
   dispatch_error?: string | null;
   status: 'pending' | 'sent' | 'completed' | 'failed';
-  route: Array<{ node_id: number; snr: number | null }> | null;
-  route_back: Array<{ node_id: number; snr: number | null }> | null;
+  route: Array<{ meshtastic_node_id: number; snr: number | null }> | null;
+  route_back: Array<{ meshtastic_node_id: number; snr: number | null }> | null;
   route_nodes?: TracerouteRouteNode[];
   route_back_nodes?: TracerouteRouteNode[];
   raw_packet: string | null;
@@ -280,7 +280,7 @@ export interface TextMessageSender {
 }
 
 export interface PacketObservationObserver {
-  node_id: number;
+  meshtastic_node_id: number;
   node_id_str: string;
   long_name: string | null;
   short_name: string | null;
@@ -420,7 +420,7 @@ export interface Position {
 // API response types
 export interface NodeSearchResult {
   internal_id: number;
-  node_id: number;
+  meshtastic_node_id: number;
   node_id_str: string;
   short_name: string | null;
   long_name: string | null;
@@ -465,7 +465,7 @@ export interface PacketStats {
 }
 
 export interface NeighbourStatsCandidate {
-  node_id: number;
+  meshtastic_node_id: number;
   node_id_str: string;
   short_name: string | null;
 }
@@ -515,7 +515,7 @@ export interface Constellation {
 
 export interface NodeClaim {
   node: {
-    node_id: number;
+    meshtastic_node_id: number;
     node_id_str: string;
     long_name: string;
     short_name: string;
@@ -697,7 +697,7 @@ export interface DxNodeMetadataPublic {
 
 export interface DxDestinationNode {
   internal_id: string;
-  node_id: number;
+  meshtastic_node_id: number;
   node_id_str: string;
   short_name: string;
   long_name: string;
@@ -706,7 +706,7 @@ export interface DxDestinationNode {
 
 export interface DxManagedNodeMinimal {
   internal_id: string;
-  node_id: number;
+  meshtastic_node_id: number;
   node_id_str: string;
   name: string;
 }
@@ -735,7 +735,7 @@ export type DxExplorationSkipReason =
 
 export interface DxObservedNodeHop {
   internal_id: string;
-  node_id: number;
+  meshtastic_node_id: number;
   node_id_str: string;
   short_name: string;
   long_name: string;
@@ -811,7 +811,7 @@ export interface DxEventDetail extends DxEventListItem {
 }
 
 export interface DxNodeExclusionResponse {
-  node_id: number;
+  meshtastic_node_id: number;
   node_id_str: string;
   exclude_from_detection: boolean;
   exclude_notes: string;

--- a/src/lib/my-nodes-grouping.test.ts
+++ b/src/lib/my-nodes-grouping.test.ts
@@ -20,7 +20,7 @@ const NOW = new Date('2026-04-21T12:00:00.000Z');
 function makeObserved(overrides: Partial<ObservedNode> = {}): ObservedNode {
   return {
     internal_id: 1,
-    node_id: 100,
+    meshtastic_node_id: 100,
     node_id_str: '!00000064',
     mac_addr: null,
     long_name: 'LN',
@@ -35,7 +35,7 @@ function makeObserved(overrides: Partial<ObservedNode> = {}): ObservedNode {
 
 function makeManaged(overrides: Partial<ManagedNode> = {}): ManagedNode {
   return {
-    node_id: 200,
+    meshtastic_node_id: 200,
     long_name: 'Managed LN',
     short_name: 'M1',
     last_heard: NOW,
@@ -97,14 +97,14 @@ describe('groupClaimedNodes', () => {
 
   it('partitions nodes into buckets', () => {
     const online = makeObserved({
-      node_id: 1,
+      meshtastic_node_id: 1,
       last_heard: new Date(NOW.getTime() - 60_000),
     });
     const recent = makeObserved({
-      node_id: 2,
+      meshtastic_node_id: 2,
       last_heard: new Date(NOW.getTime() - MY_NODES_CLAIMED_ONLINE_MS - 60_000),
     });
-    const offline = makeObserved({ node_id: 3, last_heard: null });
+    const offline = makeObserved({ meshtastic_node_id: 3, last_heard: null });
     const g = groupClaimedNodes([online, recent, offline], NOW);
     expect(g.online).toEqual([online]);
     expect(g.recent).toEqual([recent]);
@@ -271,13 +271,13 @@ describe('getPositionHint', () => {
 });
 
 describe('buildNodesForMap and merge', () => {
-  it('dedupes by node_id and merges managed position when observed has none', () => {
+  it('dedupes by meshtastic_node_id and merges managed position when observed has none', () => {
     const claimed = makeObserved({
-      node_id: 42,
+      meshtastic_node_id: 42,
       latest_position: null,
     });
     const managed = makeManaged({
-      node_id: 42,
+      meshtastic_node_id: 42,
       position: { latitude: 10, longitude: 20 },
     });
     const merged = buildNodesForMap([claimed], [managed]);
@@ -288,7 +288,7 @@ describe('buildNodesForMap and merge', () => {
 
   it('keeps claimed position when already valid', () => {
     const claimed = makeObserved({
-      node_id: 42,
+      meshtastic_node_id: 42,
       latest_position: {
         latitude: 1,
         longitude: 2,
@@ -299,7 +299,7 @@ describe('buildNodesForMap and merge', () => {
       },
     });
     const managed = makeManaged({
-      node_id: 42,
+      meshtastic_node_id: 42,
       position: { latitude: 10, longitude: 20 },
     });
     const merged = buildNodesForMap([claimed], [managed]);
@@ -307,15 +307,15 @@ describe('buildNodesForMap and merge', () => {
   });
 
   it('adds managed-only nodes', () => {
-    const managed = makeManaged({ node_id: 99 });
+    const managed = makeManaged({ meshtastic_node_id: 99 });
     const merged = buildNodesForMap([], [managed]);
     expect(merged).toHaveLength(1);
-    expect(merged[0].node_id).toBe(99);
+    expect(merged[0].meshtastic_node_id).toBe(99);
   });
 
   it('mergeManagedPositionIntoObserved fills from managed', () => {
-    const o = makeObserved({ node_id: 1, latest_position: null });
-    const m = makeManaged({ node_id: 1, position: { latitude: 3, longitude: 4 } });
+    const o = makeObserved({ meshtastic_node_id: 1, latest_position: null });
+    const m = makeManaged({ meshtastic_node_id: 1, position: { latitude: 3, longitude: 4 } });
     const r = mergeManagedPositionIntoObserved(o, m);
     expect(r.latest_position?.latitude).toBe(3);
   });

--- a/src/lib/my-nodes-grouping.ts
+++ b/src/lib/my-nodes-grouping.ts
@@ -234,7 +234,7 @@ export function managedNodeToObservedNode(m: ManagedNode): ObservedNode {
   const latest_position = positionFromManaged(m);
   return {
     internal_id: 0,
-    node_id: m.node_id,
+    meshtastic_node_id: m.meshtastic_node_id,
     node_id_str: m.node_id_str,
     mac_addr: null,
     long_name: m.long_name,
@@ -258,20 +258,20 @@ export function mergeManagedPositionIntoObserved(node: ObservedNode, m: ManagedN
 }
 
 /**
- * Union of claimed + managed for `NodesMap` / battery chart: one entry per `node_id`.
+ * Union of claimed + managed for `NodesMap` / battery chart: one entry per `meshtastic_node_id`.
  * When both exist, claimed data wins; managed fills in default position if needed.
  */
 export function buildNodesForMap(claimed: ObservedNode[], managed: ManagedNode[]): ObservedNode[] {
   const map = new Map<number, ObservedNode>();
   for (const c of claimed) {
-    map.set(c.node_id, c);
+    map.set(c.meshtastic_node_id, c);
   }
   for (const m of managed) {
-    const existing = map.get(m.node_id);
+    const existing = map.get(m.meshtastic_node_id);
     if (existing) {
-      map.set(m.node_id, mergeManagedPositionIntoObserved(existing, m));
+      map.set(m.meshtastic_node_id, mergeManagedPositionIntoObserved(existing, m));
     } else {
-      map.set(m.node_id, managedNodeToObservedNode(m));
+      map.set(m.meshtastic_node_id, managedNodeToObservedNode(m));
     }
   }
   return [...map.values()];

--- a/src/lib/observed-node-recency.test.ts
+++ b/src/lib/observed-node-recency.test.ts
@@ -5,7 +5,7 @@ import type { ObservedNode } from '@/lib/models';
 function makeNode(overrides: Partial<ObservedNode> = {}): ObservedNode {
   return {
     internal_id: 1,
-    node_id: 1,
+    meshtastic_node_id: 1,
     node_id_str: '!00000001',
     mac_addr: null,
     long_name: null,

--- a/src/lib/tracerouteTargetGeometry.test.ts
+++ b/src/lib/tracerouteTargetGeometry.test.ts
@@ -35,7 +35,7 @@ function makeObserved(overrides: Partial<ObservedNode> = {}): ObservedNode {
   const now = new Date();
   return {
     internal_id: 1,
-    node_id: 99,
+    meshtastic_node_id: 99,
     node_id_str: '!00000063',
     mac_addr: null,
     long_name: 'T',
@@ -73,7 +73,7 @@ describe('tracerouteTargetGeometry', () => {
   it('classifyCandidate intra includes point on envelope boundary', () => {
     const geo = makeGeo();
     const onRing = makeObserved({
-      node_id: 501,
+      meshtastic_node_id: 501,
       latest_position: {
         latitude: destinationPoint(geo.envelope!.centroid_lat, geo.envelope!.centroid_lon, 0, geo.envelope!.radius_km)[0],
         longitude: destinationPoint(geo.envelope!.centroid_lat, geo.envelope!.centroid_lon, 0, geo.envelope!.radius_km)[1],
@@ -98,7 +98,7 @@ describe('tracerouteTargetGeometry', () => {
   it('classifyCandidate dx excludes inside envelope', () => {
     const geo = makeGeo();
     const inside = makeObserved({
-      node_id: 502,
+      meshtastic_node_id: 502,
       latest_position: {
         latitude: 55.01,
         longitude: -4.25,
@@ -123,7 +123,7 @@ describe('tracerouteTargetGeometry', () => {
   it('classifyCandidate excludes stale last_heard', () => {
     const geo = makeGeo();
     const stale = makeObserved({
-      node_id: 503,
+      meshtastic_node_id: 503,
       last_heard: new Date(Date.now() - 5 * 60 * 60 * 1000),
     });
     const ctx = {
@@ -144,7 +144,7 @@ describe('tracerouteTargetGeometry', () => {
       selection_centroid: { lat: 55.0, lon: -4.25 },
     });
     const north = makeObserved({
-      node_id: 504,
+      meshtastic_node_id: 504,
       latest_position: {
         latitude: 56.0,
         longitude: -4.25,
@@ -155,7 +155,7 @@ describe('tracerouteTargetGeometry', () => {
       },
     });
     const south = makeObserved({
-      node_id: 505,
+      meshtastic_node_id: 505,
       latest_position: {
         latitude: 53.5,
         longitude: -4.25,
@@ -184,7 +184,7 @@ describe('tracerouteTargetGeometry', () => {
       applicable_strategies: ['intra_zone', 'dx_across'],
     });
     const insideIntra = makeObserved({
-      node_id: 505,
+      meshtastic_node_id: 505,
       latest_position: {
         latitude: 55.05,
         longitude: -4.25,

--- a/src/lib/tracerouteTargetGeometry.ts
+++ b/src/lib/tracerouteTargetGeometry.ts
@@ -119,8 +119,8 @@ export function classifyCandidate(
   strategy: 'intra_zone' | 'dx_across' | 'dx_same_side',
   halfWindowDeg: number
 ): { included: boolean; reason: ExclusionReason } {
-  if (node.node_id === ctx.feederNodeId) return { included: false, reason: 'is_source' };
-  if (ctx.managedNodeIds.has(node.node_id)) return { included: false, reason: 'is_managed' };
+  if (node.meshtastic_node_id === ctx.feederNodeId) return { included: false, reason: 'is_source' };
+  if (ctx.managedNodeIds.has(node.meshtastic_node_id)) return { included: false, reason: 'is_managed' };
   const lh = node.last_heard;
   if (!lh || lh < ctx.lastHeardCutoff) return { included: false, reason: 'stale_last_heard' };
   const pos = observedLatLon(node);

--- a/src/lib/watch-monitoring-status.test.ts
+++ b/src/lib/watch-monitoring-status.test.ts
@@ -14,7 +14,7 @@ function makeWatch(overrides: {
 }): NodeWatch {
   const node: ObservedNodeWatchSummary = {
     internal_id: 1,
-    node_id: 42,
+    meshtastic_node_id: 42,
     node_id_str: '!0000002a',
     mac_addr: null,
     long_name: null,
@@ -111,7 +111,7 @@ describe('sortWatchesByMonitoringStatus', () => {
     const online = makeWatch({
       watch: { id: 1, offline_after: 3600 },
       node: {
-        node_id: 1,
+        meshtastic_node_id: 1,
         last_heard: new Date('2026-01-01T14:30:00.000Z'),
         monitoring_offline_confirmed_at: null,
         monitoring_verification_started_at: null,
@@ -120,7 +120,7 @@ describe('sortWatchesByMonitoringStatus', () => {
     const offline = makeWatch({
       watch: { id: 2, offline_after: 3600 },
       node: {
-        node_id: 2,
+        meshtastic_node_id: 2,
         monitoring_offline_confirmed_at: '2026-01-01T14:00:00Z',
         last_heard: new Date('2026-01-01T14:30:00.000Z'),
       },
@@ -141,7 +141,7 @@ describe('countWatchesByMonitoringStatus', () => {
       }),
       makeWatch({
         watch: { id: 2, offline_after: 7200 },
-        node: { node_id: 3, last_heard: new Date('2026-01-01T12:30:00.000Z') },
+        node: { meshtastic_node_id: 3, last_heard: new Date('2026-01-01T12:30:00.000Z') },
       }),
     ];
     expect(countWatchesByMonitoringStatus(watches, now)).toEqual({
@@ -159,11 +159,11 @@ describe('compareWatchesByMonitoringStatus', () => {
     const now = new Date('2026-01-01T15:00:00.000Z').getTime();
     const newerUnknown = makeWatch({
       watch: { id: 1, offline_after: 60 },
-      node: { node_id: 10, last_heard: new Date('2026-01-01T14:50:00.000Z') },
+      node: { meshtastic_node_id: 10, last_heard: new Date('2026-01-01T14:50:00.000Z') },
     });
     const olderUnknown = makeWatch({
       watch: { id: 2, offline_after: 60 },
-      node: { node_id: 11, last_heard: new Date('2026-01-01T14:00:00.000Z') },
+      node: { meshtastic_node_id: 11, last_heard: new Date('2026-01-01T14:00:00.000Z') },
     });
     const sorted = [newerUnknown, olderUnknown].sort((a, b) => compareWatchesByMonitoringStatus(a, b, now));
     expect(sorted[0].id).toBe(2);

--- a/src/lib/watch-monitoring-status.ts
+++ b/src/lib/watch-monitoring-status.ts
@@ -69,7 +69,7 @@ export function deriveWatchMonitoringStatus(watch: NodeWatch, nowMs: number = Da
   return 'unknown';
 }
 
-/** Stable sort: status rank, then last heard ascending (stale first), then node_id. */
+/** Stable sort: status rank, then last heard ascending (stale first), then meshtastic_node_id. */
 export function compareWatchesByMonitoringStatus(a: NodeWatch, b: NodeWatch, nowMs?: number): number {
   const t = nowMs ?? Date.now();
   const sa = deriveWatchMonitoringStatus(a, t);
@@ -84,7 +84,7 @@ export function compareWatchesByMonitoringStatus(a: NodeWatch, b: NodeWatch, now
   if (la == null && lb != null) return 1;
   if (la != null && lb == null) return -1;
 
-  return a.observed_node.node_id - b.observed_node.node_id;
+  return a.observed_node.meshtastic_node_id - b.observed_node.meshtastic_node_id;
 }
 
 export function sortWatchesByMonitoringStatus(watches: NodeWatch[], nowMs?: number): NodeWatch[] {

--- a/src/pages/Weather.tsx
+++ b/src/pages/Weather.tsx
@@ -167,7 +167,7 @@ function WeatherContent() {
             <WeatherNodeCard
               key={node.internal_id}
               node={node}
-              metrics={metricsMap[node.node_id] ?? []}
+              metrics={metricsMap[node.meshtastic_node_id] ?? []}
               dateRange={chartDateRange}
             />
           ))}

--- a/src/pages/map/NodeMap.tsx
+++ b/src/pages/map/NodeMap.tsx
@@ -214,7 +214,7 @@ function NodeMapContent() {
           )}
 
           <NodeDetailSheet
-            nodeId={selectedNode?.node_id ?? null}
+            nodeId={selectedNode?.meshtastic_node_id ?? null}
             open={selectedNode != null}
             onOpenChange={(open) => !open && setSelectedNode(null)}
           />

--- a/src/pages/meshcore/MeshCoreMap.tsx
+++ b/src/pages/meshcore/MeshCoreMap.tsx
@@ -35,7 +35,7 @@ function MeshCoreMapContent() {
               <h3 className="mb-2 text-sm font-medium">Feeders (default location)</h3>
               <ul className="list-inside list-disc text-sm text-muted-foreground">
                 {feedersWithPosition.map((f) => (
-                  <li key={f.node_id}>
+                  <li key={f.meshtastic_node_id}>
                     {f.long_name || f.node_id_str} — {f.position.latitude?.toFixed(4)},{' '}
                     {f.position.longitude?.toFixed(4)}
                   </li>

--- a/src/pages/nodes/DxMonitoringPage.test.tsx
+++ b/src/pages/nodes/DxMonitoringPage.test.tsx
@@ -120,7 +120,7 @@ describe('DxMonitoringPage', () => {
   it('shows exploration attempt counts on the list', () => {
     const destination: DxEventListItem['destination'] = {
       internal_id: 'aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa',
-      node_id: 123,
+      meshtastic_node_id: 123,
       node_id_str: '!0000007b',
       short_name: 'T',
       long_name: 'Target',
@@ -159,7 +159,7 @@ describe('DxMonitoringPage', () => {
     const user = userEvent.setup();
     const destination: DxEventListItem['destination'] = {
       internal_id: 'aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa',
-      node_id: 123,
+      meshtastic_node_id: 123,
       node_id_str: '!0000007b',
       short_name: 'T',
       long_name: 'Target',
@@ -167,7 +167,7 @@ describe('DxMonitoringPage', () => {
     };
     const hop = {
       internal_id: destination.internal_id,
-      node_id: destination.node_id,
+      meshtastic_node_id: destination.meshtastic_node_id,
       node_id_str: destination.node_id_str,
       short_name: destination.short_name,
       long_name: destination.long_name,
@@ -223,7 +223,7 @@ describe('DxMonitoringPage', () => {
           updated_at: '2026-01-15T10:05:00.000Z',
           source_node: {
             internal_id: 'eeeeeeee-eeee-eeee-eeee-eeeeeeeeeeee',
-            node_id: 456,
+            meshtastic_node_id: 456,
             node_id_str: '!000001c8',
             name: 'Source MN',
           },
@@ -284,7 +284,7 @@ describe('DxMonitoringPage', () => {
     const user = userEvent.setup();
     const destination: DxEventListItem['destination'] = {
       internal_id: 'aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa',
-      node_id: 123,
+      meshtastic_node_id: 123,
       node_id_str: '!0000007b',
       short_name: 'T',
       long_name: 'Target',

--- a/src/pages/nodes/DxMonitoringPage.tsx
+++ b/src/pages/nodes/DxMonitoringPage.tsx
@@ -104,8 +104,8 @@ function explorationKindLabel(row: DxEventTracerouteExplorationRow): string {
 }
 
 function explorationHistoryHref(row: DxEventTracerouteExplorationRow): string {
-  const targetNodeId = row.destination.node_id;
-  const sourceNodeId = row.source_node?.node_id ?? null;
+  const targetNodeId = row.destination.meshtastic_node_id;
+  const sourceNodeId = row.source_node?.meshtastic_node_id ?? null;
   if (row.link_kind === 'new_node_baseline') {
     return buildDxTracerouteHistoryLink({
       targetNodeId,
@@ -202,7 +202,7 @@ export default function DxMonitoringPage() {
     if (!excludeTarget) return;
     exclusionMutation.mutate(
       {
-        node_id: excludeTarget.destination.node_id,
+        meshtastic_node_id: excludeTarget.destination.meshtastic_node_id,
         exclude_from_detection: true,
         exclude_notes: excludeNotes.trim() || undefined,
       },
@@ -431,7 +431,7 @@ export default function DxMonitoringPage() {
                       <TableCell>
                         <div className="flex flex-col gap-1 max-w-[16rem]">
                           <NodeLinkLabel
-                            to={`/nodes/${row.destination.node_id}`}
+                            to={`/nodes/${row.destination.meshtastic_node_id}`}
                             {...formatDestinationLabel(row.destination)}
                           />
                           {row.destination.dx_metadata.exclude_from_detection && (
@@ -444,7 +444,7 @@ export default function DxMonitoringPage() {
                       <TableCell className="text-sm max-w-[12rem]">
                         {row.last_observer ? (
                           <NodeLinkLabel
-                            to={`/nodes/${row.last_observer.node_id}`}
+                            to={`/nodes/${row.last_observer.meshtastic_node_id}`}
                             {...formatObserverLabel(row.last_observer)}
                           />
                         ) : (
@@ -535,7 +535,7 @@ export default function DxMonitoringPage() {
                 <div className="text-muted-foreground">Destination</div>
                 <div className="flex flex-wrap items-center gap-2 mt-1">
                   <NodeLinkLabel
-                    to={`/nodes/${detailQuery.data.destination.node_id}`}
+                    to={`/nodes/${detailQuery.data.destination.meshtastic_node_id}`}
                     {...formatDestinationLabel(detailQuery.data.destination)}
                   />
                   {detailQuery.data.destination.dx_metadata.exclude_from_detection && (
@@ -574,7 +574,7 @@ export default function DxMonitoringPage() {
                             <TableCell className="text-xs whitespace-nowrap">{formatWhen(o.observed_at)}</TableCell>
                             <TableCell className="text-xs max-w-[12rem]">
                               <NodeLinkLabel
-                                to={`/nodes/${o.observer.node_id}`}
+                                to={`/nodes/${o.observer.meshtastic_node_id}`}
                                 primary={obsLabel.primary}
                                 idSecondary={obsLabel.idSecondary}
                               />
@@ -683,7 +683,7 @@ export default function DxMonitoringPage() {
                                     <TableCell className="text-xs max-w-[10rem]">
                                       {row.source_node ? (
                                         <NodeLinkLabel
-                                          to={`/nodes/${row.source_node.node_id}`}
+                                          to={`/nodes/${row.source_node.meshtastic_node_id}`}
                                           {...formatObserverLabel(row.source_node)}
                                         />
                                       ) : (
@@ -692,7 +692,7 @@ export default function DxMonitoringPage() {
                                     </TableCell>
                                     <TableCell className="text-xs max-w-[10rem]">
                                       <NodeLinkLabel
-                                        to={`/nodes/${row.destination.node_id}`}
+                                        to={`/nodes/${row.destination.meshtastic_node_id}`}
                                         {...formatHopLabel(row.destination)}
                                       />
                                     </TableCell>

--- a/src/pages/nodes/ManagedNodesStatus.tsx
+++ b/src/pages/nodes/ManagedNodesStatus.tsx
@@ -407,19 +407,19 @@ function ManagedNodesStatusContent() {
                   {group.nodes.map((node) => {
                     const tier = getManagedNodeStatusTier(node.last_packet_ingested_at);
                     return (
-                      <TableRow key={node.node_id}>
+                      <TableRow key={node.meshtastic_node_id}>
                         <TableCell>
                           <Badge style={{ backgroundColor: managedNodeStatusTierColor(tier), color: 'white' }}>
                             {tierLabel(tier)}
                           </Badge>
                         </TableCell>
                         <TableCell>
-                          <Link to={`/nodes/${node.node_id}`} className="text-primary hover:underline">
+                          <Link to={`/nodes/${node.meshtastic_node_id}`} className="text-primary hover:underline">
                             {node.short_name ?? '—'}
                           </Link>
                         </TableCell>
                         <TableCell>
-                          <Link to={`/nodes/${node.node_id}`} className="text-primary hover:underline">
+                          <Link to={`/nodes/${node.meshtastic_node_id}`} className="text-primary hover:underline">
                             {node.long_name ?? node.node_id_str}
                           </Link>
                         </TableCell>

--- a/src/pages/nodes/MeshInfrastructure.tsx
+++ b/src/pages/nodes/MeshInfrastructure.tsx
@@ -141,7 +141,7 @@ function MeshInfrastructureContent() {
     includeStatus: true,
     includeGeoClassification: true,
   });
-  const managedByMeshId = useMemo(() => new Map(managedNodes.map((m) => [m.node_id, m])), [managedNodes]);
+  const managedByMeshId = useMemo(() => new Map(managedNodes.map((m) => [m.meshtastic_node_id, m])), [managedNodes]);
   const managedNodesForMap = useMemo(() => filterManagedNodesForMapDisplay(managedNodes), [managedNodes]);
 
   const { metricsMap } = useMultiNodeMetricsSuspense(nodes, chartDateRange);
@@ -190,7 +190,7 @@ function MeshInfrastructureContent() {
     const m = new Map<number, 'diamond' | 'rounded-square'>();
     for (const n of allInfraNodes) {
       if (!hasMeshInfraMapBatteryOrPresenceAlert(n)) continue;
-      m.set(n.node_id, n.node_id % 2 === 0 ? 'diamond' : 'rounded-square');
+      m.set(n.meshtastic_node_id, n.meshtastic_node_id % 2 === 0 ? 'diamond' : 'rounded-square');
     }
     return m;
   }, [allInfraNodes]);
@@ -206,7 +206,7 @@ function MeshInfrastructureContent() {
   );
 
   const chartNodes = useMemo(
-    () => nodes.filter((n) => selectedChartNodeIds.has(n.node_id)),
+    () => nodes.filter((n) => selectedChartNodeIds.has(n.meshtastic_node_id)),
     [nodes, selectedChartNodeIds]
   );
 
@@ -316,13 +316,16 @@ function MeshInfrastructureContent() {
                     !node.last_heard ||
                     (node.last_heard instanceof Date ? node.last_heard : new Date(node.last_heard)) < cutoff;
                   const watch = watchesByNodeIdStr.get(node.node_id_str);
-                  const managed = managedByMeshId.get(node.node_id);
+                  const managed = managedByMeshId.get(node.meshtastic_node_id);
                   return (
                     <TableRow key={node.internal_id}>
                       <TableCell>
                         <div className="flex flex-col gap-0.5">
                           <div className="flex items-center gap-2">
-                            <Link to={`/nodes/${node.node_id}`} className="font-medium text-primary hover:underline">
+                            <Link
+                              to={`/nodes/${node.meshtastic_node_id}`}
+                              className="font-medium text-primary hover:underline"
+                            >
                               {node.long_name} ({node.short_name || node.node_id_str})
                             </Link>
                             {isOffline && (
@@ -376,19 +379,22 @@ function MeshInfrastructureContent() {
                           node={node}
                           watch={watch}
                           watchesQuery={watchesQuery}
-                          idPrefix={`infra-no-loc-${node.node_id}`}
+                          idPrefix={`infra-no-loc-${node.meshtastic_node_id}`}
                         />
                       </TableCell>
                       <TableCell>
                         <div className="flex flex-col items-start gap-1 sm:flex-row sm:items-center sm:gap-3">
-                          <Link to={`/nodes/${node.node_id}`} className="text-primary text-sm hover:underline">
+                          <Link
+                            to={`/nodes/${node.meshtastic_node_id}`}
+                            className="text-primary text-sm hover:underline"
+                          >
                             View details
                           </Link>
                           {managed != null && (
                             <Link
-                              to={`/traceroutes/map/coverage?feeder=${node.node_id}`}
+                              to={`/traceroutes/map/coverage?feeder=${node.meshtastic_node_id}`}
                               className="text-muted-foreground text-sm underline-offset-4 hover:text-primary hover:underline"
-                              data-testid={`infra-no-loc-coverage-link-${node.node_id}`}
+                              data-testid={`infra-no-loc-coverage-link-${node.meshtastic_node_id}`}
                             >
                               Coverage map
                             </Link>
@@ -500,7 +506,7 @@ function MeshInfrastructureContent() {
                     const reportedAt = getBatteryMetricsReportedAt(node);
                     const level = node.latest_device_metrics?.battery_level;
                     const watch = watchesByNodeIdStr.get(node.node_id_str);
-                    const managed = managedByMeshId.get(node.node_id);
+                    const managed = managedByMeshId.get(node.meshtastic_node_id);
                     const cutoff = subDays(new Date(), 7);
                     const isOffline =
                       !node.last_heard ||
@@ -513,7 +519,10 @@ function MeshInfrastructureContent() {
                         <TableCell>
                           <div className="flex flex-col gap-0.5">
                             <div className="flex items-center gap-2">
-                              <Link to={`/nodes/${node.node_id}`} className="font-medium text-primary hover:underline">
+                              <Link
+                                to={`/nodes/${node.meshtastic_node_id}`}
+                                className="font-medium text-primary hover:underline"
+                              >
                                 {node.long_name} ({node.short_name || node.node_id_str})
                               </Link>
                               {isOffline && (
@@ -595,19 +604,22 @@ function MeshInfrastructureContent() {
                             node={node}
                             watch={watch}
                             watchesQuery={watchesQuery}
-                            idPrefix={`infra-batt-${node.node_id}`}
+                            idPrefix={`infra-batt-${node.meshtastic_node_id}`}
                           />
                         </TableCell>
                         <TableCell>
                           <div className="flex flex-col items-start gap-1 sm:flex-row sm:items-center sm:gap-3">
-                            <Link to={`/nodes/${node.node_id}`} className="text-primary text-sm hover:underline">
+                            <Link
+                              to={`/nodes/${node.meshtastic_node_id}`}
+                              className="text-primary text-sm hover:underline"
+                            >
                               View details
                             </Link>
                             {managed != null && (
                               <Link
-                                to={`/traceroutes/map/coverage?feeder=${node.node_id}`}
+                                to={`/traceroutes/map/coverage?feeder=${node.meshtastic_node_id}`}
                                 className="text-muted-foreground text-sm underline-offset-4 hover:text-primary hover:underline"
-                                data-testid={`infra-batt-coverage-link-${node.node_id}`}
+                                data-testid={`infra-batt-coverage-link-${node.meshtastic_node_id}`}
                               >
                                 Coverage map
                               </Link>
@@ -646,8 +658,8 @@ function MeshInfrastructureContent() {
             <InfrastructureNodeCard
               key={node.internal_id}
               node={node}
-              managedNode={managedByMeshId.get(node.node_id)}
-              metrics={metricsMap[node.node_id] ?? []}
+              managedNode={managedByMeshId.get(node.meshtastic_node_id)}
+              metrics={metricsMap[node.meshtastic_node_id] ?? []}
               dateRange={chartDateRange}
               onCompareToggle={handleCompareToggle}
               watch={watchesByNodeIdStr.get(node.node_id_str)}

--- a/src/pages/nodes/MyNodes.test.tsx
+++ b/src/pages/nodes/MyNodes.test.tsx
@@ -58,7 +58,7 @@ const NOW = new Date('2026-04-21T12:00:00.000Z');
 function makeObserved(overrides: Partial<ObservedNode> = {}): ObservedNode {
   return {
     internal_id: 1,
-    node_id: 100,
+    meshtastic_node_id: 100,
     node_id_str: '!00000064',
     mac_addr: null,
     long_name: 'LN',
@@ -74,7 +74,7 @@ function makeObserved(overrides: Partial<ObservedNode> = {}): ObservedNode {
 
 function makeManaged(overrides: Partial<ManagedNode> = {}): ManagedNode {
   return {
-    node_id: 200,
+    meshtastic_node_id: 200,
     long_name: 'MLN',
     short_name: 'M1',
     last_heard: NOW,
@@ -126,13 +126,13 @@ describe('MyNodes', () => {
   it('dedupes claimed+managed so the node appears only under Managed', () => {
     const nid = 42;
     const claimed = makeObserved({
-      node_id: nid,
+      meshtastic_node_id: nid,
       node_id_str: '!0000002a',
       short_name: 'DEDUP',
       last_heard: new Date(NOW.getTime() - 60_000),
     });
     const managed = makeManaged({
-      node_id: nid,
+      meshtastic_node_id: nid,
       node_id_str: '!0000002a',
       short_name: 'DEDUP',
     });
@@ -147,7 +147,7 @@ describe('MyNodes', () => {
 
   it('shows online empty state when every claimed-only node is offline', () => {
     const offline = makeObserved({
-      node_id: 1,
+      meshtastic_node_id: 1,
       last_heard: new Date(NOW.getTime() - MY_NODES_CLAIMED_RECENT_MS - 60_000),
     });
     useMyClaimedNodesSuspense.mockReturnValue({ myClaimedNodes: [offline] });
@@ -160,7 +160,7 @@ describe('MyNodes', () => {
 
   it('hides Recent and Offline sections when those buckets are empty', () => {
     const online = makeObserved({
-      node_id: 1,
+      meshtastic_node_id: 1,
       last_heard: new Date(NOW.getTime() - 60_000),
     });
     useMyClaimedNodesSuspense.mockReturnValue({ myClaimedNodes: [online] });
@@ -172,7 +172,7 @@ describe('MyNodes', () => {
 
   it('shows destructive managed liveness when feeder and radio are stale', () => {
     const managed = makeManaged({
-      node_id: 7,
+      meshtastic_node_id: 7,
       last_packet_ingested_at: new Date(NOW.getTime() - MY_NODES_FEEDER_FRESH_MS - 120_000),
       radio_last_heard: new Date(NOW.getTime() - MY_NODES_CLAIMED_ONLINE_MS - 120_000),
     });
@@ -185,7 +185,7 @@ describe('MyNodes', () => {
 
   it('does not show feeder-not-reporting when last_packet_ingested_at is missing but radio is fresh', () => {
     const managed = makeManaged({
-      node_id: 8,
+      meshtastic_node_id: 8,
       last_packet_ingested_at: null,
       radio_last_heard: new Date(NOW.getTime() - 60_000),
     });

--- a/src/pages/nodes/MyNodes.tsx
+++ b/src/pages/nodes/MyNodes.tsx
@@ -67,18 +67,18 @@ function MyNodesContent() {
     return m;
   }, [watchesQuery.data]);
 
-  const managedNodeIds = useMemo(() => new Set(myManagedNodes.map((n) => n.node_id)), [myManagedNodes]);
+  const managedNodeIds = useMemo(() => new Set(myManagedNodes.map((n) => n.meshtastic_node_id)), [myManagedNodes]);
 
   const claimedByNodeId = useMemo(() => {
     const m = new Map<number, ObservedNode>();
     for (const c of myClaimedNodes) {
-      m.set(c.node_id, c);
+      m.set(c.meshtastic_node_id, c);
     }
     return m;
   }, [myClaimedNodes]);
 
   const claimedOnlyNodes = useMemo(
-    () => myClaimedNodes.filter((n) => !managedNodeIds.has(n.node_id)),
+    () => myClaimedNodes.filter((n) => !managedNodeIds.has(n.meshtastic_node_id)),
     [myClaimedNodes, managedNodeIds]
   );
 
@@ -102,7 +102,7 @@ function MyNodesContent() {
 
   const renderInstructionsModal = () => {
     if (!showInstructionsNode) return null;
-    const nodeApiKeys = apiKeys?.filter((key) => key.nodes.includes(showInstructionsNode.node_id)) || [];
+    const nodeApiKeys = apiKeys?.filter((key) => key.nodes.includes(showInstructionsNode.meshtastic_node_id)) || [];
     const firstApiKey = nodeApiKeys[0]?.key;
     return (
       <Dialog
@@ -164,7 +164,9 @@ function MyNodesContent() {
             <Button variant="outline" onClick={() => setInstructionsModalOpen(false)}>
               Close
             </Button>
-            <Button onClick={() => navigate(`/nodes/${showInstructionsNode.node_id}`)}>Go to Node Details</Button>
+            <Button onClick={() => navigate(`/nodes/${showInstructionsNode.meshtastic_node_id}`)}>
+              Go to Node Details
+            </Button>
           </DialogFooter>
         </DialogContent>
       </Dialog>
@@ -217,7 +219,7 @@ function MyNodesContent() {
               disabled={cancelClaimMutation.isPending}
               onClick={() => {
                 if (!unclaimTarget) return;
-                cancelClaimMutation.mutate(unclaimTarget.node_id, {
+                cancelClaimMutation.mutate(unclaimTarget.meshtastic_node_id, {
                   onSuccess: () => setUnclaimTarget(null),
                 });
               }}
@@ -281,12 +283,12 @@ function MyNodesContent() {
               <CardContent>
                 <div className="grid grid-cols-1 sm:grid-cols-2 xl:grid-cols-3 gap-4">
                   {myManagedNodes.map((managed) => {
-                    const node = observedNodeForManagedRow(managed, claimedByNodeId.get(managed.node_id));
+                    const node = observedNodeForManagedRow(managed, claimedByNodeId.get(managed.meshtastic_node_id));
                     const watch = watchesByNodeIdStr.get(node.node_id_str);
                     const liveness = getManagedLiveness(managed);
                     return (
                       <MyNodeCard
-                        key={`managed-${managed.node_id}`}
+                        key={`managed-${managed.meshtastic_node_id}`}
                         node={node}
                         isManaged
                         isClaimed={node.owner?.id !== undefined}
@@ -301,7 +303,7 @@ function MyNodesContent() {
                         }}
                         onRequestUnmanage={() =>
                           setUnmanageTarget({
-                            nodeId: managed.node_id,
+                            nodeId: managed.meshtastic_node_id,
                             label: node.short_name || node.node_id_str,
                           })
                         }
@@ -333,7 +335,7 @@ function MyNodesContent() {
                         const watch = watchesByNodeIdStr.get(node.node_id_str);
                         return (
                           <MyNodeCard
-                            key={node.node_id}
+                            key={node.meshtastic_node_id}
                             node={node}
                             isManaged={false}
                             isClaimed={node.owner?.id !== undefined}
@@ -367,7 +369,7 @@ function MyNodesContent() {
                         const watch = watchesByNodeIdStr.get(node.node_id_str);
                         return (
                           <MyNodeCard
-                            key={node.node_id}
+                            key={node.meshtastic_node_id}
                             node={node}
                             isManaged={false}
                             isClaimed={node.owner?.id !== undefined}
@@ -397,7 +399,7 @@ function MyNodesContent() {
                         const watch = watchesByNodeIdStr.get(node.node_id_str);
                         return (
                           <MyNodeCard
-                            key={node.node_id}
+                            key={node.meshtastic_node_id}
                             node={node}
                             isManaged={false}
                             isClaimed={node.owner?.id !== undefined}

--- a/src/pages/nodes/NodesList.tsx
+++ b/src/pages/nodes/NodesList.tsx
@@ -45,7 +45,7 @@ function getLastHeardAfter(timeRange: TimeRangeOption): Date | undefined {
 function RecentNodeChip({ node }: { node: ObservedNode }) {
   return (
     <Link
-      to={`/nodes/${node.node_id}`}
+      to={`/nodes/${node.meshtastic_node_id}`}
       className="flex-shrink-0 inline-flex items-center gap-2 px-4 py-2 rounded-lg bg-primary/10 hover:bg-primary/20 transition-colors border border-primary/20"
     >
       <span className="font-medium text-sm truncate max-w-[120px]">{node.short_name}</span>

--- a/src/pages/nodes/monitor.tsx
+++ b/src/pages/nodes/monitor.tsx
@@ -42,7 +42,7 @@ export default function MonitorNodesPage() {
     const m = new Map<number, string>();
     for (const w of sortedWatches) {
       const st = deriveWatchMonitoringStatus(w);
-      m.set(w.observed_node.node_id, WATCH_STATUS_MAP_COLOR[st]);
+      m.set(w.observed_node.meshtastic_node_id, WATCH_STATUS_MAP_COLOR[st]);
     }
     return m;
   }, [sortedWatches]);
@@ -80,9 +80,9 @@ export default function MonitorNodesPage() {
   const modalManagedNodes = useMemo(() => {
     const triggerable = triggerableQuery.data ?? [];
     const pages = managedPages.data?.pages.flatMap((p) => p.results) ?? [];
-    const byId = new Map(pages.map((m) => [m.node_id, m]));
+    const byId = new Map(pages.map((m) => [m.meshtastic_node_id, m]));
     return triggerable.map((t) => {
-      const full = byId.get(t.node_id);
+      const full = byId.get(t.meshtastic_node_id);
       return full ? { ...t, ...full } : t;
     });
   }, [triggerableQuery.data, managedPages.data?.pages]);

--- a/src/pages/traceroutes/ConstellationCoveragePage.tsx
+++ b/src/pages/traceroutes/ConstellationCoveragePage.tsx
@@ -172,11 +172,11 @@ export function ConstellationCoveragePage() {
 
   const representedForHeard = useMemo(() => {
     const s = new Set<number>();
-    for (const t of data?.targets ?? []) s.add(t.node_id);
-    for (const f of data?.feeders ?? []) s.add(f.node_id);
+    for (const t of data?.targets ?? []) s.add(t.meshtastic_node_id);
+    for (const f of data?.feeders ?? []) s.add(f.meshtastic_node_id);
     if (Number.isFinite(constellationIdNum)) {
       for (const m of managedNodes ?? []) {
-        if (m.constellation?.id === constellationIdNum && m.node_id != null) s.add(m.node_id);
+        if (m.constellation?.id === constellationIdNum && m.meshtastic_node_id != null) s.add(m.meshtastic_node_id);
       }
     }
     return s;

--- a/src/pages/traceroutes/FeederCoveragePage.test.tsx
+++ b/src/pages/traceroutes/FeederCoveragePage.test.tsx
@@ -23,15 +23,15 @@ vi.mock('@/components/traceroutes/FeederCoverageMap', () => ({
     enabledLayers,
     minAttempts,
   }: {
-    feeder: { node_id: number };
-    targets: { node_id: number }[];
+    feeder: { meshtastic_node_id: number };
+    targets: { meshtastic_node_id: number }[];
     heardGhosts: unknown[];
     enabledLayers: string[];
     minAttempts: number;
   }) => (
     <div
       data-testid="feeder-coverage-map-mock"
-      data-feeder={feeder.node_id}
+      data-feeder={feeder.meshtastic_node_id}
       data-target-count={targets.length}
       data-heard-ghost-count={heardGhosts.length}
       data-enabled-layers={enabledLayers.join(',')}
@@ -49,7 +49,7 @@ const mockedUseFeederReach = vi.mocked(useFeederReach);
 
 function makeManagedNode(overrides: Partial<ManagedNode> = {}): ManagedNode {
   return {
-    node_id: 200,
+    meshtastic_node_id: 200,
     long_name: 'Source node',
     short_name: 'SRC',
     last_heard: null,
@@ -101,12 +101,12 @@ describe('FeederCoveragePage', () => {
   it('hydrates the selected feeder from the ?feeder= URL parameter', () => {
     setupHooks({
       managedNodes: [
-        makeManagedNode({ node_id: 100, short_name: 'AAA' }),
-        makeManagedNode({ node_id: 200, short_name: 'BBB' }),
+        makeManagedNode({ meshtastic_node_id: 100, short_name: 'AAA' }),
+        makeManagedNode({ meshtastic_node_id: 200, short_name: 'BBB' }),
       ],
       data: {
         feeder: {
-          node_id: 200,
+          meshtastic_node_id: 200,
           node_id_str: '!000000c8',
           short_name: 'BBB',
           long_name: 'Source node',
@@ -136,7 +136,7 @@ describe('FeederCoveragePage', () => {
     setupHooks({
       data: {
         feeder: {
-          node_id: 200,
+          meshtastic_node_id: 200,
           node_id_str: '!000000c8',
           short_name: 'SRC',
           long_name: 'Source',
@@ -146,7 +146,7 @@ describe('FeederCoveragePage', () => {
         window: { triggered_at_after: null, triggered_at_before: null },
         targets: [
           {
-            node_id: 1,
+            meshtastic_node_id: 1,
             node_id_str: '!00000001',
             short_name: 'A',
             long_name: null,
@@ -156,7 +156,7 @@ describe('FeederCoveragePage', () => {
             successes: 4,
           },
           {
-            node_id: 2,
+            meshtastic_node_id: 2,
             node_id_str: '!00000002',
             short_name: 'B',
             long_name: null,
@@ -182,7 +182,7 @@ describe('FeederCoveragePage', () => {
     setupHooks({
       data: {
         feeder: {
-          node_id: 200,
+          meshtastic_node_id: 200,
           node_id_str: '!000000c8',
           short_name: 'SRC',
           long_name: 'Source',

--- a/src/pages/traceroutes/FeederCoveragePage.tsx
+++ b/src/pages/traceroutes/FeederCoveragePage.tsx
@@ -124,7 +124,7 @@ export function FeederCoveragePage() {
   const feederOptions = useMemo(
     () =>
       [...(managedNodes ?? [])]
-        .filter((n) => n.node_id != null)
+        .filter((n) => n.meshtastic_node_id != null)
         .sort((a, b) => {
           const labelA = (a.short_name || a.long_name || a.node_id_str || '').toLowerCase();
           const labelB = (b.short_name || b.long_name || b.node_id_str || '').toLowerCase();
@@ -143,7 +143,7 @@ export function FeederCoveragePage() {
   useEffect(() => {
     if (selectedFeederId != null) return;
     if (feederOptions.length === 0) return;
-    setSelectedFeederId(feederOptions[0].node_id);
+    setSelectedFeederId(feederOptions[0].meshtastic_node_id);
   }, [feederOptions, selectedFeederId]);
 
   // Mirror selection into the URL so it's deep-linkable.
@@ -179,8 +179,8 @@ export function FeederCoveragePage() {
 
   const representedForHeard = useMemo(() => {
     const s = new Set<number>();
-    if (data?.feeder?.node_id != null) s.add(data.feeder.node_id);
-    for (const t of data?.targets ?? []) s.add(t.node_id);
+    if (data?.feeder?.meshtastic_node_id != null) s.add(data.feeder.meshtastic_node_id);
+    for (const t of data?.targets ?? []) s.add(t.meshtastic_node_id);
     return s;
   }, [data]);
 
@@ -200,7 +200,7 @@ export function FeederCoveragePage() {
     ? filteredTargets.reduce((acc, t) => acc + smoothedRate(t.successes, t.attempts), 0) / filteredTargets.length
     : null;
 
-  const selectedFeeder = feederOptions.find((n) => n.node_id === selectedFeederId);
+  const selectedFeeder = feederOptions.find((n) => n.meshtastic_node_id === selectedFeederId);
   const feederLabel = selectedFeeder
     ? selectedFeeder.short_name || selectedFeeder.long_name || selectedFeeder.node_id_str
     : 'Select a feeder';
@@ -239,7 +239,7 @@ export function FeederCoveragePage() {
                 </SelectTrigger>
                 <SelectContent>
                   {feederOptions.map((n) => (
-                    <SelectItem key={n.node_id} value={String(n.node_id)}>
+                    <SelectItem key={n.meshtastic_node_id} value={String(n.meshtastic_node_id)}>
                       {n.short_name || n.long_name || n.node_id_str}
                     </SelectItem>
                   ))}

--- a/src/pages/traceroutes/TracerouteDetailModal.tsx
+++ b/src/pages/traceroutes/TracerouteDetailModal.tsx
@@ -86,7 +86,7 @@ export function TracerouteDetailModal({ tracerouteId, open, onOpenChange }: Trac
             {traceroute ? (
               <>
                 <Link
-                  to={`/nodes/${traceroute.source_node.node_id}`}
+                  to={`/nodes/${traceroute.source_node.meshtastic_node_id}`}
                   onClick={(e) => e.stopPropagation()}
                   className="font-medium text-primary underline-offset-4 hover:underline"
                 >
@@ -94,7 +94,7 @@ export function TracerouteDetailModal({ tracerouteId, open, onOpenChange }: Trac
                 </Link>
                 <span aria-hidden>→</span>
                 <Link
-                  to={`/nodes/${traceroute.target_node.node_id}`}
+                  to={`/nodes/${traceroute.target_node.meshtastic_node_id}`}
                   onClick={(e) => e.stopPropagation()}
                   className="font-medium text-primary underline-offset-4 hover:underline"
                 >
@@ -119,7 +119,7 @@ export function TracerouteDetailModal({ tracerouteId, open, onOpenChange }: Trac
               <Badge variant="outline" className="gap-1">
                 <span className="text-muted-foreground">Source:</span>
                 <Link
-                  to={`/nodes/${traceroute.source_node.node_id}`}
+                  to={`/nodes/${traceroute.source_node.meshtastic_node_id}`}
                   onClick={(e) => e.stopPropagation()}
                   className="text-primary underline-offset-4 hover:underline"
                 >
@@ -129,7 +129,7 @@ export function TracerouteDetailModal({ tracerouteId, open, onOpenChange }: Trac
               <Badge variant="outline" className="gap-1">
                 <span className="text-muted-foreground">Target:</span>
                 <Link
-                  to={`/nodes/${traceroute.target_node.node_id}`}
+                  to={`/nodes/${traceroute.target_node.meshtastic_node_id}`}
                   onClick={(e) => e.stopPropagation()}
                   className="text-primary underline-offset-4 hover:underline"
                 >

--- a/src/pages/traceroutes/TracerouteHeatmapPage.test.tsx
+++ b/src/pages/traceroutes/TracerouteHeatmapPage.test.tsx
@@ -27,7 +27,7 @@ describe('TracerouteHeatmapPage URL → API', () => {
     mockUseManaged.mockReturnValue({
       managedNodes: [
         {
-          node_id: 99,
+          meshtastic_node_id: 99,
           short_name: 'Feed',
           node_id_str: '!00000063',
           long_name: null,

--- a/src/pages/traceroutes/TracerouteHeatmapPage.tsx
+++ b/src/pages/traceroutes/TracerouteHeatmapPage.tsx
@@ -79,11 +79,11 @@ export function TracerouteHeatmapPage({ edgeMetric }: { edgeMetric: EdgeMetric }
   const selectedRaw = searchParams.get('selected');
   const selectedNodeId = selectedRaw && /^\d+$/.test(selectedRaw.trim()) ? Number.parseInt(selectedRaw, 10) : null;
   const selectedNode: HeatmapNode | null =
-    selectedNodeId != null ? (nodes.find((n) => n.node_id === selectedNodeId) ?? null) : null;
+    selectedNodeId != null ? (nodes.find((n) => n.meshtastic_node_id === selectedNodeId) ?? null) : null;
 
   useEffect(() => {
     if (selectedNodeId == null || nodes.length === 0) return;
-    if (!nodes.some((n) => n.node_id === selectedNodeId)) {
+    if (!nodes.some((n) => n.meshtastic_node_id === selectedNodeId)) {
       updateParams({ selected: null });
     }
   }, [nodes, selectedNodeId, updateParams]);
@@ -133,7 +133,9 @@ export function TracerouteHeatmapPage({ edgeMetric }: { edgeMetric: EdgeMetric }
                 edgeMetric={edgeMetric}
                 staleThresholdHours={HEATMAP_STALE_THRESHOLD_HOURS}
                 selectedNode={selectedNode}
-                onSelectedNodeChange={(node) => updateParams({ selected: node ? String(node.node_id) : null })}
+                onSelectedNodeChange={(node) =>
+                  updateParams({ selected: node ? String(node.meshtastic_node_id) : null })
+                }
                 topologyLink={topologyLink}
               />
             )}

--- a/src/pages/traceroutes/TracerouteHistory.test.tsx
+++ b/src/pages/traceroutes/TracerouteHistory.test.tsx
@@ -39,7 +39,7 @@ const mockedUseManagedNodes = vi.mocked(useManagedNodesSuspense);
 
 function makeManagedNode(overrides: Partial<ManagedNode> = {}): ManagedNode {
   return {
-    node_id: 200,
+    meshtastic_node_id: 200,
     long_name: 'Source node',
     short_name: 'SRC',
     last_heard: null,
@@ -58,7 +58,7 @@ function makeTraceroute(overrides: Partial<AutoTraceRoute> = {}): AutoTraceRoute
     source_node: makeManagedNode(),
     target_node: {
       internal_id: 1,
-      node_id: 100,
+      meshtastic_node_id: 100,
       node_id_str: '!00000064',
       mac_addr: null,
       long_name: 'Target',
@@ -98,7 +98,7 @@ interface InfiniteOptions {
 function makeObservedNode(overrides: Partial<ObservedNode> = {}): ObservedNode {
   return {
     internal_id: 1,
-    node_id: 100,
+    meshtastic_node_id: 100,
     node_id_str: '!00000064',
     mac_addr: null,
     long_name: 'Target',
@@ -278,9 +278,9 @@ describe('TracerouteHistory', () => {
 
   it('opens the searchable target filter and filters options by query', () => {
     const nodes = [
-      makeObservedNode({ node_id: 1, node_id_str: '!00000001', short_name: 'AAA', long_name: 'Alpha' }),
-      makeObservedNode({ node_id: 2, node_id_str: '!00000002', short_name: 'BBB', long_name: 'Bravo' }),
-      makeObservedNode({ node_id: 3, node_id_str: '!00000003', short_name: 'CCC', long_name: 'Charlie' }),
+      makeObservedNode({ meshtastic_node_id: 1, node_id_str: '!00000001', short_name: 'AAA', long_name: 'Alpha' }),
+      makeObservedNode({ meshtastic_node_id: 2, node_id_str: '!00000002', short_name: 'BBB', long_name: 'Bravo' }),
+      makeObservedNode({ meshtastic_node_id: 3, node_id_str: '!00000003', short_name: 'CCC', long_name: 'Charlie' }),
     ];
     setupHooks({}, [], nodes);
     renderAt('/traceroutes/history');
@@ -301,7 +301,7 @@ describe('TracerouteHistory', () => {
 
   it('selecting a node from the searchable target filter updates the query', () => {
     const nodes = [
-      makeObservedNode({ node_id: 555, node_id_str: '!0000022b', short_name: 'PICKME', long_name: 'Pick me' }),
+      makeObservedNode({ meshtastic_node_id: 555, node_id_str: '!0000022b', short_name: 'PICKME', long_name: 'Pick me' }),
     ];
     setupHooks({}, [], nodes);
     renderAt('/traceroutes/history');

--- a/src/pages/traceroutes/TracerouteHistory.tsx
+++ b/src/pages/traceroutes/TracerouteHistory.tsx
@@ -186,11 +186,11 @@ export function TracerouteHistory() {
     includeStatus: true,
     includeGeoClassification: true,
   });
-  const managedByMeshId = useMemo(() => new Map(managedNodes.map((m) => [m.node_id, m])), [managedNodes]);
+  const managedByMeshId = useMemo(() => new Map(managedNodes.map((m) => [m.meshtastic_node_id, m])), [managedNodes]);
   const modalManagedNodes = useMemo(
     () =>
       triggerableNodes.map((t) => {
-        const full = managedByMeshId.get(t.node_id);
+        const full = managedByMeshId.get(t.meshtastic_node_id);
         return full ? { ...t, ...full } : t;
       }),
     [triggerableNodes, managedByMeshId]
@@ -245,8 +245,8 @@ export function TracerouteHistory() {
               <SelectContent>
                 <SelectItem value="all">All sources</SelectItem>
                 {triggerableNodes.map((n) => (
-                  <SelectItem key={n.node_id} value={String(n.node_id)}>
-                    {n.short_name ?? n.node_id_str ?? String(n.node_id)}
+                  <SelectItem key={n.meshtastic_node_id} value={String(n.meshtastic_node_id)}>
+                    {n.short_name ?? n.node_id_str ?? String(n.meshtastic_node_id)}
                   </SelectItem>
                 ))}
               </SelectContent>
@@ -433,7 +433,7 @@ export function TracerouteHistory() {
                       </TableCell>
                       {canTrigger && (
                         <TableCell onClick={(e) => e.stopPropagation()}>
-                          {triggerableNodes.some((n) => n.node_id === tr.source_node.node_id) ? (
+                          {triggerableNodes.some((n) => n.meshtastic_node_id === tr.source_node.meshtastic_node_id) ? (
                             <Button
                               variant="ghost"
                               size="icon"
@@ -441,8 +441,8 @@ export function TracerouteHistory() {
                               onClick={() =>
                                 triggerMutation.mutate(
                                   {
-                                    managedNodeId: tr.source_node.node_id,
-                                    targetNodeId: tr.target_node.node_id,
+                                    managedNodeId: tr.source_node.meshtastic_node_id,
+                                    targetNodeId: tr.target_node.meshtastic_node_id,
                                     targetStrategy:
                                       tr.target_strategy === 'intra_zone' ||
                                       tr.target_strategy === 'dx_across' ||
@@ -549,9 +549,9 @@ function SearchableNodeFilter({ nodes, value, onChange, placeholder, allLabel, c
     }
   }, [open]);
 
-  const selected = value != null ? nodes.find((n) => n.node_id === value) : null;
+  const selected = value != null ? nodes.find((n) => n.meshtastic_node_id === value) : null;
   const selectedLabel = selected
-    ? (selected.short_name ?? selected.node_id_str ?? String(selected.node_id))
+    ? (selected.short_name ?? selected.node_id_str ?? String(selected.meshtastic_node_id))
     : placeholder;
 
   const filtered = useMemo(() => {
@@ -559,7 +559,7 @@ function SearchableNodeFilter({ nodes, value, onChange, placeholder, allLabel, c
     if (!q) return nodes.slice(0, 200);
     return nodes
       .filter((n) => {
-        const haystack = [n.short_name, n.long_name, n.node_id_str, String(n.node_id)]
+        const haystack = [n.short_name, n.long_name, n.node_id_str, String(n.meshtastic_node_id)]
           .filter((s): s is string => !!s)
           .join(' ')
           .toLowerCase();
@@ -611,15 +611,15 @@ function SearchableNodeFilter({ nodes, value, onChange, placeholder, allLabel, c
               <li className="px-3 py-2 text-sm text-muted-foreground">No nodes match “{query}”</li>
             )}
             {filtered.map((n) => {
-              const label = n.short_name ?? n.node_id_str ?? String(n.node_id);
-              const isSelected = value === n.node_id;
+              const label = n.short_name ?? n.node_id_str ?? String(n.meshtastic_node_id);
+              const isSelected = value === n.meshtastic_node_id;
               return (
-                <li key={n.node_id}>
+                <li key={n.meshtastic_node_id}>
                   <button
                     type="button"
                     className={`w-full text-left px-3 py-1.5 text-sm hover:bg-accent ${isSelected ? 'bg-accent/50 font-medium' : ''}`}
                     onClick={() => {
-                      onChange(n.node_id);
+                      onChange(n.meshtastic_node_id);
                       setOpen(false);
                     }}
                   >

--- a/src/pages/traceroutes/TracerouteStatsPage.tsx
+++ b/src/pages/traceroutes/TracerouteStatsPage.tsx
@@ -39,11 +39,11 @@ export function TracerouteStatsPage() {
     includeStatus: true,
     includeGeoClassification: true,
   });
-  const managedByMeshId = useMemo(() => new Map(managedNodes.map((m) => [m.node_id, m])), [managedNodes]);
+  const managedByMeshId = useMemo(() => new Map(managedNodes.map((m) => [m.meshtastic_node_id, m])), [managedNodes]);
   const modalManagedNodes = useMemo(
     () =>
       triggerableNodes.map((t) => {
-        const full = managedByMeshId.get(t.node_id);
+        const full = managedByMeshId.get(t.meshtastic_node_id);
         return full ? { ...t, ...full } : t;
       }),
     [triggerableNodes, managedByMeshId]
@@ -73,8 +73,8 @@ export function TracerouteStatsPage() {
             <SelectContent>
               <SelectItem value="all">All sources</SelectItem>
               {triggerableNodes.map((n) => (
-                <SelectItem key={n.node_id} value={String(n.node_id)}>
-                  {n.short_name ?? n.node_id_str ?? String(n.node_id)}
+                <SelectItem key={n.meshtastic_node_id} value={String(n.meshtastic_node_id)}>
+                  {n.short_name ?? n.node_id_str ?? String(n.meshtastic_node_id)}
                 </SelectItem>
               ))}
             </SelectContent>

--- a/src/pages/traceroutes/TracerouteTopologyPage.test.tsx
+++ b/src/pages/traceroutes/TracerouteTopologyPage.test.tsx
@@ -22,7 +22,7 @@ const mockUseHeatmap = vi.mocked(useHeatmapEdges);
 const mockUseManaged = vi.mocked(useManagedNodesSuspense);
 
 const sampleNode = {
-  node_id: 0x11a,
+  meshtastic_node_id: 0x11a,
   node_id_str: '!0000011a',
   short_name: 'A',
   long_name: 'Node A',
@@ -40,7 +40,7 @@ describe('TracerouteTopologyPage URL → API', () => {
     mockUseManaged.mockReturnValue({
       managedNodes: [
         {
-          node_id: 99,
+          meshtastic_node_id: 99,
           short_name: 'Feed',
           node_id_str: '!00000063',
           long_name: null,
@@ -84,7 +84,7 @@ describe('TracerouteTopologyPage URL → API', () => {
   });
 
   it('shows node panel when selected query matches a loaded node', () => {
-    renderPage(`/traceroutes/map/topology/heat?selected=${sampleNode.node_id}`);
+    renderPage(`/traceroutes/map/topology/heat?selected=${sampleNode.meshtastic_node_id}`);
     expect(screen.getByTestId('topology-node-panel')).toBeInTheDocument();
     expect(screen.getByText('Open details')).toBeInTheDocument();
   });

--- a/src/pages/traceroutes/TracerouteTopologyPage.tsx
+++ b/src/pages/traceroutes/TracerouteTopologyPage.tsx
@@ -74,11 +74,11 @@ export function TracerouteTopologyPage({ edgeMetric }: { edgeMetric: EdgeMetric 
   const selectedRaw = searchParams.get('selected');
   const selectedNodeId = selectedRaw && /^\d+$/.test(selectedRaw.trim()) ? Number.parseInt(selectedRaw, 10) : null;
   const selectedNode: HeatmapNode | null =
-    selectedNodeId != null ? (nodes.find((n) => n.node_id === selectedNodeId) ?? null) : null;
+    selectedNodeId != null ? (nodes.find((n) => n.meshtastic_node_id === selectedNodeId) ?? null) : null;
 
   useEffect(() => {
     if (selectedNodeId == null || nodes.length === 0) return;
-    if (!nodes.some((n) => n.node_id === selectedNodeId)) {
+    if (!nodes.some((n) => n.meshtastic_node_id === selectedNodeId)) {
       updateParams({ selected: null });
     }
   }, [nodes, selectedNodeId, updateParams]);
@@ -124,7 +124,9 @@ export function TracerouteTopologyPage({ edgeMetric }: { edgeMetric: EdgeMetric 
                 edgeMetric={edgeMetric}
                 staleThresholdHours={HEATMAP_STALE_THRESHOLD_HOURS}
                 selectedNodeId={selectedNodeId}
-                onSelectedNodeChange={(node) => updateParams({ selected: node ? String(node.node_id) : null })}
+                onSelectedNodeChange={(node) =>
+                  updateParams({ selected: node ? String(node.meshtastic_node_id) : null })
+                }
               />
             )}
           </CardContent>

--- a/src/pages/traceroutes/TriggerTracerouteModal.test.tsx
+++ b/src/pages/traceroutes/TriggerTracerouteModal.test.tsx
@@ -23,7 +23,7 @@ vi.mock('@/components/traceroutes/AutoTargetPreviewMap', () => ({
 function makeObservedNode(overrides: Partial<ObservedNode> = {}): ObservedNode {
   return {
     internal_id: 1,
-    node_id: 42,
+    meshtastic_node_id: 42,
     node_id_str: '!0000002a',
     mac_addr: null,
     long_name: 'Fixed target',
@@ -52,7 +52,7 @@ function sampleGeo(): GeoClassification {
 
 function makeManagedNode(overrides: Partial<ManagedNode> = {}): ManagedNode {
   return {
-    node_id: 7,
+    meshtastic_node_id: 7,
     long_name: 'Source',
     short_name: 'SRC',
     last_heard: null,

--- a/src/pages/traceroutes/TriggerTracerouteModal.tsx
+++ b/src/pages/traceroutes/TriggerTracerouteModal.tsx
@@ -79,17 +79,20 @@ export function TriggerTracerouteModal({
 
   useEffect(() => {
     if (!hasFixedTarget || !fixedTargetNode) return;
-    setTargetNodeId(fixedTargetNode.node_id);
+    setTargetNodeId(fixedTargetNode.meshtastic_node_id);
     setTargetNodeLabel(formatNodeLabel(fixedTargetNode));
   }, [hasFixedTarget, fixedTargetNode]);
 
-  const selectedManaged = managedNodes.find((m) => m.node_id === managedNodeId);
+  const selectedManaged = managedNodes.find((m) => m.meshtastic_node_id === managedNodeId);
   const geo = selectedManaged?.geo_classification;
   const canIntraZone = geo?.applicable_strategies?.includes('intra_zone') ?? false;
 
   const managedNodesForMap = useMemo(() => filterManagedNodesForMapDisplay(managedNodes), [managedNodes]);
 
-  const managedNodeIdSet = useMemo(() => new Set(managedNodesForMap.map((m) => m.node_id)), [managedNodesForMap]);
+  const managedNodeIdSet = useMemo(
+    () => new Set(managedNodesForMap.map((m) => m.meshtastic_node_id)),
+    [managedNodesForMap]
+  );
 
   const [pickTargetLastHeardAfter, setPickTargetLastHeardAfter] = useState(() => pickTargetLastHeardCutoff());
 
@@ -138,7 +141,7 @@ export function TriggerTracerouteModal({
       setTargetNodeLabel(null);
       return false;
     }
-    setTargetNodeId(node.node_id);
+    setTargetNodeId(node.meshtastic_node_id);
     setTargetNodeLabel(`${node.short_name ?? node.node_id_str} (${node.node_id_str})`);
     return true;
   };
@@ -147,9 +150,9 @@ export function TriggerTracerouteModal({
   // Clicking anything else (e.g. the fixed target itself) is a no-op.
   const handleFixedTargetMapNodeSelect = (node: MapNode | null) => {
     if (!node) return false;
-    const isManaged = managedNodesForMap.some((m) => m.node_id === node.node_id);
+    const isManaged = managedNodesForMap.some((m) => m.meshtastic_node_id === node.meshtastic_node_id);
     if (!isManaged) return false;
-    setManagedNodeId(node.node_id);
+    setManagedNodeId(node.meshtastic_node_id);
     return true;
   };
 
@@ -189,7 +192,7 @@ export function TriggerTracerouteModal({
               </SelectTrigger>
               <SelectContent>
                 {managedNodes.map((node) => (
-                  <SelectItem key={node.node_id} value={node.node_id.toString()}>
+                  <SelectItem key={node.meshtastic_node_id} value={node.meshtastic_node_id.toString()}>
                     {node.short_name ?? node.node_id_str} ({node.node_id_str})
                   </SelectItem>
                 ))}
@@ -297,7 +300,7 @@ export function TriggerTracerouteModal({
                     showUnmanagedNodes={true}
                     drawBoundingBox={false}
                     enableBubbles={false}
-                    selectedNodeId={managedNodeId ?? fixedTargetNode.node_id}
+                    selectedNodeId={managedNodeId ?? fixedTargetNode.meshtastic_node_id}
                     onNodeSelect={handleFixedTargetMapNodeSelect}
                   />
                 </div>

--- a/src/pages/user/ApiKeysPage.tsx
+++ b/src/pages/user/ApiKeysPage.tsx
@@ -282,20 +282,20 @@ function ApiKeysContent() {
             <div className="max-h-48 overflow-y-auto border rounded p-2 mb-4">
               {nodesForAssignModal.length > 0 ? (
                 nodesForAssignModal.map((node) => (
-                  <div key={node.node_id} className="flex items-center gap-2 mb-1">
+                  <div key={node.meshtastic_node_id} className="flex items-center gap-2 mb-1">
                     <input
                       type="checkbox"
-                      id={`assign-node-${node.node_id}`}
-                      checked={selectedAssignNodes.includes(node.node_id)}
+                      id={`assign-node-${node.meshtastic_node_id}`}
+                      checked={selectedAssignNodes.includes(node.meshtastic_node_id)}
                       onChange={(e) => {
                         if (e.target.checked) {
-                          setSelectedAssignNodes((prev) => [...prev, node.node_id]);
+                          setSelectedAssignNodes((prev) => [...prev, node.meshtastic_node_id]);
                         } else {
-                          setSelectedAssignNodes((prev) => prev.filter((id) => id !== node.node_id));
+                          setSelectedAssignNodes((prev) => prev.filter((id) => id !== node.meshtastic_node_id));
                         }
                       }}
                     />
-                    <label htmlFor={`assign-node-${node.node_id}`} className="text-sm cursor-pointer">
+                    <label htmlFor={`assign-node-${node.meshtastic_node_id}`} className="text-sm cursor-pointer">
                       {node.short_name || node.node_id_str}
                     </label>
                   </div>
@@ -356,8 +356,8 @@ function ApiKeyCard({
   const assignedNodeNames = apiKey.nodes
     .map(
       (nid) =>
-        myManagedNodes.find((n) => n.node_id === nid)?.short_name ||
-        myManagedNodes.find((n) => n.node_id === nid)?.node_id_str ||
+        myManagedNodes.find((n) => n.meshtastic_node_id === nid)?.short_name ||
+        myManagedNodes.find((n) => n.meshtastic_node_id === nid)?.node_id_str ||
         `!${nid.toString(16)}`
     )
     .filter(Boolean);

--- a/src/pages/user/NodeSettings.tsx
+++ b/src/pages/user/NodeSettings.tsx
@@ -77,7 +77,7 @@ function NodeSettingsContent() {
   };
 
   // Create a Set of managed node IDs for quick lookup
-  const managedNodeIds = new Set(myManagedNodes.map((n) => n.node_id));
+  const managedNodeIds = new Set(myManagedNodes.map((n) => n.meshtastic_node_id));
 
   // Fetch API keys
   const { data: apiKeys, isLoading: isLoadingApiKeys } = useQuery({
@@ -112,7 +112,7 @@ function NodeSettingsContent() {
               {myClaimedNodes.length > 0 ? (
                 <div className="space-y-4">
                   {myClaimedNodes.map((node) => (
-                    <div key={node.node_id} className="border rounded-md p-4">
+                    <div key={node.meshtastic_node_id} className="border rounded-md p-4">
                       <div className="flex justify-between items-start">
                         <div>
                           <h3 className="font-medium">{node.short_name || node.node_id_str}</h3>
@@ -124,10 +124,13 @@ function NodeSettingsContent() {
                         </div>
                       </div>
                       <div className="mt-2 flex gap-2">
-                        <Link to={`/nodes/${node.node_id}`} className="text-blue-500 hover:text-blue-700 text-sm">
+                        <Link
+                          to={`/nodes/${node.meshtastic_node_id}`}
+                          className="text-blue-500 hover:text-blue-700 text-sm"
+                        >
                           View Node
                         </Link>
-                        {!managedNodeIds.has(node.node_id) && (
+                        {!managedNodeIds.has(node.meshtastic_node_id) && (
                           <Button
                             onClick={() => handleRunAsManagedNode(node)}
                             size="sm"
@@ -182,7 +185,7 @@ function NodeSettingsContent() {
                   return pendingClaims.length > 0 ? (
                     <div className="space-y-4">
                       {pendingClaims.map((claim) => (
-                        <div key={claim.node.node_id} className="border rounded-md p-4">
+                        <div key={claim.node.meshtastic_node_id} className="border rounded-md p-4">
                           <div className="flex justify-between items-start gap-2">
                             <div>
                               <h3 className="font-medium">{claim.node.short_name || claim.node.node_id_str}</h3>
@@ -196,14 +199,14 @@ function NodeSettingsContent() {
                               variant="outline"
                               size="sm"
                               className="shrink-0 text-destructive border-destructive/40 hover:bg-destructive/10"
-                              onClick={() => setCancelClaimForNodeId(claim.node.node_id)}
+                              onClick={() => setCancelClaimForNodeId(claim.node.meshtastic_node_id)}
                             >
                               Cancel claim
                             </Button>
                           </div>
                           <div className="mt-2">
                             <Link
-                              to={`/nodes/${claim.node.node_id}`}
+                              to={`/nodes/${claim.node.meshtastic_node_id}`}
                               className="text-blue-500 hover:text-blue-700 text-sm"
                             >
                               View Node
@@ -258,11 +261,11 @@ function NodeSettingsContent() {
               {myManagedNodes.length > 0 ? (
                 <Accordion type="multiple" className="space-y-2">
                   {myManagedNodes.map((node) => {
-                    const nodeApiKeys = apiKeys?.filter((key) => key.nodes.includes(node.node_id)) || [];
+                    const nodeApiKeys = apiKeys?.filter((key) => key.nodes.includes(node.meshtastic_node_id)) || [];
                     return (
                       <AccordionItem
-                        key={node.node_id}
-                        value={`node-${node.node_id}`}
+                        key={node.meshtastic_node_id}
+                        value={`node-${node.meshtastic_node_id}`}
                         className="border-2 border-slate-300 dark:border-slate-500 rounded-lg bg-slate-50/80 dark:bg-slate-950/40 shadow-sm"
                       >
                         <AccordionTrigger className="px-4 py-3 hover:no-underline">
@@ -355,7 +358,7 @@ function NodeSettingsContent() {
               disabled={cancelClaimMutation.isPending}
               onClick={() => {
                 if (!unclaimMyNodesTarget) return;
-                cancelClaimMutation.mutate(unclaimMyNodesTarget.node_id, {
+                cancelClaimMutation.mutate(unclaimMyNodesTarget.meshtastic_node_id, {
                   onSuccess: () => setUnclaimMyNodesTarget(null),
                 });
               }}
@@ -388,7 +391,7 @@ function NodeSettingsContent() {
               disabled={deleteManagedMutation.isPending}
               onClick={() => {
                 if (!unmanageManagedTarget) return;
-                deleteManagedMutation.mutate(unmanageManagedTarget.node_id, {
+                deleteManagedMutation.mutate(unmanageManagedTarget.meshtastic_node_id, {
                   onSuccess: () => setUnmanageManagedTarget(null),
                 });
               }}
@@ -503,7 +506,7 @@ function ManagedNodeSettings({
 
   const saveChannels = useMutation({
     mutationFn: () =>
-      api.patchManagedNode(node.node_id, {
+      api.patchManagedNode(node.meshtastic_node_id, {
         channel_0: mappings.channel_0,
         channel_1: mappings.channel_1,
         channel_2: mappings.channel_2,
@@ -527,7 +530,7 @@ function ManagedNodeSettings({
   return (
     <div className="space-y-4 pt-2">
       <div className="flex flex-wrap gap-2">
-        <Link to={`/nodes/${node.node_id}`}>
+        <Link to={`/nodes/${node.meshtastic_node_id}`}>
           <Button variant="outline" size="sm">
             View Node Details
           </Button>
@@ -593,11 +596,11 @@ function ManagedNodeSettings({
                     const cur = mappings[slotKey];
                     return (
                       <div key={i} className="flex items-center gap-2">
-                        <Label htmlFor={`managed-ch-${node.node_id}-${i}`} className="w-24 shrink-0 text-sm">
+                        <Label htmlFor={`managed-ch-${node.meshtastic_node_id}-${i}`} className="w-24 shrink-0 text-sm">
                           Slot {i}
                         </Label>
                         <Select value={cur == null ? 'none' : String(cur)} onValueChange={(v) => setSlot(i, v)}>
-                          <SelectTrigger id={`managed-ch-${node.node_id}-${i}`} className="flex-1">
+                          <SelectTrigger id={`managed-ch-${node.meshtastic_node_id}-${i}`} className="flex-1">
                             <SelectValue placeholder="Unmapped" />
                           </SelectTrigger>
                           <SelectContent>

--- a/tests/browser/dashboard.spec.ts
+++ b/tests/browser/dashboard.spec.ts
@@ -47,7 +47,7 @@ test.describe('Dashboard', () => {
       const nodesWithData = {
         results: [
           {
-            node_id: 1,
+            meshtastic_node_id: 1,
             node_id_str: '!abc123',
             short_name: 'TestNode',
             long_name: 'Test Node',

--- a/tests/browser/fixtures/heatmap-edges.json
+++ b/tests/browser/fixtures/heatmap-edges.json
@@ -30,7 +30,7 @@
   ],
   "nodes": [
     {
-      "node_id": 1,
+      "meshtastic_node_id": 1,
       "node_id_str": "!a1b2c3d4",
       "lat": 55.86,
       "lng": -4.25,
@@ -38,7 +38,7 @@
       "long_name": "Test Node A"
     },
     {
-      "node_id": 2,
+      "meshtastic_node_id": 2,
       "node_id_str": "!b2c3d4e5",
       "lat": 55.5,
       "lng": -5.0,
@@ -46,7 +46,7 @@
       "long_name": "Test Node B"
     },
     {
-      "node_id": 3,
+      "meshtastic_node_id": 3,
       "node_id_str": "!c3d4e5f6",
       "lat": 56.2,
       "lng": -3.5,


### PR DESCRIPTION
## Summary

- Rename `node_id` → `meshtastic_node_id` on `ObservedNode` / `ManagedNode` TypeScript types and all client usages.
- Update `meshtastic-api`, components, hooks, pages, and Playwright fixtures.

**Depends on:** merge and deploy [meshflow-api#322](https://github.com/pskillen/meshflow-api/pull/322) first (or merge same day).

Part of #310

## Testing performed

- [x] `npm run format`
- [x] `vitest run` (250 tests) via pre-commit hook
- [x] `npm run build` (verify locally)

## Coordinated PRs

- meshflow-api: https://github.com/pskillen/meshflow-api/pull/322
- meshflow-bot: no code changes required