### PR TITLE
feat(infra-export): infrastructure CSV and Meshtastic CLI favorites export

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -13,6 +13,7 @@ import { WebSocketProvider } from '@/providers/WebSocketProvider';
 
 import { NodesList } from '@/pages/nodes/NodesList';
 import { MeshInfrastructure } from '@/pages/nodes/MeshInfrastructure';
+import { InfrastructureExport } from '@/pages/nodes/InfrastructureExport';
 import { Weather } from '@/pages/Weather';
 import { NodeMap } from '@/pages/map/NodeMap';
 import { MessageHistory } from '@/pages/messages/MessageHistory';
@@ -61,6 +62,7 @@ function App() {
                   <Route path="/" element={<Dashboard />} />
                   <Route path="/nodes" element={<NodesList />} />
                   <Route path="/nodes/infrastructure" element={<MeshInfrastructure />} />
+                  <Route path="/nodes/infrastructure/export" element={<InfrastructureExport />} />
                   <Route
                     path="/nodes/managed-nodes"
                     element={

--- a/src/components/SiteBreadcrumb.tsx
+++ b/src/components/SiteBreadcrumb.tsx
@@ -18,6 +18,9 @@ function getBreadcrumbSegments(pathname: string): { path: string; label: string 
     segments.push({ path: '/nodes', label: 'Nodes' });
     if (parts[1] === 'infrastructure') {
       segments.push({ path: '/nodes/infrastructure', label: 'Infrastructure' });
+      if (parts[2] === 'export') {
+        segments.push({ path: '/nodes/infrastructure/export', label: 'Export' });
+      }
     } else if (parts[1] === 'my-nodes') {
       segments.push({ path: '/nodes/my-nodes', label: 'My Nodes' });
     } else if (parts[1] === 'monitor') {

--- a/src/components/nodes/InfrastructureExportTable.tsx
+++ b/src/components/nodes/InfrastructureExportTable.tsx
@@ -1,0 +1,581 @@
+import * as React from 'react';
+import { Link } from 'react-router-dom';
+import {
+  ColumnDef,
+  ColumnFiltersState,
+  flexRender,
+  getCoreRowModel,
+  getFilteredRowModel,
+  getPaginationRowModel,
+  getSortedRowModel,
+  SortingState,
+  useReactTable,
+  type FilterFn,
+} from '@tanstack/react-table';
+import { format } from 'date-fns';
+import { enGB } from 'date-fns/locale';
+import { toast } from 'sonner';
+import { Copy, Download, Terminal } from 'lucide-react';
+
+import { Table, TableBody, TableCell, TableHead, TableHeader, TableRow } from '@/components/ui/table';
+import { Button } from '@/components/ui/button';
+import { Input } from '@/components/ui/input';
+import { Label } from '@/components/ui/label';
+import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from '@/components/ui/select';
+import { Card, CardContent, CardDescription, CardHeader, CardTitle } from '@/components/ui/card';
+import { infrastructureRowsToCsv, downloadCsv, downloadTextFile, type CsvColumnDef } from '@/lib/infrastructure-csv';
+import { buildSetFavoriteNodeCommands, countSetFavoriteNodeCommands } from '@/lib/infrastructure-meshtastic-cli';
+import type { InfrastructureExportRow } from '@/lib/infrastructure-export-rows';
+
+const INFRA_ROLE_OPTIONS = ['ROUTER', 'ROUTER_CLIENT', 'REPEATER', 'ROUTER_LATE', 'CLIENT_BASE'] as const;
+
+type TriState = 'all' | 'yes' | 'no';
+
+const triStateFilter: FilterFn<InfrastructureExportRow> = (row, columnId, filterValue) => {
+  const v = filterValue as TriState;
+  if (!v || v === 'all') return true;
+  const cell = row.getValue(columnId) as boolean | null;
+  if (v === 'yes') return cell === true;
+  return cell !== true;
+};
+
+const roleFilter: FilterFn<InfrastructureExportRow> = (row, columnId, filterValue) => {
+  const v = filterValue as string;
+  if (!v || v === 'all') return true;
+  return String(row.getValue(columnId)) === v;
+};
+
+export const INFRASTRUCTURE_EXPORT_CSV_COLUMNS: CsvColumnDef<InfrastructureExportRow>[] = [
+  { id: 'node_id_str', header: 'Node ID', getValue: (r) => r.node_id_str },
+  { id: 'short_name', header: 'Short name', getValue: (r) => r.short_name },
+  { id: 'long_name', header: 'Long name', getValue: (r) => r.long_name },
+  { id: 'role_label', header: 'Role', getValue: (r) => r.role_label },
+  { id: 'hw_model', header: 'HW model', getValue: (r) => r.hw_model },
+  { id: 'last_heard_iso', header: 'Last heard', getValue: (r) => r.last_heard_iso },
+  { id: 'latitude', header: 'Latitude', getValue: (r) => r.latitude },
+  { id: 'longitude', header: 'Longitude', getValue: (r) => r.longitude },
+  { id: 'altitude', header: 'Altitude', getValue: (r) => r.altitude },
+  { id: 'battery_percent', header: 'Battery %', getValue: (r) => r.battery_percent },
+  { id: 'channel_util_percent', header: 'Channel util %', getValue: (r) => r.channel_util_percent },
+  { id: 'owner_username', header: 'Owner', getValue: (r) => r.owner_username },
+  {
+    id: 'is_managed_feeder',
+    header: 'Managed feeder',
+    getValue: (r) => (r.is_managed_feeder ? 'Yes' : 'No'),
+  },
+  { id: 'constellation_name', header: 'Constellation', getValue: (r) => r.constellation_name },
+  {
+    id: 'is_licensed',
+    header: 'Licensed',
+    getValue: (r) => (r.is_licensed == null ? '' : r.is_licensed ? 'Yes' : 'No'),
+  },
+  {
+    id: 'has_rf_profile',
+    header: 'RF profile',
+    getValue: (r) => (r.has_rf_profile ? 'Yes' : 'No'),
+  },
+  {
+    id: 'has_ready_rf_render',
+    header: 'RF render ready',
+    getValue: (r) => (r.has_ready_rf_render ? 'Yes' : 'No'),
+  },
+];
+
+function formatLastHeard(iso: string): string {
+  if (!iso) return '—';
+  const d = new Date(iso);
+  if (Number.isNaN(d.getTime())) return '—';
+  return format(d, 'PPpp', { locale: enGB });
+}
+
+function boolCell(value: boolean | null): string {
+  if (value === null) return '—';
+  return value ? 'Yes' : 'No';
+}
+
+const columns: ColumnDef<InfrastructureExportRow>[] = [
+  {
+    accessorKey: 'node_id_str',
+    header: 'Node ID',
+    filterFn: 'includesString',
+    cell: ({ row }) => <span className="font-mono text-sm">{row.original.node_id_str}</span>,
+  },
+  {
+    id: 'name',
+    accessorFn: (r) => `${r.short_name} ${r.long_name}`,
+    header: 'Name',
+    filterFn: 'includesString',
+    cell: ({ row }) => (
+      <Link to={`/nodes/${row.original.internal_id}`} className="text-primary hover:underline">
+        <div className="font-medium">{row.original.long_name || row.original.short_name || '—'}</div>
+        {row.original.short_name && row.original.long_name && (
+          <div className="text-xs text-muted-foreground">{row.original.short_name}</div>
+        )}
+      </Link>
+    ),
+  },
+  {
+    accessorKey: 'role_label',
+    header: 'Role',
+    filterFn: roleFilter,
+    cell: ({ getValue }) => getValue() || '—',
+  },
+  {
+    accessorKey: 'hw_model',
+    header: 'HW model',
+    filterFn: 'includesString',
+    cell: ({ getValue }) => getValue() || '—',
+  },
+  {
+    accessorKey: 'last_heard_iso',
+    header: 'Last heard',
+    filterFn: 'includesString',
+    cell: ({ getValue }) => formatLastHeard(String(getValue() ?? '')),
+  },
+  {
+    accessorKey: 'latitude',
+    header: 'Latitude',
+    filterFn: 'includesString',
+    cell: ({ getValue }) => getValue() || '—',
+  },
+  {
+    accessorKey: 'longitude',
+    header: 'Longitude',
+    filterFn: 'includesString',
+    cell: ({ getValue }) => getValue() || '—',
+  },
+  {
+    accessorKey: 'battery_percent',
+    header: 'Battery %',
+    filterFn: 'includesString',
+    cell: ({ getValue }) => getValue() || '—',
+  },
+  {
+    accessorKey: 'channel_util_percent',
+    header: 'Ch util %',
+    filterFn: 'includesString',
+    cell: ({ getValue }) => getValue() || '—',
+  },
+  {
+    accessorKey: 'owner_username',
+    header: 'Owner',
+    filterFn: 'includesString',
+    cell: ({ getValue }) => getValue() || '—',
+  },
+  {
+    accessorKey: 'is_managed_feeder',
+    header: 'Managed',
+    filterFn: triStateFilter,
+    cell: ({ getValue }) => boolCell(getValue() as boolean),
+  },
+  {
+    accessorKey: 'constellation_name',
+    header: 'Constellation',
+    filterFn: 'includesString',
+    cell: ({ getValue }) => getValue() || '—',
+  },
+  {
+    accessorKey: 'is_licensed',
+    header: 'Licensed',
+    filterFn: triStateFilter,
+    cell: ({ getValue }) => boolCell(getValue() as boolean | null),
+  },
+  {
+    accessorKey: 'has_rf_profile',
+    header: 'RF profile',
+    filterFn: triStateFilter,
+    cell: ({ getValue }) => boolCell(getValue() as boolean),
+  },
+  {
+    accessorKey: 'has_ready_rf_render',
+    header: 'RF render',
+    filterFn: triStateFilter,
+    cell: ({ getValue }) => boolCell(getValue() as boolean),
+  },
+];
+
+function TriStateFilter({ value, onChange, id }: { value: TriState; onChange: (v: TriState) => void; id: string }) {
+  return (
+    <Select value={value} onValueChange={(v) => onChange(v as TriState)}>
+      <SelectTrigger className="h-8 w-full" id={id} aria-label={`Filter ${id}`}>
+        <SelectValue />
+      </SelectTrigger>
+      <SelectContent>
+        <SelectItem value="all">All</SelectItem>
+        <SelectItem value="yes">Yes</SelectItem>
+        <SelectItem value="no">No</SelectItem>
+      </SelectContent>
+    </Select>
+  );
+}
+
+export interface InfrastructureExportTableProps {
+  rows: InfrastructureExportRow[];
+}
+
+export function InfrastructureExportTable({ rows }: InfrastructureExportTableProps) {
+  const [sorting, setSorting] = React.useState<SortingState>([{ id: 'last_heard_iso', desc: true }]);
+  const [columnFilters, setColumnFilters] = React.useState<ColumnFiltersState>([]);
+  const [routersOnly, setRoutersOnly] = React.useState(false);
+  const [connectionArgs, setConnectionArgs] = React.useState('');
+  const [destNodeId, setDestNodeId] = React.useState('');
+
+  React.useEffect(() => {
+    setColumnFilters((prev) => {
+      const withoutRole = prev.filter((f) => f.id !== 'role_label');
+      if (!routersOnly) return withoutRole;
+      return [...withoutRole, { id: 'role_label', value: 'ROUTER' }];
+    });
+  }, [routersOnly]);
+
+  const table = useReactTable({
+    data: rows,
+    columns,
+    state: { sorting, columnFilters },
+    onSortingChange: setSorting,
+    onColumnFiltersChange: setColumnFilters,
+    getCoreRowModel: getCoreRowModel(),
+    getFilteredRowModel: getFilteredRowModel(),
+    getSortedRowModel: getSortedRowModel(),
+    getPaginationRowModel: getPaginationRowModel(),
+    initialState: { pagination: { pageSize: 50 } },
+  });
+
+  const filteredRows = table.getFilteredRowModel().rows.map((r) => r.original);
+  const filteredCount = filteredRows.length;
+  const totalCount = rows.length;
+
+  const dateStamp = new Date().toISOString().slice(0, 10);
+
+  const copyToClipboard = async (text: string, successMessage: string) => {
+    try {
+      await navigator.clipboard.writeText(text);
+      toast.success(successMessage);
+    } catch {
+      toast.error('Could not copy to clipboard');
+    }
+  };
+
+  const handleCopyCsv = () => {
+    if (filteredCount === 0) {
+      toast.message('No rows to export');
+      return;
+    }
+    const csv = infrastructureRowsToCsv(filteredRows, INFRASTRUCTURE_EXPORT_CSV_COLUMNS);
+    void copyToClipboard(csv, `Copied CSV (${filteredCount} rows)`);
+  };
+
+  const handleDownloadCsv = () => {
+    if (filteredCount === 0) {
+      toast.message('No rows to export');
+      return;
+    }
+    const csv = infrastructureRowsToCsv(filteredRows, INFRASTRUCTURE_EXPORT_CSV_COLUMNS);
+    downloadCsv(`meshflow-infrastructure-${dateStamp}.csv`, csv);
+    toast.success(`Downloaded ${filteredCount} rows`);
+  };
+
+  const cliOptions = React.useMemo(
+    () => ({
+      connectionArgs: connectionArgs.trim() || undefined,
+      destNodeId: destNodeId.trim() || undefined,
+    }),
+    [connectionArgs, destNodeId]
+  );
+
+  const handleCopyCli = () => {
+    const script = buildSetFavoriteNodeCommands(filteredRows, cliOptions);
+    const count = countSetFavoriteNodeCommands(filteredRows, { ...cliOptions, includeHeader: false });
+    if (count === 0) {
+      toast.message('No valid node IDs in filtered rows (or invalid admin target)');
+      return;
+    }
+    void copyToClipboard(script, `Copied ${count} CLI command${count === 1 ? '' : 's'}`);
+  };
+
+  const handleDownloadCli = () => {
+    const script = buildSetFavoriteNodeCommands(filteredRows, cliOptions);
+    const count = countSetFavoriteNodeCommands(filteredRows, { ...cliOptions, includeHeader: false });
+    if (count === 0) {
+      toast.message('No valid node IDs in filtered rows');
+      return;
+    }
+    downloadTextFile(`meshflow-favorites-${dateStamp}.sh`, script, 'text/plain;charset=utf-8');
+    toast.success(`Downloaded ${count} commands`);
+  };
+
+  const setColumnFilter = (id: string, value: unknown) => {
+    setColumnFilters((prev) => {
+      const rest = prev.filter((f) => f.id !== id);
+      if (value === '' || value === 'all' || value == null) return rest;
+      return [...rest, { id, value }];
+    });
+  };
+
+  const getFilterValue = (id: string): string => {
+    const f = columnFilters.find((c) => c.id === id);
+    return f?.value != null ? String(f.value) : '';
+  };
+
+  if (totalCount === 0) {
+    return <p className="text-center text-muted-foreground py-12">No infrastructure nodes in this time range.</p>;
+  }
+
+  return (
+    <div className="space-y-4">
+      <Card>
+        <CardHeader className="pb-3">
+          <CardTitle className="text-base">Meshtastic CLI options</CardTitle>
+          <CardDescription>
+            Used for &quot;Copy CLI favorite commands&quot;. See{' '}
+            <a
+              href="https://meshtastic.org/docs/software/python/cli/"
+              className="underline"
+              target="_blank"
+              rel="noreferrer"
+            >
+              Meshtastic CLI
+            </a>{' '}
+            (<code className="text-xs">--set-favorite-node</code>).
+          </CardDescription>
+        </CardHeader>
+        <CardContent className="grid gap-4 sm:grid-cols-2">
+          <div className="space-y-2">
+            <Label htmlFor="cli-connection">Connection prefix (optional)</Label>
+            <Input
+              id="cli-connection"
+              placeholder="e.g. -b MyRadio or --host meshtastic.local"
+              value={connectionArgs}
+              onChange={(e) => setConnectionArgs(e.target.value)}
+            />
+          </div>
+          <div className="space-y-2">
+            <Label htmlFor="cli-dest">Admin target --dest (optional)</Label>
+            <Input
+              id="cli-dest"
+              placeholder="e.g. !a5592387"
+              value={destNodeId}
+              onChange={(e) => setDestNodeId(e.target.value)}
+            />
+          </div>
+        </CardContent>
+      </Card>
+
+      <div className="flex flex-wrap items-center gap-2">
+        <Button type="button" variant="default" size="sm" onClick={handleCopyCli}>
+          <Terminal className="h-4 w-4 mr-1" />
+          Copy CLI favorite commands
+        </Button>
+        <Button type="button" variant="outline" size="sm" onClick={handleDownloadCli}>
+          <Download className="h-4 w-4 mr-1" />
+          Download .sh
+        </Button>
+        <Button type="button" variant="outline" size="sm" onClick={handleCopyCsv}>
+          <Copy className="h-4 w-4 mr-1" />
+          Copy CSV
+        </Button>
+        <Button type="button" variant="outline" size="sm" onClick={handleDownloadCsv}>
+          <Download className="h-4 w-4 mr-1" />
+          Download CSV
+        </Button>
+        <Button
+          type="button"
+          variant={routersOnly ? 'default' : 'outline'}
+          size="sm"
+          onClick={() => setRoutersOnly((v) => !v)}
+        >
+          Routers only
+        </Button>
+        <span className="text-sm text-muted-foreground ml-auto">
+          Showing {filteredCount} of {totalCount} nodes
+        </span>
+      </div>
+
+      <div className="rounded-md border overflow-x-auto">
+        <Table>
+          <TableHeader>
+            {table.getHeaderGroups().map((headerGroup) => (
+              <TableRow key={headerGroup.id}>
+                {headerGroup.headers.map((header) => (
+                  <TableHead key={header.id} className="whitespace-nowrap">
+                    {header.isPlaceholder ? null : (
+                      <button
+                        type="button"
+                        className="font-medium hover:underline text-left"
+                        onClick={header.column.getToggleSortingHandler()}
+                      >
+                        {flexRender(header.column.columnDef.header, header.getContext())}
+                        {{ asc: ' ↑', desc: ' ↓' }[header.column.getIsSorted() as string] ?? null}
+                      </button>
+                    )}
+                  </TableHead>
+                ))}
+              </TableRow>
+            ))}
+            <TableRow className="bg-muted/50">
+              <TableHead>
+                <Input
+                  className="h-8"
+                  placeholder="Filter…"
+                  value={getFilterValue('node_id_str')}
+                  onChange={(e) => setColumnFilter('node_id_str', e.target.value)}
+                  aria-label="Filter node ID"
+                />
+              </TableHead>
+              <TableHead>
+                <Input
+                  className="h-8"
+                  placeholder="Filter…"
+                  value={getFilterValue('name')}
+                  onChange={(e) => setColumnFilter('name', e.target.value)}
+                  aria-label="Filter name"
+                />
+              </TableHead>
+              <TableHead>
+                <Select
+                  value={getFilterValue('role_label') || 'all'}
+                  onValueChange={(v) => setColumnFilter('role_label', v)}
+                >
+                  <SelectTrigger className="h-8 w-full" aria-label="Filter role">
+                    <SelectValue placeholder="All" />
+                  </SelectTrigger>
+                  <SelectContent>
+                    <SelectItem value="all">All</SelectItem>
+                    {INFRA_ROLE_OPTIONS.map((role) => (
+                      <SelectItem key={role} value={role}>
+                        {role}
+                      </SelectItem>
+                    ))}
+                  </SelectContent>
+                </Select>
+              </TableHead>
+              <TableHead>
+                <Input
+                  className="h-8"
+                  value={getFilterValue('hw_model')}
+                  onChange={(e) => setColumnFilter('hw_model', e.target.value)}
+                  aria-label="Filter HW model"
+                />
+              </TableHead>
+              <TableHead>
+                <Input
+                  className="h-8"
+                  value={getFilterValue('last_heard_iso')}
+                  onChange={(e) => setColumnFilter('last_heard_iso', e.target.value)}
+                  aria-label="Filter last heard"
+                />
+              </TableHead>
+              <TableHead>
+                <Input
+                  className="h-8"
+                  value={getFilterValue('latitude')}
+                  onChange={(e) => setColumnFilter('latitude', e.target.value)}
+                  aria-label="Filter latitude"
+                />
+              </TableHead>
+              <TableHead>
+                <Input
+                  className="h-8"
+                  value={getFilterValue('longitude')}
+                  onChange={(e) => setColumnFilter('longitude', e.target.value)}
+                  aria-label="Filter longitude"
+                />
+              </TableHead>
+              <TableHead>
+                <Input
+                  className="h-8"
+                  value={getFilterValue('battery_percent')}
+                  onChange={(e) => setColumnFilter('battery_percent', e.target.value)}
+                  aria-label="Filter battery"
+                />
+              </TableHead>
+              <TableHead>
+                <Input
+                  className="h-8"
+                  value={getFilterValue('channel_util_percent')}
+                  onChange={(e) => setColumnFilter('channel_util_percent', e.target.value)}
+                  aria-label="Filter channel util"
+                />
+              </TableHead>
+              <TableHead>
+                <Input
+                  className="h-8"
+                  value={getFilterValue('owner_username')}
+                  onChange={(e) => setColumnFilter('owner_username', e.target.value)}
+                  aria-label="Filter owner"
+                />
+              </TableHead>
+              <TableHead>
+                <TriStateFilter
+                  id="managed"
+                  value={(getFilterValue('is_managed_feeder') as TriState) || 'all'}
+                  onChange={(v) => setColumnFilter('is_managed_feeder', v)}
+                />
+              </TableHead>
+              <TableHead>
+                <Input
+                  className="h-8"
+                  value={getFilterValue('constellation_name')}
+                  onChange={(e) => setColumnFilter('constellation_name', e.target.value)}
+                  aria-label="Filter constellation"
+                />
+              </TableHead>
+              <TableHead>
+                <TriStateFilter
+                  id="licensed"
+                  value={(getFilterValue('is_licensed') as TriState) || 'all'}
+                  onChange={(v) => setColumnFilter('is_licensed', v)}
+                />
+              </TableHead>
+              <TableHead>
+                <TriStateFilter
+                  id="rf-profile"
+                  value={(getFilterValue('has_rf_profile') as TriState) || 'all'}
+                  onChange={(v) => setColumnFilter('has_rf_profile', v)}
+                />
+              </TableHead>
+              <TableHead>
+                <TriStateFilter
+                  id="rf-render"
+                  value={(getFilterValue('has_ready_rf_render') as TriState) || 'all'}
+                  onChange={(v) => setColumnFilter('has_ready_rf_render', v)}
+                />
+              </TableHead>
+            </TableRow>
+          </TableHeader>
+          <TableBody>
+            {table.getRowModel().rows.length ? (
+              table.getRowModel().rows.map((row) => (
+                <TableRow key={row.id}>
+                  {row.getVisibleCells().map((cell) => (
+                    <TableCell key={cell.id} className="whitespace-nowrap">
+                      {flexRender(cell.column.columnDef.cell, cell.getContext())}
+                    </TableCell>
+                  ))}
+                </TableRow>
+              ))
+            ) : (
+              <TableRow>
+                <TableCell colSpan={columns.length} className="h-24 text-center text-muted-foreground">
+                  No rows match the current filters.
+                </TableCell>
+              </TableRow>
+            )}
+          </TableBody>
+        </Table>
+      </div>
+
+      <div className="flex items-center justify-end gap-2">
+        <Button variant="outline" size="sm" onClick={() => table.previousPage()} disabled={!table.getCanPreviousPage()}>
+          Previous
+        </Button>
+        <span className="text-sm text-muted-foreground">
+          Page {table.getState().pagination.pageIndex + 1} of {table.getPageCount()}
+        </span>
+        <Button variant="outline" size="sm" onClick={() => table.nextPage()} disabled={!table.getCanNextPage()}>
+          Next
+        </Button>
+      </div>
+    </div>
+  );
+}

--- a/src/components/nodes/InfrastructureExportTable.tsx
+++ b/src/components/nodes/InfrastructureExportTable.tsx
@@ -15,19 +15,28 @@ import {
 import { format } from 'date-fns';
 import { enGB } from 'date-fns/locale';
 import { toast } from 'sonner';
-import { Copy, Download, Terminal } from 'lucide-react';
+import { ChevronDown, Copy, Download, Terminal } from 'lucide-react';
 
 import { Table, TableBody, TableCell, TableHead, TableHeader, TableRow } from '@/components/ui/table';
 import { Button } from '@/components/ui/button';
 import { Input } from '@/components/ui/input';
 import { Label } from '@/components/ui/label';
 import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from '@/components/ui/select';
+import {
+  DropdownMenu,
+  DropdownMenuCheckboxItem,
+  DropdownMenuContent,
+  DropdownMenuTrigger,
+} from '@/components/ui/dropdown-menu';
 import { Card, CardContent, CardDescription, CardHeader, CardTitle } from '@/components/ui/card';
 import { infrastructureRowsToCsv, downloadCsv, downloadTextFile, type CsvColumnDef } from '@/lib/infrastructure-csv';
 import { buildSetFavoriteNodeCommands, countSetFavoriteNodeCommands } from '@/lib/infrastructure-meshtastic-cli';
 import type { InfrastructureExportRow } from '@/lib/infrastructure-export-rows';
 
-const INFRA_ROLE_OPTIONS = ['ROUTER', 'ROUTER_CLIENT', 'REPEATER', 'ROUTER_LATE', 'CLIENT_BASE'] as const;
+export const INFRA_EXPORT_ROLE_OPTIONS = ['ROUTER', 'ROUTER_CLIENT', 'REPEATER', 'ROUTER_LATE', 'CLIENT_BASE'] as const;
+
+/** Default role filter: standard infrastructure roles, excluding CLIENT_BASE. */
+export const DEFAULT_INCLUDED_INFRA_ROLES: readonly string[] = ['ROUTER', 'ROUTER_CLIENT', 'REPEATER', 'ROUTER_LATE'];
 
 type TriState = 'all' | 'yes' | 'no';
 
@@ -40,10 +49,16 @@ const triStateFilter: FilterFn<InfrastructureExportRow> = (row, columnId, filter
 };
 
 const roleFilter: FilterFn<InfrastructureExportRow> = (row, columnId, filterValue) => {
-  const v = filterValue as string;
-  if (!v || v === 'all') return true;
-  return String(row.getValue(columnId)) === v;
+  const allowed = filterValue as string[] | undefined;
+  if (!allowed || allowed.length === 0) return true;
+  return allowed.includes(String(row.getValue(columnId)));
 };
+
+function parseRoleFilterValue(value: unknown): string[] {
+  if (Array.isArray(value)) return value.filter((v) => typeof v === 'string');
+  if (typeof value === 'string' && value !== 'all') return [value];
+  return [];
+}
 
 export const INFRASTRUCTURE_EXPORT_CSV_COLUMNS: CsvColumnDef<InfrastructureExportRow>[] = [
   { id: 'node_id_str', header: 'Node ID', getValue: (r) => r.node_id_str },
@@ -213,9 +228,53 @@ export interface InfrastructureExportTableProps {
   rows: InfrastructureExportRow[];
 }
 
+function RoleFilterMenu({ includedRoles, onChange }: { includedRoles: string[]; onChange: (roles: string[]) => void }) {
+  const effectiveRoles = includedRoles.length === 0 ? [...INFRA_EXPORT_ROLE_OPTIONS] : includedRoles;
+
+  const label =
+    includedRoles.length === 0 || includedRoles.length === INFRA_EXPORT_ROLE_OPTIONS.length
+      ? 'All roles'
+      : `${includedRoles.length} roles`;
+
+  const toggleRole = (role: string, checked: boolean) => {
+    const base = includedRoles.length === 0 ? [...INFRA_EXPORT_ROLE_OPTIONS] : [...includedRoles];
+    if (checked) {
+      onChange([...new Set([...base, role])]);
+    } else {
+      const next = base.filter((r) => r !== role);
+      onChange(next);
+    }
+  };
+
+  return (
+    <DropdownMenu>
+      <DropdownMenuTrigger asChild>
+        <Button variant="outline" size="sm" className="h-8 w-full justify-between font-normal">
+          {label}
+          <ChevronDown className="h-3 w-3 opacity-50" />
+        </Button>
+      </DropdownMenuTrigger>
+      <DropdownMenuContent align="start" className="w-48">
+        {INFRA_EXPORT_ROLE_OPTIONS.map((role) => (
+          <DropdownMenuCheckboxItem
+            key={role}
+            checked={effectiveRoles.includes(role)}
+            onCheckedChange={(checked) => toggleRole(role, checked === true)}
+            onSelect={(e) => e.preventDefault()}
+          >
+            {role}
+          </DropdownMenuCheckboxItem>
+        ))}
+      </DropdownMenuContent>
+    </DropdownMenu>
+  );
+}
+
 export function InfrastructureExportTable({ rows }: InfrastructureExportTableProps) {
   const [sorting, setSorting] = React.useState<SortingState>([{ id: 'last_heard_iso', desc: true }]);
-  const [columnFilters, setColumnFilters] = React.useState<ColumnFiltersState>([]);
+  const [columnFilters, setColumnFilters] = React.useState<ColumnFiltersState>([
+    { id: 'role_label', value: [...DEFAULT_INCLUDED_INFRA_ROLES] },
+  ]);
   const [routersOnly, setRoutersOnly] = React.useState(false);
   const [connectionArgs, setConnectionArgs] = React.useState('');
   const [destNodeId, setDestNodeId] = React.useState('');
@@ -223,8 +282,10 @@ export function InfrastructureExportTable({ rows }: InfrastructureExportTablePro
   React.useEffect(() => {
     setColumnFilters((prev) => {
       const withoutRole = prev.filter((f) => f.id !== 'role_label');
-      if (!routersOnly) return withoutRole;
-      return [...withoutRole, { id: 'role_label', value: 'ROUTER' }];
+      if (!routersOnly) {
+        return [...withoutRole, { id: 'role_label', value: [...DEFAULT_INCLUDED_INFRA_ROLES] }];
+      }
+      return [...withoutRole, { id: 'role_label', value: ['ROUTER'] }];
     });
   }, [routersOnly]);
 
@@ -325,7 +386,7 @@ export function InfrastructureExportTable({ rows }: InfrastructureExportTablePro
     <div className="space-y-4">
       <Card>
         <CardHeader className="pb-3">
-          <CardTitle className="text-base">Meshtastic CLI options</CardTitle>
+          <CardTitle className="text-base">Meshtastic CLI tools</CardTitle>
           <CardDescription>
             Used for &quot;Copy CLI favorite commands&quot;. See{' '}
             <a
@@ -339,37 +400,41 @@ export function InfrastructureExportTable({ rows }: InfrastructureExportTablePro
             (<code className="text-xs">--set-favorite-node</code>).
           </CardDescription>
         </CardHeader>
-        <CardContent className="grid gap-4 sm:grid-cols-2">
-          <div className="space-y-2">
-            <Label htmlFor="cli-connection">Connection prefix (optional)</Label>
-            <Input
-              id="cli-connection"
-              placeholder="e.g. -b MyRadio or --host meshtastic.local"
-              value={connectionArgs}
-              onChange={(e) => setConnectionArgs(e.target.value)}
-            />
+        <CardContent className="space-y-4">
+          <div className="grid gap-4 sm:grid-cols-2">
+            <div className="space-y-2">
+              <Label htmlFor="cli-connection">Connection prefix (optional)</Label>
+              <Input
+                id="cli-connection"
+                placeholder="e.g. -b MyRadio or --host meshtastic.local"
+                value={connectionArgs}
+                onChange={(e) => setConnectionArgs(e.target.value)}
+              />
+            </div>
+            <div className="space-y-2">
+              <Label htmlFor="cli-dest">Admin target --dest (optional)</Label>
+              <Input
+                id="cli-dest"
+                placeholder="e.g. !a5592387"
+                value={destNodeId}
+                onChange={(e) => setDestNodeId(e.target.value)}
+              />
+            </div>
           </div>
-          <div className="space-y-2">
-            <Label htmlFor="cli-dest">Admin target --dest (optional)</Label>
-            <Input
-              id="cli-dest"
-              placeholder="e.g. !a5592387"
-              value={destNodeId}
-              onChange={(e) => setDestNodeId(e.target.value)}
-            />
+          <div className="flex flex-wrap gap-2">
+            <Button type="button" variant="default" size="sm" onClick={handleCopyCli}>
+              <Terminal className="h-4 w-4 mr-1" />
+              Copy CLI favorite commands
+            </Button>
+            <Button type="button" variant="outline" size="sm" onClick={handleDownloadCli}>
+              <Download className="h-4 w-4 mr-1" />
+              Download .sh
+            </Button>
           </div>
         </CardContent>
       </Card>
 
       <div className="flex flex-wrap items-center gap-2">
-        <Button type="button" variant="default" size="sm" onClick={handleCopyCli}>
-          <Terminal className="h-4 w-4 mr-1" />
-          Copy CLI favorite commands
-        </Button>
-        <Button type="button" variant="outline" size="sm" onClick={handleDownloadCli}>
-          <Download className="h-4 w-4 mr-1" />
-          Download .sh
-        </Button>
         <Button type="button" variant="outline" size="sm" onClick={handleCopyCsv}>
           <Copy className="h-4 w-4 mr-1" />
           Copy CSV
@@ -432,22 +497,19 @@ export function InfrastructureExportTable({ rows }: InfrastructureExportTablePro
                 />
               </TableHead>
               <TableHead>
-                <Select
-                  value={getFilterValue('role_label') || 'all'}
-                  onValueChange={(v) => setColumnFilter('role_label', v)}
-                >
-                  <SelectTrigger className="h-8 w-full" aria-label="Filter role">
-                    <SelectValue placeholder="All" />
-                  </SelectTrigger>
-                  <SelectContent>
-                    <SelectItem value="all">All</SelectItem>
-                    {INFRA_ROLE_OPTIONS.map((role) => (
-                      <SelectItem key={role} value={role}>
-                        {role}
-                      </SelectItem>
-                    ))}
-                  </SelectContent>
-                </Select>
+                <RoleFilterMenu
+                  includedRoles={parseRoleFilterValue(columnFilters.find((f) => f.id === 'role_label')?.value)}
+                  onChange={(roles) => {
+                    setRoutersOnly(false);
+                    setColumnFilters((prev) => {
+                      const rest = prev.filter((f) => f.id !== 'role_label');
+                      if (roles.length === 0 || roles.length === INFRA_EXPORT_ROLE_OPTIONS.length) {
+                        return rest;
+                      }
+                      return [...rest, { id: 'role_label', value: roles }];
+                    });
+                  }}
+                />
               </TableHead>
               <TableHead>
                 <Input

--- a/src/lib/infrastructure-csv.test.ts
+++ b/src/lib/infrastructure-csv.test.ts
@@ -1,0 +1,49 @@
+import { describe, expect, it } from 'vitest';
+import { escapeCsvCell, infrastructureRowsToCsv, type CsvColumnDef } from './infrastructure-csv';
+
+type Row = { name: string; count: number | null };
+
+const columns: CsvColumnDef<Row>[] = [
+  { id: 'name', header: 'Name', getValue: (r) => r.name },
+  { id: 'count', header: 'Count', getValue: (r) => r.count },
+];
+
+describe('escapeCsvCell', () => {
+  it('quotes fields with commas', () => {
+    expect(escapeCsvCell('a,b')).toBe('"a,b"');
+  });
+
+  it('escapes double quotes', () => {
+    expect(escapeCsvCell('say "hi"')).toBe('"say ""hi"""');
+  });
+
+  it('quotes multiline values', () => {
+    expect(escapeCsvCell('line1\nline2')).toBe('"line1\nline2"');
+  });
+
+  it('leaves simple strings unquoted', () => {
+    expect(escapeCsvCell('router-1')).toBe('router-1');
+  });
+});
+
+describe('infrastructureRowsToCsv', () => {
+  it('includes header and one row per input', () => {
+    const csv = infrastructureRowsToCsv(
+      [
+        { name: 'Alpha', count: 1 },
+        { name: 'Beta', count: null },
+      ],
+      columns
+    );
+    const lines = csv.split('\n');
+    expect(lines).toHaveLength(3);
+    expect(lines[0]).toBe('Name,Count');
+    expect(lines[1]).toBe('Alpha,1');
+    expect(lines[2]).toBe('Beta,');
+  });
+
+  it('quotes node names containing commas', () => {
+    const csv = infrastructureRowsToCsv([{ name: 'East, Router', count: 2 }], columns);
+    expect(csv).toContain('"East, Router"');
+  });
+});

--- a/src/lib/infrastructure-csv.ts
+++ b/src/lib/infrastructure-csv.ts
@@ -1,0 +1,42 @@
+/**
+ * RFC 4180 CSV serialisation for infrastructure export rows.
+ */
+
+export interface CsvColumnDef<T> {
+  id: string;
+  header: string;
+  getValue: (row: T) => string | number | boolean | null | undefined;
+}
+
+export function escapeCsvCell(value: string): string {
+  if (value.includes('"') || value.includes(',') || value.includes('\n') || value.includes('\r')) {
+    return `"${value.replace(/"/g, '""')}"`;
+  }
+  return value;
+}
+
+function cellToString(value: string | number | boolean | null | undefined): string {
+  if (value === null || value === undefined) return '';
+  if (typeof value === 'boolean') return value ? 'Yes' : 'No';
+  return String(value);
+}
+
+export function infrastructureRowsToCsv<T>(rows: T[], columns: CsvColumnDef<T>[]): string {
+  const headerLine = columns.map((c) => escapeCsvCell(c.header)).join(',');
+  const dataLines = rows.map((row) => columns.map((col) => escapeCsvCell(cellToString(col.getValue(row)))).join(','));
+  return [headerLine, ...dataLines].join('\n');
+}
+
+export function downloadTextFile(filename: string, content: string, mimeType: string): void {
+  const blob = new Blob([content], { type: mimeType });
+  const url = URL.createObjectURL(blob);
+  const anchor = document.createElement('a');
+  anchor.href = url;
+  anchor.download = filename;
+  anchor.click();
+  URL.revokeObjectURL(url);
+}
+
+export function downloadCsv(filename: string, content: string): void {
+  downloadTextFile(filename, content, 'text/csv;charset=utf-8');
+}

--- a/src/lib/infrastructure-export-rows.ts
+++ b/src/lib/infrastructure-export-rows.ts
@@ -1,0 +1,76 @@
+import type { ManagedNode, ObservedNode } from '@/lib/models';
+import { getRoleLabel } from '@/lib/meshtastic';
+
+export interface InfrastructureExportRow {
+  internal_id: string;
+  node_id_str: string;
+  short_name: string;
+  long_name: string;
+  role_label: string;
+  hw_model: string;
+  last_heard_iso: string;
+  latitude: string;
+  longitude: string;
+  altitude: string;
+  battery_percent: string;
+  channel_util_percent: string;
+  owner_username: string;
+  is_managed_feeder: boolean;
+  constellation_name: string;
+  is_licensed: boolean | null;
+  has_rf_profile: boolean;
+  has_ready_rf_render: boolean;
+}
+
+function formatCoord(value: number | null | undefined): string {
+  if (value == null || value === 0) return '';
+  return String(value);
+}
+
+function formatIso(date: Date | string | null | undefined): string {
+  if (!date) return '';
+  const d = date instanceof Date ? date : new Date(date);
+  if (Number.isNaN(d.getTime())) return '';
+  return d.toISOString();
+}
+
+function formatMetric(value: number | null | undefined): string {
+  if (value == null) return '';
+  return String(value);
+}
+
+export function buildInfrastructureExportRow(
+  node: ObservedNode,
+  managedNode?: ManagedNode | null
+): InfrastructureExportRow {
+  const pos = node.latest_position;
+  const metrics = node.latest_device_metrics;
+
+  return {
+    internal_id: node.internal_id,
+    node_id_str: node.node_id_str ?? '',
+    short_name: node.short_name ?? '',
+    long_name: node.long_name ?? '',
+    role_label: getRoleLabel(node.meshtastic_role) ?? '',
+    hw_model: node.meshtastic_hw_model ?? '',
+    last_heard_iso: formatIso(node.last_heard),
+    latitude: formatCoord(pos?.latitude),
+    longitude: formatCoord(pos?.longitude),
+    altitude: formatMetric(pos?.altitude),
+    battery_percent: formatMetric(metrics?.battery_level),
+    channel_util_percent: formatMetric(metrics?.meshtastic_channel_utilization),
+    owner_username: node.owner?.username ?? '',
+    is_managed_feeder: managedNode != null,
+    constellation_name: managedNode?.constellation?.name ?? '',
+    is_licensed: node.meshtastic_is_licensed ?? null,
+    has_rf_profile: node.has_rf_profile ?? false,
+    has_ready_rf_render: node.has_ready_rf_render ?? false,
+  };
+}
+
+export function buildInfrastructureExportRows(
+  nodes: ObservedNode[],
+  managedByMeshId: Map<number, ManagedNode>
+): InfrastructureExportRow[] {
+  return nodes.map((node) => buildInfrastructureExportRow(node, managedByMeshId.get(node.meshtastic_node_id)));
+}

--- a/src/lib/infrastructure-meshtastic-cli.test.ts
+++ b/src/lib/infrastructure-meshtastic-cli.test.ts
@@ -1,0 +1,72 @@
+import { describe, expect, it } from 'vitest';
+import type { InfrastructureExportRow } from './infrastructure-export-rows';
+import { buildSetFavoriteNodeCommands, countSetFavoriteNodeCommands } from './infrastructure-meshtastic-cli';
+
+function row(overrides: Partial<InfrastructureExportRow> = {}): InfrastructureExportRow {
+  return {
+    internal_id: '00000000-0000-4000-8000-000000000001',
+    node_id_str: '!a1b2c3d4',
+    short_name: 'R1',
+    long_name: 'Router One',
+    role_label: 'ROUTER',
+    hw_model: '',
+    last_heard_iso: '',
+    latitude: '',
+    longitude: '',
+    altitude: '',
+    battery_percent: '',
+    channel_util_percent: '',
+    owner_username: '',
+    is_managed_feeder: false,
+    constellation_name: '',
+    is_licensed: null,
+    has_rf_profile: false,
+    has_ready_rf_render: false,
+    ...overrides,
+  };
+}
+
+describe('buildSetFavoriteNodeCommands', () => {
+  it('emits local favorite commands with quoted node ids', () => {
+    const text = buildSetFavoriteNodeCommands([row()], { includeHeader: false });
+    expect(text).toBe("meshtastic --set-favorite-node '!a1b2c3d4'");
+  });
+
+  it('includes connection prefix when provided', () => {
+    const text = buildSetFavoriteNodeCommands([row()], {
+      connectionArgs: '-b MyRadio',
+      includeHeader: false,
+    });
+    expect(text).toBe("meshtastic -b MyRadio --set-favorite-node '!a1b2c3d4'");
+  });
+
+  it('includes --dest for remote admin', () => {
+    const text = buildSetFavoriteNodeCommands([row({ node_id_str: '!0c3a3de4' })], {
+      connectionArgs: '-b MyRadio',
+      destNodeId: '!a5592387',
+      includeHeader: false,
+    });
+    expect(text).toBe(
+      "meshtastic -b MyRadio --dest '!a5592387' --set-favorite-node '!0c3a3de4'"
+    );
+  });
+
+  it('skips rows with invalid node ids', () => {
+    const text = buildSetFavoriteNodeCommands(
+      [row({ node_id_str: 'bad' }), row({ node_id_str: '!12345678' })],
+      { includeHeader: false }
+    );
+    expect(text).toBe("meshtastic --set-favorite-node '!12345678'");
+    expect(countSetFavoriteNodeCommands([row({ node_id_str: 'bad' }), row()])).toBe(1);
+  });
+
+  it('returns empty when dest is invalid', () => {
+    expect(buildSetFavoriteNodeCommands([row()], { destNodeId: 'not-an-id' })).toBe('');
+  });
+
+  it('includes comment header by default', () => {
+    const text = buildSetFavoriteNodeCommands([row(), row({ node_id_str: '!bbbbbbbb' })]);
+    expect(text).toMatch(/^# Meshflow infrastructure export — 2 favorite commands/);
+    expect(text).toContain("meshtastic --set-favorite-node '!a1b2c3d4'");
+  });
+});

--- a/src/lib/infrastructure-meshtastic-cli.ts
+++ b/src/lib/infrastructure-meshtastic-cli.ts
@@ -1,0 +1,77 @@
+import type { InfrastructureExportRow } from './infrastructure-export-rows';
+
+export interface BuildSetFavoriteNodeCommandsOptions {
+  /** e.g. "-b MyRadio" or "--host meshtastic.local" */
+  connectionArgs?: string;
+  /** Remote NodeDB to update, e.g. "!a5592387" */
+  destNodeId?: string;
+  /** Include comment header with count and date */
+  includeHeader?: boolean;
+}
+
+const MESHTASTIC_NODE_ID_RE = /^![0-9a-fA-F]{8}$/;
+
+function normalizeNodeId(id: string): string | null {
+  const trimmed = id.trim();
+  if (!trimmed) return null;
+  const withBang = trimmed.startsWith('!') ? trimmed : `!${trimmed}`;
+  return MESHTASTIC_NODE_ID_RE.test(withBang) ? withBang : null;
+}
+
+function buildCommandLine(favoriteNodeId: string, connectionArgs?: string, destNodeId?: string): string {
+  const parts = ['meshtastic'];
+  if (connectionArgs?.trim()) {
+    parts.push(connectionArgs.trim());
+  }
+  const dest = destNodeId ? normalizeNodeId(destNodeId) : null;
+  if (dest) {
+    parts.push(`--dest '${dest}'`);
+  }
+  parts.push(`--set-favorite-node '${favoriteNodeId}'`);
+  return parts.join(' ');
+}
+
+/**
+ * Build meshtastic CLI commands to set each row as a favorite node.
+ * @see https://wiki.mbug.com.au/meshtastic-python-cli (--set-favorite-node)
+ */
+export function buildSetFavoriteNodeCommands(
+  rows: InfrastructureExportRow[],
+  options?: BuildSetFavoriteNodeCommandsOptions
+): string {
+  const connectionArgs = options?.connectionArgs;
+  const dest = options?.destNodeId ? normalizeNodeId(options.destNodeId) : null;
+  if (options?.destNodeId && !dest) {
+    return '';
+  }
+
+  const lines: string[] = [];
+  for (const row of rows) {
+    const nodeId = normalizeNodeId(row.node_id_str);
+    if (!nodeId) continue;
+    lines.push(buildCommandLine(nodeId, connectionArgs, dest ?? undefined));
+  }
+
+  if (lines.length === 0) return '';
+
+  if (options?.includeHeader !== false) {
+    const date = new Date().toISOString().slice(0, 10);
+    const header = [
+      `# Meshflow infrastructure export — ${lines.length} favorite command${lines.length === 1 ? '' : 's'}`,
+      `# Generated ${date} — review before running`,
+      '',
+    ];
+    return [...header, ...lines].join('\n');
+  }
+
+  return lines.join('\n');
+}
+
+export function countSetFavoriteNodeCommands(
+  rows: InfrastructureExportRow[],
+  options?: BuildSetFavoriteNodeCommandsOptions
+): number {
+  const text = buildSetFavoriteNodeCommands(rows, { ...options, includeHeader: false });
+  if (!text) return 0;
+  return text.split('\n').filter((l) => l.trim() && !l.startsWith('#')).length;
+}

--- a/src/pages/nodes/InfrastructureExport.tsx
+++ b/src/pages/nodes/InfrastructureExport.tsx
@@ -1,0 +1,128 @@
+import { Suspense, useMemo, useState } from 'react';
+import { Link, useSearchParams } from 'react-router-dom';
+import { subDays, subHours } from 'date-fns';
+
+import { useAllInfrastructureNodesSuspense, useManagedNodesSuspense } from '@/hooks/api/useNodes';
+import { buildInfrastructureExportRows } from '@/lib/infrastructure-export-rows';
+import { InfrastructureExportTable } from '@/components/nodes/InfrastructureExportTable';
+import { Button } from '@/components/ui/button';
+import { Label } from '@/components/ui/label';
+import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from '@/components/ui/select';
+import { Switch } from '@/components/ui/switch';
+
+type NodeListTimeRange = '2h' | '24h' | '7d' | '14d' | '30d' | 'all';
+
+const TIME_RANGE_OPTIONS: { value: NodeListTimeRange; label: string }[] = [
+  { value: '2h', label: '2 hours' },
+  { value: '24h', label: '24 hours' },
+  { value: '7d', label: '7 days' },
+  { value: '14d', label: '14 days' },
+  { value: '30d', label: '30 days' },
+  { value: 'all', label: 'All time' },
+];
+
+function parseTimeRangeParam(param: string | null): NodeListTimeRange {
+  if (param && TIME_RANGE_OPTIONS.some((o) => o.value === param)) {
+    return param as NodeListTimeRange;
+  }
+  return 'all';
+}
+
+function getLastHeardAfter(timeRange: NodeListTimeRange): Date | undefined {
+  if (timeRange === 'all') return undefined;
+  const now = new Date();
+  switch (timeRange) {
+    case '2h':
+      return subHours(now, 2);
+    case '24h':
+      return subHours(now, 24);
+    case '7d':
+      return subDays(now, 7);
+    case '14d':
+      return subDays(now, 14);
+    case '30d':
+      return subDays(now, 30);
+    default:
+      return undefined;
+  }
+}
+
+function InfrastructureExportContent() {
+  const [searchParams] = useSearchParams();
+  const [timeRange, setTimeRange] = useState<NodeListTimeRange>(() =>
+    parseTimeRangeParam(searchParams.get('last_heard'))
+  );
+  const [includeClientBase, setIncludeClientBase] = useState(() => searchParams.get('include_client_base') === 'true');
+
+  const lastHeardAfter = useMemo(() => getLastHeardAfter(timeRange), [timeRange]);
+
+  const { nodes } = useAllInfrastructureNodesSuspense({
+    lastHeardAfter,
+    includeClientBase,
+  });
+
+  const { managedNodes } = useManagedNodesSuspense({
+    pageSize: 500,
+    includeStatus: true,
+  });
+
+  const managedByMeshId = useMemo(() => new Map(managedNodes.map((m) => [m.meshtastic_node_id, m])), [managedNodes]);
+
+  const exportRows = useMemo(() => buildInfrastructureExportRows(nodes, managedByMeshId), [nodes, managedByMeshId]);
+
+  return (
+    <div className="container mx-auto px-4 py-8">
+      <div className="mb-6 flex flex-col gap-4 sm:flex-row sm:items-start sm:justify-between">
+        <div>
+          <h1 className="text-3xl font-bold">Infrastructure export</h1>
+          <p className="text-muted-foreground mt-1">
+            Filter infrastructure nodes, export CSV, or copy Meshtastic CLI commands to set favorites.
+          </p>
+        </div>
+        <Button variant="outline" asChild>
+          <Link to="/nodes/infrastructure">← Mesh Infrastructure</Link>
+        </Button>
+      </div>
+
+      <div className="flex flex-col sm:flex-row flex-wrap items-start sm:items-center gap-4 mb-8">
+        <div className="flex items-center gap-2">
+          <label htmlFor="export-time-range" className="text-sm text-muted-foreground">
+            Last heard:
+          </label>
+          <Select value={timeRange} onValueChange={(v) => setTimeRange(v as NodeListTimeRange)}>
+            <SelectTrigger className="w-[180px]" id="export-time-range" aria-label="Select time range">
+              <SelectValue placeholder="Select time range" />
+            </SelectTrigger>
+            <SelectContent>
+              {TIME_RANGE_OPTIONS.map((opt) => (
+                <SelectItem key={opt.value} value={opt.value}>
+                  {opt.label}
+                </SelectItem>
+              ))}
+            </SelectContent>
+          </Select>
+        </div>
+        <div className="flex items-center gap-2">
+          <Switch id="export-include-client-base" checked={includeClientBase} onCheckedChange={setIncludeClientBase} />
+          <Label htmlFor="export-include-client-base">Include CLIENT_BASE</Label>
+        </div>
+      </div>
+
+      <InfrastructureExportTable rows={exportRows} />
+    </div>
+  );
+}
+
+export function InfrastructureExport() {
+  return (
+    <Suspense
+      fallback={
+        <div className="flex justify-center min-h-[40vh] items-center">
+          <div className="animate-spin rounded-full h-12 w-12 border-t-2 border-b-2 border-primary" />
+        </div>
+      }
+    >
+      <InfrastructureExportContent />
+    </Suspense>
+  );
+}

--- a/src/pages/nodes/InfrastructureExport.tsx
+++ b/src/pages/nodes/InfrastructureExport.tsx
@@ -6,9 +6,7 @@ import { useAllInfrastructureNodesSuspense, useManagedNodesSuspense } from '@/ho
 import { buildInfrastructureExportRows } from '@/lib/infrastructure-export-rows';
 import { InfrastructureExportTable } from '@/components/nodes/InfrastructureExportTable';
 import { Button } from '@/components/ui/button';
-import { Label } from '@/components/ui/label';
 import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from '@/components/ui/select';
-import { Switch } from '@/components/ui/switch';
 
 type NodeListTimeRange = '2h' | '24h' | '7d' | '14d' | '30d' | 'all';
 
@@ -52,13 +50,11 @@ function InfrastructureExportContent() {
   const [timeRange, setTimeRange] = useState<NodeListTimeRange>(() =>
     parseTimeRangeParam(searchParams.get('last_heard'))
   );
-  const [includeClientBase, setIncludeClientBase] = useState(() => searchParams.get('include_client_base') === 'true');
-
   const lastHeardAfter = useMemo(() => getLastHeardAfter(timeRange), [timeRange]);
 
   const { nodes } = useAllInfrastructureNodesSuspense({
     lastHeardAfter,
-    includeClientBase,
+    includeClientBase: true,
   });
 
   const { managedNodes } = useManagedNodesSuspense({
@@ -101,10 +97,6 @@ function InfrastructureExportContent() {
               ))}
             </SelectContent>
           </Select>
-        </div>
-        <div className="flex items-center gap-2">
-          <Switch id="export-include-client-base" checked={includeClientBase} onCheckedChange={setIncludeClientBase} />
-          <Label htmlFor="export-include-client-base">Include CLIENT_BASE</Label>
         </div>
       </div>
 

--- a/src/pages/nodes/MeshInfrastructure.tsx
+++ b/src/pages/nodes/MeshInfrastructure.tsx
@@ -259,9 +259,7 @@ function MeshInfrastructureContent() {
           </Select>
         </div>
         <Button variant="outline" size="sm" asChild>
-          <Link to={`/nodes/infrastructure/export?last_heard=${timeRange}&include_client_base=${includeClientBase}`}>
-            Export table
-          </Link>
+          <Link to={`/nodes/infrastructure/export?last_heard=${timeRange}`}>Export table</Link>
         </Button>
       </div>
 

--- a/src/pages/nodes/MeshInfrastructure.tsx
+++ b/src/pages/nodes/MeshInfrastructure.tsx
@@ -258,6 +258,11 @@ function MeshInfrastructureContent() {
             </SelectContent>
           </Select>
         </div>
+        <Button variant="outline" size="sm" asChild>
+          <Link to={`/nodes/infrastructure/export?last_heard=${timeRange}&include_client_base=${includeClientBase}`}>
+            Export table
+          </Link>
+        </Button>
       </div>
 
       <div className="mb-8">


### PR DESCRIPTION
## Summary

- Adds `/nodes/infrastructure/export` with a client-side filterable table of infrastructure nodes (same API as Mesh Infrastructure).
- **Copy / Download CSV** for the currently filtered rows.
- **Copy CLI favorite commands** / **Download .sh** — generates `meshtastic --set-favorite-node '!…'` lines per filtered row, with optional connection prefix and `--dest` for remote admin.
- **Routers only** quick filter; link from Mesh Infrastructure preserves time range and CLIENT_BASE toggle via query params.

Closes #285

## Testing performed

- [x] `npm test` (including `infrastructure-csv` and `infrastructure-meshtastic-cli` unit tests)
- [x] `npm run build` and `npm run lint`
- [x] Manual: filter routers → copy CLI commands → verify line count and quoting
- [x] Manual: copy/download CSV with comma in node name