### PR TITLE
feat(nodes): show reported bot version on managed nodes page

### DIFF
--- a/src/lib/models.ts
+++ b/src/lib/models.ts
@@ -194,6 +194,9 @@ export interface ManagedNode {
     bot_default_meshtastic_hop_limit?: number | null;
   };
   allow_auto_traceroute?: boolean;
+  /** Last meshflow-bot version reported on connect (null if never reported). */
+  bot_version?: string | null;
+  bot_version_reported_at?: Date | string | null;
   position: {
     latitude: number | null;
     longitude: number | null;

--- a/src/pages/nodes/ManagedNodesStatus.tsx
+++ b/src/pages/nodes/ManagedNodesStatus.tsx
@@ -92,6 +92,21 @@ function autoTracerouteBadge(node: ManagedNode) {
   return node.is_eligible_traceroute_source ? <Badge>eligible</Badge> : <Badge variant="secondary">stale-source</Badge>;
 }
 
+function renderBotVersionCell(node: ManagedNode) {
+  if (!node.bot_version) {
+    return '—';
+  }
+  const reportedAt = node.bot_version_reported_at ? new Date(node.bot_version_reported_at) : null;
+  return (
+    <div className="flex flex-col">
+      <span>{node.bot_version}</span>
+      {reportedAt ? (
+        <StaleReportedTime at={reportedAt} className="text-xs text-muted-foreground" variant="neutral" />
+      ) : null}
+    </div>
+  );
+}
+
 function ManagedNodesStatusContent() {
   const { managedNodes } = useManagedNodesSuspense({ pageSize: 500, includeStatus: true });
   const [searchParams, setSearchParams] = useSearchParams();
@@ -400,6 +415,7 @@ function ManagedNodesStatusContent() {
                     <TableHead>Packets / 24h</TableHead>
                     <TableHead>Radio last heard</TableHead>
                     <TableHead>Owner</TableHead>
+                    <TableHead>Bot version</TableHead>
                     <TableHead>Auto-TR</TableHead>
                   </TableRow>
                 </TableHeader>
@@ -428,6 +444,7 @@ function ManagedNodesStatusContent() {
                         <TableCell>{node.packets_last_24h ?? 0}</TableCell>
                         <TableCell>{renderTimestampCell(node.radio_last_heard)}</TableCell>
                         <TableCell>{node.owner.username}</TableCell>
+                        <TableCell>{renderBotVersionCell(node)}</TableCell>
                         <TableCell>{autoTracerouteBadge(node)}</TableCell>
                       </TableRow>
                     );


### PR DESCRIPTION
## Summary

- Extend `ManagedNode` type with `bot_version` and `bot_version_reported_at`.
- Add **Bot version** column on the Managed Nodes status table (version + relative reported time).

Requires meshflow-api PR deployed so list responses include the new fields.

**Tracking:** [meshflow-bot#99](https://github.com/pskillen/meshflow-bot/issues/99)

**Related PRs:** meshflow-api and meshflow-bot `bot-99/pskillen/bot-version-report` branches.

## Testing performed

- `npm run lint` (warnings only, pre-existing)
- `npm run test` (250 passed)

Relates to meshflow-bot#99