### PR TITLE
fix(ui): MeshCore map, node detail links, message pickers

### DIFF
--- a/src/components/NeighbourPieChart.tsx
+++ b/src/components/NeighbourPieChart.tsx
@@ -2,6 +2,7 @@
 
 import * as React from 'react';
 import { Link } from 'react-router-dom';
+import { nodeDetailPath } from '@/lib/node-detail-routes';
 import { Cell, Legend, Pie, PieChart } from 'recharts';
 import { useNeighbourStats } from '@/hooks/api/usePacketStats';
 import { subDays } from 'date-fns';
@@ -218,7 +219,10 @@ export function NeighbourPieChart({
                         {item.candidates.map((c) => (
                           <Link
                             key={c.meshtastic_node_id}
-                            to={`/nodes/${c.meshtastic_node_id}`}
+                            to={nodeDetailPath({
+                              meshtastic_node_id: c.meshtastic_node_id,
+                              node_id_str: c.node_id_str,
+                            })}
                             className="text-xs text-teal-600 dark:text-teal-400 hover:underline px-1.5 py-0.5 rounded bg-muted"
                           >
                             {c.short_name || c.node_id_str}

--- a/src/components/nodes/NodeTracerouteLinksMap.tsx
+++ b/src/components/nodes/NodeTracerouteLinksMap.tsx
@@ -3,6 +3,7 @@ import { Popup } from 'react-map-gl/mapbox';
 import { ArcLayer, ScatterplotLayer, TextLayer } from '@deck.gl/layers';
 import type { PickingInfo } from '@deck.gl/core';
 import { Link } from 'react-router-dom';
+import { nodeDetailPath } from '@/lib/node-detail-routes';
 import { X } from 'lucide-react';
 import type { NodeTracerouteLinkEdge, NodeTracerouteLinkNode } from '@/hooks/api/useNodeTracerouteLinks';
 
@@ -195,7 +196,10 @@ export function NodeTracerouteLinksMap({ edges, nodes, focusNodeId, showLabels =
                 </div>
               )}
               <Link
-                to={`/nodes/${selectedNode.meshtastic_node_id}`}
+                to={nodeDetailPath({
+                  meshtastic_node_id: selectedNode.meshtastic_node_id,
+                  node_id_str: selectedNode.node_id_str,
+                })}
                 className="mt-1 inline-block text-xs text-emerald-400 hover:text-emerald-300 hover:underline"
               >
                 Open details

--- a/src/components/nodes/map-utils.test.ts
+++ b/src/components/nodes/map-utils.test.ts
@@ -2,11 +2,26 @@ import { describe, it, expect } from 'vitest';
 import * as turf from '@turf/turf';
 import type { Feature, Point, Polygon } from 'geojson';
 
-import { boundaryPolygonFromPoints } from './map-utils';
+import { boundaryPolygonFromPoints, buildNodePopupHtml } from './map-utils';
 
 function pt(lng: number, lat: number): Feature<Point> {
   return turf.point([lng, lat]);
 }
+
+describe('buildNodePopupHtml', () => {
+  it('links to internal_id not meshtastic_node_id zero', () => {
+    const html = buildNodePopupHtml({
+      internal_id: 'a1b2c3d4-e5f6-4789-a012-8456789abcde',
+      meshtastic_node_id: 0,
+      node_id_str: 'mc:abc',
+      long_name: 'Test',
+      short_name: 't',
+      protocol: 2,
+    });
+    expect(html).toContain('href="/nodes/a1b2c3d4-e5f6-4789-a012-8456789abcde"');
+    expect(html).not.toContain('href="/nodes/0"');
+  });
+});
 
 describe('boundaryPolygonFromPoints', () => {
   it('returns null for an empty point set', () => {

--- a/src/components/nodes/map-utils.ts
+++ b/src/components/nodes/map-utils.ts
@@ -1,6 +1,7 @@
 import L from 'leaflet';
 import * as turf from '@turf/turf';
 import type { Feature, MultiPolygon, Point, Polygon } from 'geojson';
+import { nodeDetailPath, type NodeDetailLinkInput } from '@/lib/node-detail-routes';
 
 /** Role IDs from Meshtastic (matches ROLE_LABELS in lib/meshtastic). */
 export const ROLE_COLORS: Record<number, string> = {
@@ -129,15 +130,15 @@ function percentileSorted(sorted: number[], p: number): number {
 }
 
 /** Minimal node fields for popup content */
-export interface NodePopupData {
+export interface NodePopupData extends NodeDetailLinkInput {
   meshtastic_node_id: number;
-  node_id_str?: string;
   long_name: string | null;
   short_name: string | null;
   /** Date or ISO string – API may return either; we normalize to locale format */
   last_heard?: Date | string | null;
   /** Constellation name when this is a managed node */
   constellationName?: string | null;
+  protocol?: number | null;
 }
 
 /**
@@ -150,7 +151,7 @@ export function buildNodePopupHtml(node: NodePopupData): string {
       ? `${node.long_name} (${node.short_name})`
       : node.long_name || node.short_name || node.node_id_str || `Node ${node.meshtastic_node_id}`;
   const lastSeen = node.last_heard != null ? new Date(node.last_heard).toLocaleString() : 'Never';
-  const detailsUrl = `/nodes/${node.meshtastic_node_id}`;
+  const detailsUrl = nodeDetailPath(node);
   const constellationLine =
     node.constellationName != null && node.constellationName !== ''
       ? `Constellation: ${escapeHtml(node.constellationName)}`

--- a/src/components/traceroutes/ConstellationCoverageMap.tsx
+++ b/src/components/traceroutes/ConstellationCoverageMap.tsx
@@ -1,5 +1,6 @@
 import { useCallback, useMemo, useState } from 'react';
 import { Link } from 'react-router-dom';
+import { isObservedNodeInternalId, nodeDetailPath } from '@/lib/node-detail-routes';
 import { Popup } from 'react-map-gl/mapbox';
 import { ScatterplotLayer } from '@deck.gl/layers';
 import { H3HexagonLayer } from '@deck.gl/geo-layers';
@@ -207,7 +208,10 @@ export function ConstellationCoverageMap({
                 {selectedHeardGhost.node_id_str || `!${selectedHeardGhost.meshtastic_node_id.toString(16)}`}
               </div>
               <Link
-                to={`/nodes/${selectedHeardGhost.meshtastic_node_id}`}
+                to={nodeDetailPath({
+                  meshtastic_node_id: selectedHeardGhost.meshtastic_node_id,
+                  node_id_str: selectedHeardGhost.node_id_str,
+                })}
                 className="mt-1 inline-block text-xs text-emerald-400 hover:text-emerald-300 hover:underline"
               >
                 Open details
@@ -295,7 +299,10 @@ export function ConstellationCoverageMap({
                 {selectedTarget.contributing_feeders === 1 ? '' : 's'}
               </div>
               <Link
-                to={`/nodes/${selectedTarget.meshtastic_node_id}`}
+                to={nodeDetailPath({
+                  meshtastic_node_id: selectedTarget.meshtastic_node_id,
+                  node_id_str: selectedTarget.node_id_str,
+                })}
                 className="mt-1 inline-block text-xs text-emerald-400 hover:text-emerald-300 hover:underline"
               >
                 Open details
@@ -331,7 +338,13 @@ export function ConstellationCoverageMap({
                 {selectedFeeder.node_id_str || `!${selectedFeeder.meshtastic_node_id.toString(16)}`}
               </div>
               <Link
-                to={`/nodes/${selectedFeeder.meshtastic_node_id}`}
+                to={nodeDetailPath({
+                  internal_id: isObservedNodeInternalId(selectedFeeder.managed_node_id)
+                    ? selectedFeeder.managed_node_id
+                    : undefined,
+                  meshtastic_node_id: selectedFeeder.meshtastic_node_id,
+                  node_id_str: selectedFeeder.node_id_str,
+                })}
                 className="mt-1 inline-block text-xs text-emerald-400 hover:text-emerald-300 hover:underline"
               >
                 Open details

--- a/src/components/traceroutes/FeederCoverageMap.tsx
+++ b/src/components/traceroutes/FeederCoverageMap.tsx
@@ -8,6 +8,7 @@ import { concave, featureCollection, point as turfPoint } from '@turf/turf';
 import type { Feature, MultiPolygon, Polygon } from 'geojson';
 
 import { Link } from 'react-router-dom';
+import { isObservedNodeInternalId, nodeDetailPath } from '@/lib/node-detail-routes';
 import { X } from 'lucide-react';
 
 import { buildFeederIconLayer } from '@/components/map/FeederIconLayer';
@@ -266,7 +267,10 @@ export function FeederCoverageMap({
                 Smoothed: {(smoothedRate(selectedTarget.successes, selectedTarget.attempts) * 100).toFixed(0)}%
               </div>
               <Link
-                to={`/nodes/${selectedTarget.meshtastic_node_id}`}
+                to={nodeDetailPath({
+                  meshtastic_node_id: selectedTarget.meshtastic_node_id,
+                  node_id_str: selectedTarget.node_id_str,
+                })}
                 className="mt-1 inline-block text-xs text-emerald-400 hover:text-emerald-300 hover:underline"
               >
                 Open details
@@ -304,7 +308,10 @@ export function FeederCoverageMap({
                 {selectedHeardGhost.node_id_str || `!${selectedHeardGhost.meshtastic_node_id.toString(16)}`}
               </div>
               <Link
-                to={`/nodes/${selectedHeardGhost.meshtastic_node_id}`}
+                to={nodeDetailPath({
+                  meshtastic_node_id: selectedHeardGhost.meshtastic_node_id,
+                  node_id_str: selectedHeardGhost.node_id_str,
+                })}
                 className="mt-1 inline-block text-xs text-emerald-400 hover:text-emerald-300 hover:underline"
               >
                 Open details
@@ -340,7 +347,13 @@ export function FeederCoverageMap({
                 {selectedFeederMarker.node_id_str || `!${selectedFeederMarker.meshtastic_node_id.toString(16)}`}
               </div>
               <Link
-                to={`/nodes/${selectedFeederMarker.meshtastic_node_id}`}
+                to={nodeDetailPath({
+                  internal_id: isObservedNodeInternalId(selectedFeederMarker.managed_node_id)
+                    ? selectedFeederMarker.managed_node_id
+                    : undefined,
+                  meshtastic_node_id: selectedFeederMarker.meshtastic_node_id,
+                  node_id_str: selectedFeederMarker.node_id_str,
+                })}
                 className="mt-1 inline-block text-xs text-emerald-400 hover:text-emerald-300 hover:underline"
               >
                 Open details

--- a/src/components/traceroutes/TracerouteFlowDiagram.tsx
+++ b/src/components/traceroutes/TracerouteFlowDiagram.tsx
@@ -1,4 +1,5 @@
 import { Link } from 'react-router-dom';
+import { nodeDetailPath } from '@/lib/node-detail-routes';
 import { Badge } from '@/components/ui/badge';
 import { AutoTraceRoute, TracerouteRouteNode } from '@/lib/models';
 import { ArrowRight } from 'lucide-react';
@@ -16,7 +17,7 @@ function FlowEndpointBadge({
 }) {
   return (
     <Link
-      to={`/nodes/${nodeId}`}
+      to={nodeDetailPath({ meshtastic_node_id: nodeId })}
       onClick={(e) => e.stopPropagation()}
       className="inline-flex max-w-full rounded-md focus:outline-none focus:ring-2 focus:ring-ring focus:ring-offset-2"
     >
@@ -50,7 +51,7 @@ function NodeBadge({ node }: { node: TracerouteRouteNode }) {
 
   return (
     <Link
-      to={`/nodes/${node.meshtastic_node_id}`}
+      to={nodeDetailPath({ meshtastic_node_id: node.meshtastic_node_id, node_id_str: node.node_id_str })}
       onClick={(e) => e.stopPropagation()}
       className="inline-flex max-w-full rounded-md focus:outline-none focus:ring-2 focus:ring-ring focus:ring-offset-2"
     >

--- a/src/components/traceroutes/TracerouteHeatmapBackboneRelayTable.tsx
+++ b/src/components/traceroutes/TracerouteHeatmapBackboneRelayTable.tsx
@@ -1,5 +1,6 @@
 import { useMemo } from 'react';
 import { Link } from 'react-router-dom';
+import { nodeDetailPath } from '@/lib/node-detail-routes';
 import { Card, CardContent, CardDescription, CardHeader, CardTitle } from '@/components/ui/card';
 import { Table, TableBody, TableCell, TableHead, TableHeader, TableRow } from '@/components/ui/table';
 import type { HeatmapNode } from '@/hooks/api/useHeatmapEdges';
@@ -49,7 +50,10 @@ function RoleNodeTable({ nodes }: { nodes: HeatmapNode[] }) {
         {nodes.map((n) => (
           <TableRow key={n.meshtastic_node_id}>
             <TableCell>
-              <Link to={`/nodes/${n.meshtastic_node_id}`} className="font-medium text-primary hover:underline">
+              <Link
+                to={nodeDetailPath({ meshtastic_node_id: n.meshtastic_node_id, node_id_str: n.node_id_str })}
+                className="font-medium text-primary hover:underline"
+              >
                 {getHeatmapNodeLabel(n)}
               </Link>
               <div className="text-muted-foreground text-xs">

--- a/src/components/traceroutes/TracerouteHeatmapNodePanel.tsx
+++ b/src/components/traceroutes/TracerouteHeatmapNodePanel.tsx
@@ -1,5 +1,6 @@
 import { formatDistanceToNow, parseISO } from 'date-fns';
 import { Link } from 'react-router-dom';
+import { nodeDetailPath } from '@/lib/node-detail-routes';
 import { X } from 'lucide-react';
 import { getHeatmapNodeLabel } from '@/components/traceroutes/heatmapEncoding';
 import type { HeatmapNode } from '@/hooks/api/useHeatmapEdges';
@@ -77,7 +78,10 @@ export function TracerouteHeatmapNodePanel({
           Last seen: <span className="text-slate-300">{formatRecency(node.last_seen)}</span>
         </div>
         <Link
-          to={`/nodes/${node.meshtastic_node_id}`}
+          to={nodeDetailPath({
+            meshtastic_node_id: node.meshtastic_node_id,
+            node_id_str: node.node_id_str,
+          })}
           className="mt-1 inline-block text-xs text-emerald-400 hover:text-emerald-300 hover:underline"
         >
           Open details

--- a/src/lib/constellation-protocol.test.ts
+++ b/src/lib/constellation-protocol.test.ts
@@ -1,0 +1,29 @@
+import { describe, expect, it } from 'vitest';
+import { filterConstellationsForProtocol } from '@/lib/constellation-protocol';
+import type { Constellation } from '@/lib/models';
+
+const constellations: Constellation[] = [
+  {
+    id: 1,
+    name: 'MT only',
+    description: '',
+    created_by: 1,
+    map_color: '#000',
+    channels: [{ id: 10, name: 'mt', constellation: 1, protocol: 1 }],
+  },
+  {
+    id: 2,
+    name: 'MC only',
+    description: '',
+    created_by: 1,
+    map_color: '#111',
+    channels: [{ id: 20, name: 'mc', constellation: 2, protocol: 2 }],
+  },
+];
+
+describe('filterConstellationsForProtocol', () => {
+  it('keeps constellations with at least one matching channel', () => {
+    expect(filterConstellationsForProtocol(constellations, 'meshcore').map((c) => c.id)).toEqual([2]);
+    expect(filterConstellationsForProtocol(constellations, 'meshtastic').map((c) => c.id)).toEqual([1]);
+  });
+});

--- a/src/lib/constellation-protocol.test.ts
+++ b/src/lib/constellation-protocol.test.ts
@@ -1,29 +1,46 @@
 import { describe, expect, it } from 'vitest';
-import { filterConstellationsForProtocol } from '@/lib/constellation-protocol';
+import { filterConstellationsForProtocol, resolveMessageConstellationId } from '@/lib/constellation-protocol';
 import type { Constellation } from '@/lib/models';
 
 const constellations: Constellation[] = [
   {
     id: 1,
-    name: 'MT only',
+    name: 'Central Belt Scotland',
     description: '',
     created_by: 1,
+    protocol: 1,
     map_color: '#000',
-    channels: [{ id: 10, name: 'mt', constellation: 1, protocol: 1 }],
+    channels: [
+      { id: 10, name: 'mt', constellation: 1, protocol: 1 },
+      { id: 11, name: 'stray-mc', constellation: 1, protocol: 2 },
+    ],
   },
   {
     id: 2,
-    name: 'MC only',
+    name: 'Scottish Mesh MC',
     description: '',
     created_by: 1,
+    protocol: 2,
     map_color: '#111',
     channels: [{ id: 20, name: 'mc', constellation: 2, protocol: 2 }],
   },
 ];
 
 describe('filterConstellationsForProtocol', () => {
-  it('keeps constellations with at least one matching channel', () => {
+  it('excludes Meshtastic constellations in MeshCore mode even if they have MC channels', () => {
     expect(filterConstellationsForProtocol(constellations, 'meshcore').map((c) => c.id)).toEqual([2]);
     expect(filterConstellationsForProtocol(constellations, 'meshtastic').map((c) => c.id)).toEqual([1]);
+  });
+});
+
+describe('resolveMessageConstellationId', () => {
+  it('ignores preferred id when it is not in the filtered list', () => {
+    const mcOnly = filterConstellationsForProtocol(constellations, 'meshcore');
+    expect(resolveMessageConstellationId(mcOnly, 1, 'meshcore')).toBe(2);
+  });
+
+  it('keeps preferred id when it is in the filtered list', () => {
+    const mtOnly = filterConstellationsForProtocol(constellations, 'meshtastic');
+    expect(resolveMessageConstellationId(mtOnly, 1, 'meshtastic')).toBe(1);
   });
 });

--- a/src/lib/constellation-protocol.ts
+++ b/src/lib/constellation-protocol.ts
@@ -1,15 +1,47 @@
 import type { Constellation } from '@/lib/models';
 import type { ProtocolSlug } from '@/lib/mesh-protocol';
-import { filterChannelsForProtocol } from '@/lib/message-channels';
+import { filterChannelsForProtocol, protocolSlugFromApiValue } from '@/lib/message-channels';
 
-/** Constellations that have at least one message channel for the active protocol. */
+/** Constellations whose protocol and channels match the active protocol route. */
 export function filterConstellationsForProtocol(
   constellations: Constellation[],
   protocol: ProtocolSlug
 ): Constellation[] {
-  return constellations.filter((c) => filterChannelsForProtocol(c.channels ?? [], protocol).length > 0);
+  return constellations.filter((c) => {
+    const constellationSlug = protocolSlugFromApiValue(c.protocol);
+    if (constellationSlug != null && constellationSlug !== protocol) {
+      return false;
+    }
+    return filterChannelsForProtocol(c.channels ?? [], protocol).length > 0;
+  });
 }
 
 export function constellationStorageKey(protocol: ProtocolSlug): string {
   return `meshflow-messages-constellation-${protocol}`;
+}
+
+/**
+ * Pick a constellation id that exists in `constellations` (protocol-filtered list).
+ */
+export function resolveMessageConstellationId(
+  constellations: Constellation[],
+  preferredId: number | null,
+  protocol: ProtocolSlug
+): number | null {
+  if (constellations.length === 0) {
+    return null;
+  }
+  if (preferredId != null && constellations.some((c) => c.id === preferredId)) {
+    return preferredId;
+  }
+  if (typeof window !== 'undefined') {
+    const raw = window.localStorage.getItem(constellationStorageKey(protocol));
+    if (raw) {
+      const stored = Number(raw);
+      if (Number.isFinite(stored) && constellations.some((c) => c.id === stored)) {
+        return stored;
+      }
+    }
+  }
+  return constellations[0].id;
 }

--- a/src/lib/constellation-protocol.ts
+++ b/src/lib/constellation-protocol.ts
@@ -1,0 +1,15 @@
+import type { Constellation } from '@/lib/models';
+import type { ProtocolSlug } from '@/lib/mesh-protocol';
+import { filterChannelsForProtocol } from '@/lib/message-channels';
+
+/** Constellations that have at least one message channel for the active protocol. */
+export function filterConstellationsForProtocol(
+  constellations: Constellation[],
+  protocol: ProtocolSlug
+): Constellation[] {
+  return constellations.filter((c) => filterChannelsForProtocol(c.channels ?? [], protocol).length > 0);
+}
+
+export function constellationStorageKey(protocol: ProtocolSlug): string {
+  return `meshflow-messages-constellation-${protocol}`;
+}

--- a/src/lib/meshcore-map-nodes.test.ts
+++ b/src/lib/meshcore-map-nodes.test.ts
@@ -1,0 +1,54 @@
+import { describe, expect, it } from 'vitest';
+import { buildMeshCoreMapNodes } from '@/lib/meshcore-map-nodes';
+import type { ManagedNode, ObservedNode } from '@/lib/models';
+
+function makeObserved(overrides: Partial<ObservedNode> = {}): ObservedNode {
+  return {
+    internal_id: '11111111-1111-4111-8111-111111111111',
+    meshtastic_node_id: 0,
+    node_id_str: 'mc:aaaabbbbcccc',
+    mac_addr: null,
+    long_name: 'Observed',
+    short_name: 'obs',
+    meshtastic_hw_model: null,
+    meshtastic_public_key: null,
+    protocol: 2,
+    last_heard: null,
+    latest_position: { latitude: 55.1, longitude: -4.2, reported_time: null, logged_time: null, altitude: null, meshtastic_location_source: 'gps' },
+    latest_device_metrics: null,
+    ...overrides,
+  };
+}
+
+function makeManaged(overrides: Partial<ManagedNode> = {}): ManagedNode {
+  return {
+    protocol: 2,
+    meshtastic_node_id: 0,
+    node_id_str: 'mc:feedfeedfeed',
+    long_name: 'Feeder',
+    short_name: 'fd',
+    last_heard: null,
+    owner: { id: 1, username: 'op' },
+    constellation: { id: 1, name: 'MC' },
+    position: { latitude: 55.5, longitude: -4.5 },
+    ...overrides,
+  };
+}
+
+describe('buildMeshCoreMapNodes', () => {
+  it('includes managed feeders with position not in observed list', () => {
+    const nodes = buildMeshCoreMapNodes([], [makeManaged()]);
+    expect(nodes).toHaveLength(1);
+    expect(nodes[0].node_id_str).toBe('mc:feedfeedfeed');
+    expect(nodes[0].latest_position?.latitude).toBe(55.5);
+  });
+
+  it('merges feeder position into matching observed node', () => {
+    const observed = makeObserved({ latest_position: null });
+    const managed = makeManaged({ node_id_str: observed.node_id_str, position: { latitude: 56, longitude: -5 } });
+    const nodes = buildMeshCoreMapNodes([observed], [managed]);
+    expect(nodes).toHaveLength(1);
+    expect(nodes[0].internal_id).toBe(observed.internal_id);
+    expect(nodes[0].latest_position?.latitude).toBe(56);
+  });
+});

--- a/src/lib/meshcore-map-nodes.ts
+++ b/src/lib/meshcore-map-nodes.ts
@@ -1,0 +1,22 @@
+import type { ManagedNode, ObservedNode } from '@/lib/models';
+import { managedNodeToObservedNode, mergeManagedPositionIntoObserved } from '@/lib/my-nodes-grouping';
+
+/**
+ * Observed nodes plus MC managed feeders with a map position (feeders use `node_id_str` as key).
+ */
+export function buildMeshCoreMapNodes(observed: ObservedNode[], managed: ManagedNode[]): ObservedNode[] {
+  const byNodeIdStr = new Map<string, ObservedNode>();
+  for (const o of observed) {
+    byNodeIdStr.set(o.node_id_str, o);
+  }
+  for (const m of managed) {
+    if (!managedNodeToObservedNode(m).latest_position) continue;
+    const existing = byNodeIdStr.get(m.node_id_str);
+    if (existing) {
+      byNodeIdStr.set(m.node_id_str, mergeManagedPositionIntoObserved(existing, m));
+      continue;
+    }
+    byNodeIdStr.set(m.node_id_str, { ...managedNodeToObservedNode(m), protocol: 2 });
+  }
+  return [...byNodeIdStr.values()];
+}

--- a/src/lib/message-channels.ts
+++ b/src/lib/message-channels.ts
@@ -1,8 +1,10 @@
-import type { MessageChannel } from '@/lib/models';
+import type { MeshProtocol, MessageChannel } from '@/lib/models';
 import type { ProtocolSlug } from '@/lib/mesh-protocol';
 
-function channelProtocolSlug(ch: MessageChannel): ProtocolSlug | null {
-  const p = ch.protocol;
+/** Normalize API protocol field (number or string) to a route slug; null when absent. */
+export function protocolSlugFromApiValue(
+  p: MeshProtocol | 'meshtastic' | 'meshcore' | string | null | undefined
+): ProtocolSlug | null {
   if (p === undefined || p === null) {
     return null;
   }
@@ -17,6 +19,10 @@ function channelProtocolSlug(ch: MessageChannel): ProtocolSlug | null {
     return 'meshtastic';
   }
   return null;
+}
+
+function channelProtocolSlug(ch: MessageChannel): ProtocolSlug | null {
+  return protocolSlugFromApiValue(ch.protocol);
 }
 
 export function filterChannelsForProtocol(channels: MessageChannel[], protocol: ProtocolSlug): MessageChannel[] {

--- a/src/lib/models.ts
+++ b/src/lib/models.ts
@@ -544,6 +544,8 @@ export interface Constellation {
   name: string;
   description: string;
   created_by: number;
+  /** Constellation-level protocol (1 = Meshtastic, 2 = MeshCore). */
+  protocol?: MeshProtocol | 'meshtastic' | 'meshcore' | string;
   channels: MessageChannel[];
   map_color: string;
   bot_default_ignore_meshtastic_portnums?: string | null;

--- a/src/lib/node-detail-routes.test.ts
+++ b/src/lib/node-detail-routes.test.ts
@@ -1,0 +1,35 @@
+import { describe, expect, it } from 'vitest';
+import { isObservedNodeInternalId, nodeDetailPath } from '@/lib/node-detail-routes';
+
+const VALID_UUID = 'a1b2c3d4-e5f6-4789-a012-8456789abcde';
+
+describe('nodeDetailPath', () => {
+  it('prefers internal_id UUID', () => {
+    expect(
+      nodeDetailPath({
+        internal_id: VALID_UUID,
+        meshtastic_node_id: 42,
+        node_id_str: '!0000002a',
+      })
+    ).toBe(`/nodes/${VALID_UUID}`);
+  });
+
+  it('uses legacy meshtastic numeric id when no UUID', () => {
+    expect(nodeDetailPath({ meshtastic_node_id: 42, node_id_str: '!0000002a' })).toBe('/nodes/42');
+  });
+
+  it('encodes MeshCore node_id_str when numeric id is zero', () => {
+    expect(
+      nodeDetailPath({
+        meshtastic_node_id: 0,
+        node_id_str: 'mc:deadbeefcafe',
+        protocol: 2,
+      })
+    ).toBe('/nodes/mc%3Adeadbeefcafe');
+  });
+
+  it('isObservedNodeInternalId rejects mc prefix paths', () => {
+    expect(isObservedNodeInternalId('mc:abc')).toBe(false);
+    expect(isObservedNodeInternalId(VALID_UUID)).toBe(true);
+  });
+});

--- a/src/lib/node-detail-routes.ts
+++ b/src/lib/node-detail-routes.ts
@@ -1,0 +1,39 @@
+import type { ObservedNode } from '@/lib/models';
+
+const UUID_RE = /^[0-9a-f]{8}-[0-9a-f]{4}-[1-5][0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/i;
+
+export function isObservedNodeInternalId(id: string): boolean {
+  return UUID_RE.test(id);
+}
+
+export type NodeDetailLinkInput = {
+  internal_id?: string | number | null;
+  meshtastic_node_id?: number | null;
+  node_id_str?: string | null;
+  protocol?: number | null;
+};
+
+/**
+ * React Router path for observed node detail (`/nodes/:id`).
+ * Prefers stable `internal_id`, then legacy Meshtastic numeric id, then encoded `node_id_str` (MeshCore).
+ */
+export function nodeDetailPath(input: NodeDetailLinkInput): string {
+  const rawInternalId = input.internal_id;
+  const internalId = rawInternalId == null || rawInternalId === '' ? '' : String(rawInternalId).trim();
+  if (internalId && isObservedNodeInternalId(internalId)) {
+    return `/nodes/${internalId}`;
+  }
+  const numericId = input.meshtastic_node_id;
+  if (numericId != null && numericId > 0) {
+    return `/nodes/${numericId}`;
+  }
+  const nodeIdStr = input.node_id_str?.trim();
+  if (nodeIdStr) {
+    return `/nodes/${encodeURIComponent(nodeIdStr)}`;
+  }
+  return '/nodes/0';
+}
+
+export function observedNodeDetailPath(node: Pick<ObservedNode, 'internal_id'>): string {
+  return nodeDetailPath({ internal_id: node.internal_id });
+}

--- a/src/pages/meshcore/MeshCoreMessages.tsx
+++ b/src/pages/meshcore/MeshCoreMessages.tsx
@@ -2,5 +2,5 @@ import { ProtocolMessageHistoryPage } from '@/pages/protocol/ProtocolMessageHist
 import { MESHCORE_CONFIG } from '@/lib/mesh-protocol';
 
 export function MeshCoreMessages() {
-  return <ProtocolMessageHistoryPage config={MESHCORE_CONFIG} />;
+  return <ProtocolMessageHistoryPage key={MESHCORE_CONFIG.slug} config={MESHCORE_CONFIG} />;
 }

--- a/src/pages/messages/MessageHistory.tsx
+++ b/src/pages/messages/MessageHistory.tsx
@@ -2,5 +2,5 @@ import { ProtocolMessageHistoryPage } from '@/pages/protocol/ProtocolMessageHist
 import { MESHTASTIC_CONFIG } from '@/lib/mesh-protocol';
 
 export function MessageHistory() {
-  return <ProtocolMessageHistoryPage config={MESHTASTIC_CONFIG} />;
+  return <ProtocolMessageHistoryPage key={MESHTASTIC_CONFIG.slug} config={MESHTASTIC_CONFIG} />;
 }

--- a/src/pages/nodes/ManagedNodesStatus.tsx
+++ b/src/pages/nodes/ManagedNodesStatus.tsx
@@ -25,6 +25,7 @@ import { Table, TableBody, TableCell, TableHead, TableHeader, TableRow } from '@
 import { useManagedNodesSuspense } from '@/hooks/api/useNodes';
 import { useMeshCoreManagedNodesSuspense } from '@/hooks/api/useMeshCore';
 import type { ProtocolPageConfig } from '@/lib/mesh-protocol';
+import { nodeDetailPath } from '@/lib/node-detail-routes';
 import { MESHTASTIC_CONFIG, MESHCORE_CONFIG } from '@/lib/mesh-protocol';
 import {
   ManagedNodeStatusTier,
@@ -441,19 +442,33 @@ function ProtocolManagedNodesPageContent({
                   {group.nodes.map((node) => {
                     const tier = getManagedNodeStatusTier(node.last_packet_ingested_at);
                     return (
-                      <TableRow key={node.meshtastic_node_id}>
+                      <TableRow key={node.node_id_str}>
                         <TableCell>
                           <Badge style={{ backgroundColor: managedNodeStatusTierColor(tier), color: 'white' }}>
                             {tierLabel(tier)}
                           </Badge>
                         </TableCell>
                         <TableCell>
-                          <Link to={`/nodes/${node.meshtastic_node_id}`} className="text-primary hover:underline">
+                          <Link
+                            to={nodeDetailPath({
+                              meshtastic_node_id: node.meshtastic_node_id,
+                              node_id_str: node.node_id_str,
+                              protocol: node.protocol,
+                            })}
+                            className="text-primary hover:underline"
+                          >
                             {node.short_name ?? '—'}
                           </Link>
                         </TableCell>
                         <TableCell>
-                          <Link to={`/nodes/${node.meshtastic_node_id}`} className="text-primary hover:underline">
+                          <Link
+                            to={nodeDetailPath({
+                              meshtastic_node_id: node.meshtastic_node_id,
+                              node_id_str: node.node_id_str,
+                              protocol: node.protocol,
+                            })}
+                            className="text-primary hover:underline"
+                          >
                             {node.long_name ?? node.node_id_str}
                           </Link>
                         </TableCell>

--- a/src/pages/nodes/NodeDetails.tsx
+++ b/src/pages/nodes/NodeDetails.tsx
@@ -4,8 +4,7 @@ import { useQuery } from '@tanstack/react-query';
 import { NodeDetailContent } from '@/components/nodes/NodeDetailContent';
 import { useNodeDetailPageTabs } from '@/pages/nodes/useNodeDetailPageTabs';
 import { useMeshflowApi } from '@/hooks/api/useApi';
-
-const UUID_RE = /^[0-9a-f]{8}-[0-9a-f]{4}-[1-5][0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/i;
+import { isObservedNodeInternalId } from '@/lib/node-detail-routes';
 
 function LegacyMeshtasticNodeRedirect({ meshtasticNodeId }: { meshtasticNodeId: number }) {
   const navigate = useNavigate();
@@ -44,6 +43,40 @@ function LegacyMeshtasticNodeRedirect({ meshtasticNodeId }: { meshtasticNodeId: 
   );
 }
 
+function NodeIdStrRedirect({ nodeIdStr }: { nodeIdStr: string }) {
+  const navigate = useNavigate();
+  const api = useMeshflowApi();
+  const { data, isError } = useQuery({
+    queryKey: ['observed-node-resolve-str', nodeIdStr],
+    queryFn: async () => {
+      const results = await api.searchNodes(nodeIdStr);
+      const exact = results.find((n) => n.node_id_str === nodeIdStr);
+      const match = exact ?? results[0];
+      if (!match?.internal_id) {
+        throw new Error('Node not found');
+      }
+      return String(match.internal_id);
+    },
+    retry: false,
+  });
+
+  useEffect(() => {
+    if (data) {
+      navigate(`/nodes/${data}`, { replace: true });
+    }
+  }, [data, navigate]);
+
+  if (isError) {
+    return <div className="p-8 text-center text-muted-foreground">No observed node found for id {nodeIdStr}.</div>;
+  }
+
+  return (
+    <div className="flex min-h-screen items-center justify-center">
+      <div className="h-12 w-12 animate-spin rounded-full border-b-2 border-t-2 border-teal-500" />
+    </div>
+  );
+}
+
 export function NodeDetails() {
   const { id } = useParams<{ id: string }>();
   const { activeTab, onTabChange } = useNodeDetailPageTabs();
@@ -52,11 +85,23 @@ export function NodeDetails() {
     return null;
   }
 
-  if (/^\d+$/.test(id)) {
-    return <LegacyMeshtasticNodeRedirect meshtasticNodeId={Number(id)} />;
+  const decodedId = (() => {
+    try {
+      return decodeURIComponent(id);
+    } catch {
+      return id;
+    }
+  })();
+
+  if (/^\d+$/.test(decodedId)) {
+    return <LegacyMeshtasticNodeRedirect meshtasticNodeId={Number(decodedId)} />;
   }
 
-  if (!UUID_RE.test(id)) {
+  if (decodedId.startsWith('mc:') || decodedId.startsWith('!')) {
+    return <NodeIdStrRedirect nodeIdStr={decodedId} />;
+  }
+
+  if (!isObservedNodeInternalId(decodedId)) {
     return <div className="p-8 text-center text-muted-foreground">Invalid node id in URL.</div>;
   }
 
@@ -68,7 +113,7 @@ export function NodeDetails() {
         </div>
       }
     >
-      <NodeDetailContent internalId={id} activeTab={activeTab} onTabChange={onTabChange} />
+      <NodeDetailContent internalId={decodedId} activeTab={activeTab} onTabChange={onTabChange} />
     </Suspense>
   );
 }

--- a/src/pages/protocol/ProtocolMessageHistoryPage.tsx
+++ b/src/pages/protocol/ProtocolMessageHistoryPage.tsx
@@ -5,20 +5,16 @@ import { useConstellationsSuspense } from '@/hooks/api/useConstellations';
 import type { MessageChannel } from '@/lib/models';
 import type { ProtocolPageConfig } from '@/lib/mesh-protocol';
 import { filterChannelsForProtocol, formatMessageChannelLabel } from '@/lib/message-channels';
-import { constellationStorageKey, filterConstellationsForProtocol } from '@/lib/constellation-protocol';
+import {
+  constellationStorageKey,
+  filterConstellationsForProtocol,
+  resolveMessageConstellationId,
+} from '@/lib/constellation-protocol';
 import { cn } from '@/lib/utils';
 
 type ProtocolMessageHistoryPageProps = {
   config: ProtocolPageConfig;
 };
-
-function readStoredConstellationId(protocol: ProtocolPageConfig['slug']): number | null {
-  if (typeof window === 'undefined') return null;
-  const raw = window.localStorage.getItem(constellationStorageKey(protocol));
-  if (!raw) return null;
-  const n = Number(raw);
-  return Number.isFinite(n) ? n : null;
-}
 
 export function ProtocolMessageHistoryPage({ config }: ProtocolMessageHistoryPageProps) {
   const { constellations: allConstellations } = useConstellationsSuspense();
@@ -27,35 +23,28 @@ export function ProtocolMessageHistoryPage({ config }: ProtocolMessageHistoryPag
     [allConstellations, config.slug]
   );
 
-  const [selectedConstellation, setSelectedConstellation] = useState<number | null>(() => {
-    const stored = readStoredConstellationId(config.slug);
-    return stored;
-  });
+  const [selectedConstellation, setSelectedConstellation] = useState<number | null>(null);
   const [selectedChannel, setSelectedChannel] = useState<number | null>(null);
 
+  const activeConstellationId = useMemo(
+    () => resolveMessageConstellationId(constellations, selectedConstellation, config.slug),
+    [constellations, selectedConstellation, config.slug]
+  );
+
   useEffect(() => {
-    if (constellations.length === 0) {
-      setSelectedConstellation(null);
-      setSelectedChannel(null);
-      return;
+    if (activeConstellationId !== selectedConstellation) {
+      setSelectedConstellation(activeConstellationId);
     }
-    const stillValid = selectedConstellation != null && constellations.some((c) => c.id === selectedConstellation);
-    if (!stillValid) {
-      const stored = readStoredConstellationId(config.slug);
-      const fromStorage = stored != null && constellations.some((c) => c.id === stored) ? stored : constellations[0].id;
-      setSelectedConstellation(fromStorage);
-      setSelectedChannel(null);
-    }
-  }, [constellations, config.slug, selectedConstellation]);
+  }, [activeConstellationId, selectedConstellation]);
 
   const channels: MessageChannel[] = useMemo(() => {
-    if (!selectedConstellation) {
+    if (activeConstellationId == null) {
       return [];
     }
-    const constellation = constellations.find((c) => c.id === selectedConstellation);
+    const constellation = constellations.find((c) => c.id === activeConstellationId);
     const raw = constellation?.channels ?? [];
     return filterChannelsForProtocol(raw, config.slug);
-  }, [selectedConstellation, constellations, config.slug]);
+  }, [activeConstellationId, constellations, config.slug]);
 
   useEffect(() => {
     if (channels.length === 0) {
@@ -65,7 +54,7 @@ export function ProtocolMessageHistoryPage({ config }: ProtocolMessageHistoryPag
     if (selectedChannel == null || !channels.some((ch) => ch.id === selectedChannel)) {
       setSelectedChannel(channels[0].id);
     }
-  }, [channels, selectedChannel]);
+  }, [channels, selectedChannel, activeConstellationId]);
 
   const selectConstellation = (id: number) => {
     setSelectedConstellation(id);
@@ -103,7 +92,7 @@ export function ProtocolMessageHistoryPage({ config }: ProtocolMessageHistoryPag
                         onClick={() => selectConstellation(c.id)}
                         className={cn(
                           'rounded-md border px-3 py-1.5 text-sm transition-colors',
-                          selectedConstellation === c.id
+                          activeConstellationId === c.id
                             ? 'border-primary bg-primary text-primary-foreground'
                             : 'border-border bg-background hover:bg-muted'
                         )}
@@ -132,8 +121,8 @@ export function ProtocolMessageHistoryPage({ config }: ProtocolMessageHistoryPag
                   </select>
                 </div>
               </div>
-              {selectedChannel && selectedConstellation ? (
-                <MessageList channel={selectedChannel} constellationId={selectedConstellation} protocol={config.slug} />
+              {selectedChannel != null && activeConstellationId != null ? (
+                <MessageList channel={selectedChannel} constellationId={activeConstellationId} protocol={config.slug} />
               ) : (
                 <div className="flex justify-center p-8 text-muted-foreground">
                   No channels available for this constellation.

--- a/src/pages/protocol/ProtocolMessageHistoryPage.tsx
+++ b/src/pages/protocol/ProtocolMessageHistoryPage.tsx
@@ -5,21 +5,48 @@ import { useConstellationsSuspense } from '@/hooks/api/useConstellations';
 import type { MessageChannel } from '@/lib/models';
 import type { ProtocolPageConfig } from '@/lib/mesh-protocol';
 import { filterChannelsForProtocol, formatMessageChannelLabel } from '@/lib/message-channels';
+import { constellationStorageKey, filterConstellationsForProtocol } from '@/lib/constellation-protocol';
+import { cn } from '@/lib/utils';
 
 type ProtocolMessageHistoryPageProps = {
   config: ProtocolPageConfig;
 };
 
+function readStoredConstellationId(protocol: ProtocolPageConfig['slug']): number | null {
+  if (typeof window === 'undefined') return null;
+  const raw = window.localStorage.getItem(constellationStorageKey(protocol));
+  if (!raw) return null;
+  const n = Number(raw);
+  return Number.isFinite(n) ? n : null;
+}
+
 export function ProtocolMessageHistoryPage({ config }: ProtocolMessageHistoryPageProps) {
-  const { constellations } = useConstellationsSuspense();
-  const [selectedConstellation, setSelectedConstellation] = useState<number | null>(null);
+  const { constellations: allConstellations } = useConstellationsSuspense();
+  const constellations = useMemo(
+    () => filterConstellationsForProtocol(allConstellations, config.slug),
+    [allConstellations, config.slug]
+  );
+
+  const [selectedConstellation, setSelectedConstellation] = useState<number | null>(() => {
+    const stored = readStoredConstellationId(config.slug);
+    return stored;
+  });
   const [selectedChannel, setSelectedChannel] = useState<number | null>(null);
 
   useEffect(() => {
-    if (constellations.length > 0 && selectedConstellation == null) {
-      setSelectedConstellation(constellations[0].id);
+    if (constellations.length === 0) {
+      setSelectedConstellation(null);
+      setSelectedChannel(null);
+      return;
     }
-  }, [constellations, selectedConstellation]);
+    const stillValid = selectedConstellation != null && constellations.some((c) => c.id === selectedConstellation);
+    if (!stillValid) {
+      const stored = readStoredConstellationId(config.slug);
+      const fromStorage = stored != null && constellations.some((c) => c.id === stored) ? stored : constellations[0].id;
+      setSelectedConstellation(fromStorage);
+      setSelectedChannel(null);
+    }
+  }, [constellations, config.slug, selectedConstellation]);
 
   const channels: MessageChannel[] = useMemo(() => {
     if (!selectedConstellation) {
@@ -31,14 +58,21 @@ export function ProtocolMessageHistoryPage({ config }: ProtocolMessageHistoryPag
   }, [selectedConstellation, constellations, config.slug]);
 
   useEffect(() => {
-    if (channels.length > 0 && selectedChannel == null) {
+    if (channels.length === 0) {
+      setSelectedChannel(null);
+      return;
+    }
+    if (selectedChannel == null || !channels.some((ch) => ch.id === selectedChannel)) {
       setSelectedChannel(channels[0].id);
     }
   }, [channels, selectedChannel]);
 
-  const handleConstellationSelect = (e: React.ChangeEvent<HTMLSelectElement>) => {
-    setSelectedConstellation(Number(e.target.value));
+  const selectConstellation = (id: number) => {
+    setSelectedConstellation(id);
     setSelectedChannel(null);
+    if (typeof window !== 'undefined') {
+      window.localStorage.setItem(constellationStorageKey(config.slug), String(id));
+    }
   };
 
   const handleChannelSelect = (e: React.ChangeEvent<HTMLSelectElement>) => {
@@ -52,48 +86,60 @@ export function ProtocolMessageHistoryPage({ config }: ProtocolMessageHistoryPag
           <CardTitle>{config.labels.messagesTitle}</CardTitle>
         </CardHeader>
         <CardContent>
-          <div className="mb-4 flex flex-col md:flex-row gap-4 items-center">
-            <div>
-              <label htmlFor="constellation-select" className="mr-2 font-medium">
-                Constellation:
-              </label>
-              <select
-                id="constellation-select"
-                value={selectedConstellation ?? ''}
-                onChange={handleConstellationSelect}
-                disabled={constellations.length === 0}
-                className="border rounded px-2 py-1"
-              >
-                {constellations.map((c) => (
-                  <option key={c.id} value={c.id}>
-                    {c.name}
-                  </option>
-                ))}
-              </select>
+          {constellations.length === 0 ? (
+            <div className="flex justify-center p-8 text-muted-foreground">
+              No constellations with {config.labels.section} message channels.
             </div>
-            <div>
-              <label htmlFor="channel-select" className="mr-2 font-medium">
-                Channel:
-              </label>
-              <select
-                id="channel-select"
-                value={selectedChannel ?? ''}
-                onChange={handleChannelSelect}
-                disabled={channels.length === 0}
-                className="border rounded px-2 py-1"
-              >
-                {channels.map((ch: MessageChannel) => (
-                  <option key={ch.id} value={ch.id}>
-                    {formatMessageChannelLabel(ch)}
-                  </option>
-                ))}
-              </select>
-            </div>
-          </div>
-          {selectedChannel && selectedConstellation ? (
-            <MessageList channel={selectedChannel} constellationId={selectedConstellation} protocol={config.slug} />
           ) : (
-            <div className="flex justify-center p-8">No channels available for this constellation.</div>
+            <>
+              <div className="mb-4 space-y-4">
+                <div>
+                  <p className="text-sm font-medium mb-2">Constellation</p>
+                  <div className="flex flex-wrap gap-2" role="group" aria-label="Constellation">
+                    {constellations.map((c) => (
+                      <button
+                        key={c.id}
+                        type="button"
+                        onClick={() => selectConstellation(c.id)}
+                        className={cn(
+                          'rounded-md border px-3 py-1.5 text-sm transition-colors',
+                          selectedConstellation === c.id
+                            ? 'border-primary bg-primary text-primary-foreground'
+                            : 'border-border bg-background hover:bg-muted'
+                        )}
+                      >
+                        {c.name}
+                      </button>
+                    ))}
+                  </div>
+                </div>
+                <div>
+                  <label htmlFor="channel-select" className="mr-2 text-sm font-medium">
+                    Channel:
+                  </label>
+                  <select
+                    id="channel-select"
+                    value={selectedChannel ?? ''}
+                    onChange={handleChannelSelect}
+                    disabled={channels.length === 0}
+                    className="border rounded px-2 py-1"
+                  >
+                    {channels.map((ch: MessageChannel) => (
+                      <option key={ch.id} value={ch.id}>
+                        {formatMessageChannelLabel(ch)}
+                      </option>
+                    ))}
+                  </select>
+                </div>
+              </div>
+              {selectedChannel && selectedConstellation ? (
+                <MessageList channel={selectedChannel} constellationId={selectedConstellation} protocol={config.slug} />
+              ) : (
+                <div className="flex justify-center p-8 text-muted-foreground">
+                  No channels available for this constellation.
+                </div>
+              )}
+            </>
           )}
         </CardContent>
       </Card>

--- a/src/pages/protocol/ProtocolNodesPage.tsx
+++ b/src/pages/protocol/ProtocolNodesPage.tsx
@@ -16,6 +16,7 @@ import { Table, TableBody, TableCell, TableHead, TableHeader, TableRow } from '@
 import type { ObservedNode } from '@/lib/models';
 import { Link } from 'react-router-dom';
 import { filterManagedNodesForMapDisplay } from '@/lib/managed-node-status';
+import { buildMeshCoreMapNodes } from '@/lib/meshcore-map-nodes';
 import { StaleReportedTime } from '@/components/nodes/StaleReportedTime';
 import type { ProtocolPageConfig } from '@/lib/mesh-protocol';
 import { NODE_TIME_RANGE_OPTIONS, getLastHeardAfterForRange, type NodeTimeRangeOption } from '@/lib/node-time-range';
@@ -143,7 +144,17 @@ function ProtocolNodesPageContent({
   };
 
   const displayedNodes = sortNodes(filterNodes(mainListNodes || []));
-  const mapNodes = searchQuery ? filterNodes(mainListNodes || []) : mainListNodes || [];
+  const observedForMap = searchQuery ? filterNodes(mainListNodes || []) : mainListNodes || [];
+  const mapNodes = useMemo(() => {
+    if (config.slug !== 'meshcore') {
+      return observedForMap;
+    }
+    return buildMeshCoreMapNodes(observedForMap, managedNodesForMap);
+  }, [config.slug, observedForMap, managedNodesForMap]);
+  const mapNodesWithPosition = useMemo(
+    () => mapNodes.filter((n) => n.latest_position?.latitude != null && n.latest_position?.longitude != null),
+    [mapNodes]
+  );
 
   const { withLocation, identityOnly } = useMemo(() => {
     if (config.slug === 'meshtastic') {
@@ -239,6 +250,12 @@ function ProtocolNodesPageContent({
           <CardTitle>{config.slug === 'meshtastic' ? 'Mesh Nodes and Monitoring' : 'Map'}</CardTitle>
         </CardHeader>
         <CardContent>
+          {config.slug === 'meshcore' && mapNodesWithPosition.length === 0 ? (
+            <p className="text-sm text-muted-foreground mb-4">
+              No MeshCore nodes with a known position in this time range. Managed feeders need a default location in the
+              API; observed nodes appear after ADVERT packets with coordinates.
+            </p>
+          ) : null}
           <div className="h-[600px] w-full">
             {config.features.constellationsOnMap ? (
               <NodesAndConstellationsMap
@@ -248,12 +265,7 @@ function ProtocolNodesPageContent({
                 showUnmanagedNodes={true}
               />
             ) : (
-              <NodesMap
-                nodes={mapNodes.filter(
-                  (n) => n.latest_position?.latitude != null && n.latest_position?.longitude != null
-                )}
-                roleLegend={config.features.roleLegend}
-              />
+              <NodesMap nodes={mapNodesWithPosition} roleLegend={config.features.roleLegend} />
             )}
           </div>
         </CardContent>

--- a/src/pages/traceroutes/TracerouteDetailModal.tsx
+++ b/src/pages/traceroutes/TracerouteDetailModal.tsx
@@ -1,5 +1,6 @@
 import { format } from 'date-fns';
 import { Link } from 'react-router-dom';
+import { nodeDetailPath, observedNodeDetailPath } from '@/lib/node-detail-routes';
 import { Dialog, DialogContent, DialogDescription, DialogHeader, DialogTitle } from '@/components/ui/dialog';
 import { Badge } from '@/components/ui/badge';
 import { useTraceroute } from '@/hooks/api/useTraceroutes';
@@ -86,7 +87,11 @@ export function TracerouteDetailModal({ tracerouteId, open, onOpenChange }: Trac
             {traceroute ? (
               <>
                 <Link
-                  to={`/nodes/${traceroute.source_node.meshtastic_node_id}`}
+                  to={nodeDetailPath({
+                    meshtastic_node_id: traceroute.source_node.meshtastic_node_id,
+                    node_id_str: traceroute.source_node.node_id_str,
+                    protocol: traceroute.source_node.protocol,
+                  })}
                   onClick={(e) => e.stopPropagation()}
                   className="font-medium text-primary underline-offset-4 hover:underline"
                 >
@@ -94,7 +99,7 @@ export function TracerouteDetailModal({ tracerouteId, open, onOpenChange }: Trac
                 </Link>
                 <span aria-hidden>→</span>
                 <Link
-                  to={`/nodes/${traceroute.target_node.meshtastic_node_id}`}
+                  to={observedNodeDetailPath(traceroute.target_node)}
                   onClick={(e) => e.stopPropagation()}
                   className="font-medium text-primary underline-offset-4 hover:underline"
                 >
@@ -119,7 +124,11 @@ export function TracerouteDetailModal({ tracerouteId, open, onOpenChange }: Trac
               <Badge variant="outline" className="gap-1">
                 <span className="text-muted-foreground">Source:</span>
                 <Link
-                  to={`/nodes/${traceroute.source_node.meshtastic_node_id}`}
+                  to={nodeDetailPath({
+                    meshtastic_node_id: traceroute.source_node.meshtastic_node_id,
+                    node_id_str: traceroute.source_node.node_id_str,
+                    protocol: traceroute.source_node.protocol,
+                  })}
                   onClick={(e) => e.stopPropagation()}
                   className="text-primary underline-offset-4 hover:underline"
                 >
@@ -129,7 +138,7 @@ export function TracerouteDetailModal({ tracerouteId, open, onOpenChange }: Trac
               <Badge variant="outline" className="gap-1">
                 <span className="text-muted-foreground">Target:</span>
                 <Link
-                  to={`/nodes/${traceroute.target_node.meshtastic_node_id}`}
+                  to={observedNodeDetailPath(traceroute.target_node)}
                   onClick={(e) => e.stopPropagation()}
                   className="text-primary underline-offset-4 hover:underline"
                 >

--- a/src/pages/user/NodeSettings.tsx
+++ b/src/pages/user/NodeSettings.tsx
@@ -8,6 +8,7 @@ import { Badge } from '@/components/ui/badge';
 import { StaleReportedTime } from '@/components/nodes/StaleReportedTime';
 import { Loader2, AlertCircle, Info, Copy, Radio, HelpCircle, ChevronDown, KeyRound } from 'lucide-react';
 import { useConfig } from '@/providers/ConfigProvider';
+import { nodeDetailPath, observedNodeDetailPath } from '@/lib/node-detail-routes';
 import { BotSetupInstructions } from '@/components/nodes/BotSetupInstructions';
 import { Alert, AlertDescription, AlertTitle } from '@/components/ui/alert';
 import { Button } from '@/components/ui/button';
@@ -131,10 +132,7 @@ function NodeSettingsContent() {
                         </div>
                       </div>
                       <div className="mt-2 flex gap-2">
-                        <Link
-                          to={`/nodes/${node.meshtastic_node_id}`}
-                          className="text-blue-500 hover:text-blue-700 text-sm"
-                        >
+                        <Link to={observedNodeDetailPath(node)} className="text-blue-500 hover:text-blue-700 text-sm">
                           View Node
                         </Link>
                         {!managedNodeIds.has(node.meshtastic_node_id) && (
@@ -750,7 +748,14 @@ function ManagedNodeSettings({
   return (
     <div className="space-y-4 pt-2">
       <div className="flex flex-wrap gap-2">
-        <Link to={`/nodes/${node.meshtastic_node_id}`}>
+        <Link
+          to={nodeDetailPath({
+            internal_id: node.internal_id,
+            meshtastic_node_id: node.meshtastic_node_id,
+            node_id_str: node.node_id_str,
+            protocol: node.protocol,
+          })}
+        >
           <Button variant="outline" size="sm">
             View Node Details
           </Button>


### PR DESCRIPTION
## Summary

- **#282** — Merge MeshCore managed feeders (with default position) into the MeshCore nodes map via `buildMeshCoreMapNodes`; add an empty-state hint when no pins qualify.
- **#280** — Centralize `/nodes/:id` routing in `nodeDetailPath` (UUID `internal_id`, legacy Meshtastic numeric id, or encoded `mc:` / `!` `node_id_str`); fix map popups and audit traceroute/managed-node links; `NodeDetails` resolves `mc:` / `!` via search.
- **#277** — Filter message constellations by **`Constellation.protocol`** (not only channel protocol); resolve active constellation from message + channel context.
- **#278** — Constellation button tabs, auto-select first match, persist last choice in `localStorage` (no unread badges).

### API dependency

Deploy together with **[meshflow-api #347](https://github.com/pskillen/meshflow-api/pull/347)** (`fix(constellations): return all protocol constellations by default`):

- API returns all member constellations without `?protocol=` (Meshtastic + MeshCore).
- UI filters client-side by protocol; optional API `?protocol=` is available but not required.

**Pre-prod check:** MeshCore constellations must have `protocol=2` in Django admin and the user must still have constellation membership until [meshflow-api #346](https://github.com/pskillen/meshflow-api/issues/346) (guest / global permissions) ships.

## Testing performed

- [x] `npm test` (full vitest suite in pre-commit)
- [x] New unit tests: `node-detail-routes`, `meshcore-map-nodes`, `constellation-protocol`, `buildNodePopupHtml`
- [ ] With API #347 on pre-prod: MC messages page shows MC constellation picker (not Meshtastic-only)

Closes #282, #280, #277, #278