### PR TITLE
feat(nodes): stable /nodes/:id URLs and API lookup UX (#280)

### DIFF
--- a/src/components/NeighbourPieChart.tsx
+++ b/src/components/NeighbourPieChart.tsx
@@ -219,10 +219,13 @@ export function NeighbourPieChart({
                         {item.candidates.map((c) => (
                           <Link
                             key={c.meshtastic_node_id}
-                            to={nodeDetailPath({
-                              meshtastic_node_id: c.meshtastic_node_id,
-                              node_id_str: c.node_id_str,
-                            })}
+                            to={
+                              nodeDetailPath({
+                                meshtastic_node_id: c.meshtastic_node_id,
+                                node_id_str: c.node_id_str,
+                                protocol: 1,
+                              }) ?? '#'
+                            }
                             className="text-xs text-teal-600 dark:text-teal-400 hover:underline px-1.5 py-0.5 rounded bg-muted"
                           >
                             {c.short_name || c.node_id_str}

--- a/src/components/NodeActivityTable.tsx
+++ b/src/components/NodeActivityTable.tsx
@@ -17,6 +17,7 @@ import { Button } from '@/components/ui/button';
 import { Card, CardContent, CardHeader, CardTitle, CardDescription } from '@/components/ui/card';
 import { ObservedNode } from '@/lib/models';
 import { meshtasticIdToHex } from '@/lib/utils';
+import { observedNodeDetailPath } from '@/lib/node-detail-routes';
 
 const columns: ColumnDef<ObservedNode>[] = [
   {
@@ -25,7 +26,7 @@ const columns: ColumnDef<ObservedNode>[] = [
     cell: ({ row }) => {
       const node = row.original;
       return (
-        <Link to={`/nodes/${node.internal_id}`}>
+        <Link to={observedNodeDetailPath(node) ?? '#'}>
           <div>
             <div className="font-medium">{node.short_name}</div>
             <div className="text-sm text-muted-foreground">{node.long_name}</div>

--- a/src/components/NodeSearch.tsx
+++ b/src/components/NodeSearch.tsx
@@ -4,6 +4,7 @@ import { useNodes } from '@/hooks/api/useNodes';
 import { SearchIcon, X } from 'lucide-react';
 import { Input } from '@/components/ui/input';
 import { Button } from '@/components/ui/button';
+import { nodeDetailPath } from '@/lib/node-detail-routes';
 
 interface NodeSearchProps {
   onNodeSelect?: (
@@ -114,7 +115,15 @@ export function NodeSearch({ onNodeSelect, displayValue, onClearSelection, lastH
               {filteredSearchResults.map((node) => (
                 <li key={node.internal_id}>
                   <Link
-                    to={onNodeSelect ? '#' : `/nodes/${node.internal_id}`}
+                    to={
+                      onNodeSelect
+                        ? '#'
+                        : (nodeDetailPath({
+                            node_id_str: node.node_id_str,
+                            protocol: node.node_id_str?.toLowerCase().startsWith('mc:') ? 2 : 1,
+                            meshtastic_node_id: node.meshtastic_node_id,
+                          }) ?? '#')
+                    }
                     className="block px-4 py-2 hover:bg-accent"
                     onClick={() => {
                       setIsOpen(false);

--- a/src/components/messages/MessageItem.tsx
+++ b/src/components/messages/MessageItem.tsx
@@ -9,6 +9,7 @@ import { StaleReportedTime } from '@/components/nodes/StaleReportedTime';
 import { Link } from 'react-router-dom';
 import { Dialog, DialogContent, DialogHeader, DialogTitle, DialogTrigger } from '@/components/ui/dialog';
 import { ExternalLink } from 'lucide-react';
+import { nodeDetailPath } from '@/lib/node-detail-routes';
 
 function isMeshCoreHeard(obs: PacketObservation | MeshCoreHeardObservation): obs is MeshCoreHeardObservation {
   return typeof (obs as MeshCoreHeardObservation).observer === 'string';
@@ -109,12 +110,6 @@ interface MessageItemProps {
   continuationMessages?: Array<{ message: TextMessage; replies: TextMessage[]; emojiReactions: TextMessage[] }>;
 }
 
-/** Parse node_id_str (!hex) to numeric meshtastic_node_id for routing */
-function parseNodeId(nodeIdStr: string): number | null {
-  const match = nodeIdStr?.replace(/^!/, '').match(/^[0-9a-fA-F]+$/);
-  return match ? parseInt(match[0], 16) : null;
-}
-
 // Memoize the entire component to prevent unnecessary re-renders
 export const MessageItem = memo(function MessageItem({
   message,
@@ -123,7 +118,15 @@ export const MessageItem = memo(function MessageItem({
   continuationMessages = [],
 }: MessageItemProps) {
   const proto = messageProtocol(message);
-  const nodeId = useMemo(() => (message.sender ? parseNodeId(message.sender.node_id_str) : null), [message.sender]);
+  const senderDetailPath = useMemo(() => {
+    if (!message.sender?.node_id_str) {
+      return null;
+    }
+    return nodeDetailPath({
+      node_id_str: message.sender.node_id_str,
+      protocol: proto === 'meshcore' ? 2 : 1,
+    });
+  }, [message.sender, proto]);
   const fullTime = useMemo(() => {
     return message.sent_at ? format(new Date(message.sent_at), 'MMM d, yyyy h:mm a') : 'Unknown time';
   }, [message.sent_at]);
@@ -153,16 +156,16 @@ export const MessageItem = memo(function MessageItem({
         </Avatar>
         <div className="min-w-0 flex-1 flex items-center gap-2">
           {/* Desktop: sender name as link. Mobile: sender name + subtle icon link */}
-          {nodeId != null ? (
+          {senderDetailPath != null ? (
             <>
               <Link
-                to={`/nodes/${nodeId}`}
+                to={senderDetailPath}
                 className="font-medium text-foreground hover:underline truncate md:max-w-[200px]"
               >
                 {senderName}
               </Link>
               <Link
-                to={`/nodes/${nodeId}`}
+                to={senderDetailPath}
                 className="shrink-0 p-0.5 text-muted-foreground hover:text-foreground md:sr-only"
                 aria-label={`View node ${senderName} details`}
               >

--- a/src/components/nodes/InfrastructureExportTable.tsx
+++ b/src/components/nodes/InfrastructureExportTable.tsx
@@ -32,6 +32,7 @@ import { Card, CardContent, CardDescription, CardHeader, CardTitle } from '@/com
 import { infrastructureRowsToCsv, downloadCsv, downloadTextFile, type CsvColumnDef } from '@/lib/infrastructure-csv';
 import { buildSetFavoriteNodeCommands, countSetFavoriteNodeCommands } from '@/lib/infrastructure-meshtastic-cli';
 import type { InfrastructureExportRow } from '@/lib/infrastructure-export-rows';
+import { nodeDetailPath } from '@/lib/node-detail-routes';
 
 export const INFRA_EXPORT_ROLE_OPTIONS = ['ROUTER', 'ROUTER_CLIENT', 'REPEATER', 'ROUTER_LATE', 'CLIENT_BASE'] as const;
 
@@ -121,7 +122,10 @@ const columns: ColumnDef<InfrastructureExportRow>[] = [
     header: 'Name',
     filterFn: 'includesString',
     cell: ({ row }) => (
-      <Link to={`/nodes/${row.original.internal_id}`} className="text-primary hover:underline">
+      <Link
+        to={nodeDetailPath({ node_id_str: row.original.node_id_str }) ?? '#'}
+        className="text-primary hover:underline"
+      >
         <div className="font-medium">{row.original.long_name || row.original.short_name || '—'}</div>
         {row.original.short_name && row.original.long_name && (
           <div className="text-xs text-muted-foreground">{row.original.short_name}</div>

--- a/src/components/nodes/InfrastructureNodeCard.test.tsx
+++ b/src/components/nodes/InfrastructureNodeCard.test.tsx
@@ -68,9 +68,9 @@ describe('InfrastructureNodeCard', () => {
 
   it('also renders the Open node details link to /nodes/<internal_id>', () => {
     const internalId = '00000000-0000-4000-8000-000000000007';
-    renderCard(makeNode({ meshtastic_node_id: 7, internal_id: internalId }));
+    renderCard(makeNode({ meshtastic_node_id: 7, internal_id: internalId, node_id_str: '!00000007' }));
     const detailsLink = screen.getByRole('link', { name: /open node details/i });
-    expect(detailsLink.getAttribute('href')).toBe(`/nodes/${internalId}`);
+    expect(detailsLink.getAttribute('href')).toBe('/nodes/!00000007');
   });
 
   it('shows Propagation map only when has_ready_rf_render is true', () => {

--- a/src/components/nodes/InfrastructureNodeCard.tsx
+++ b/src/components/nodes/InfrastructureNodeCard.tsx
@@ -11,6 +11,7 @@ import { NodeMiniChart } from '@/components/nodes/NodeMiniChart';
 import { Check, ChevronRight } from 'lucide-react';
 import { useState, memo } from 'react';
 import { RfPropagationMapModal } from '@/components/nodes/RfPropagationMapModal';
+import { observedNodeDetailPath } from '@/lib/node-detail-routes';
 
 interface InfrastructureNodeCardProps {
   node: ObservedNode;
@@ -182,7 +183,7 @@ function InfrastructureNodeCardInner({
           </>
         )}
         <Link
-          to={`/nodes/${node.internal_id}`}
+          to={observedNodeDetailPath(node) ?? '#'}
           className="inline-flex items-center gap-1.5 text-sm text-primary hover:underline"
         >
           Open node details

--- a/src/components/nodes/MyNodeCard.tsx
+++ b/src/components/nodes/MyNodeCard.tsx
@@ -11,6 +11,7 @@ import {
   Unplug,
 } from 'lucide-react';
 import { StaleReportedTime } from '@/components/nodes/StaleReportedTime';
+import { observedNodeDetailPath } from '@/lib/node-detail-routes';
 import type { UseQueryResult } from '@tanstack/react-query';
 
 import { MeshWatchControls } from '@/components/nodes/MeshWatchControls';
@@ -225,7 +226,7 @@ export function MyNodeCard({
           />
         </div>
         <Button asChild className="w-full">
-          <Link to={`/nodes/${node.internal_id}`} className="inline-flex items-center justify-center gap-1.5">
+          <Link to={observedNodeDetailPath(node) ?? '#'} className="inline-flex items-center justify-center gap-1.5">
             <Settings className="h-4 w-4 shrink-0" aria-hidden />
             Node details
             <ChevronRight className="h-4 w-4 shrink-0 opacity-70" aria-hidden />

--- a/src/components/nodes/NodeCard.tsx
+++ b/src/components/nodes/NodeCard.tsx
@@ -2,6 +2,7 @@ import { Link } from 'react-router-dom';
 import { Battery } from 'lucide-react';
 import { StaleReportedTime } from '@/components/nodes/StaleReportedTime';
 import { ObservedNode } from '@/lib/models';
+import { observedNodeDetailPath } from '@/lib/node-detail-routes';
 import { getRoleLabel } from '@/lib/meshtastic';
 import { cn } from '@/lib/utils';
 
@@ -42,11 +43,16 @@ function BatteryIndicator({ level }: { level: number }) {
 export function NodeCard({ node }: NodeCardProps) {
   const batteryLevel = node.latest_device_metrics?.battery_level ?? null;
   const roleLabel = getRoleLabel(node.meshtastic_role);
+  const detailPath = observedNodeDetailPath(node);
+
+  if (!detailPath) {
+    return null;
+  }
 
   return (
     <Link
       key={node.meshtastic_node_id}
-      to={`/nodes/${node.internal_id}`}
+      to={detailPath}
       className="block p-5 bg-white dark:bg-slate-800 rounded-lg shadow-md hover:shadow-lg transition-shadow duration-200 border border-slate-200 dark:border-slate-700"
     >
       <div className="flex justify-between items-start gap-3 mb-3">

--- a/src/components/nodes/NodeDetailContent.tsx
+++ b/src/components/nodes/NodeDetailContent.tsx
@@ -33,6 +33,7 @@ import {
   observedNodeMapRoleLegend,
   supportsMeshtasticTraceroutes,
 } from '@/lib/observed-node-capabilities';
+import { observedNodeDetailPath } from '@/lib/node-detail-routes';
 
 interface NodeDetailContentProps {
   internalId: string;
@@ -614,7 +615,7 @@ export function NodeDetailContent({ internalId, compact = false, activeTab, onTa
               .map((recentNode) => (
                 <Link
                   key={recentNode.meshtastic_node_id}
-                  to={`/nodes/${recentNode.internal_id}`}
+                  to={observedNodeDetailPath(recentNode) ?? '#'}
                   replace={true}
                   className="rounded-full bg-slate-100 px-3 py-1 text-sm text-teal-600 hover:bg-slate-200 dark:bg-slate-800 dark:text-teal-400 dark:hover:bg-slate-700"
                 >

--- a/src/components/nodes/NodeTracerouteLinksMap.tsx
+++ b/src/components/nodes/NodeTracerouteLinksMap.tsx
@@ -196,10 +196,13 @@ export function NodeTracerouteLinksMap({ edges, nodes, focusNodeId, showLabels =
                 </div>
               )}
               <Link
-                to={nodeDetailPath({
-                  meshtastic_node_id: selectedNode.meshtastic_node_id,
-                  node_id_str: selectedNode.node_id_str,
-                })}
+                to={
+                  nodeDetailPath({
+                    meshtastic_node_id: selectedNode.meshtastic_node_id,
+                    node_id_str: selectedNode.node_id_str,
+                    protocol: 1,
+                  }) ?? '#'
+                }
                 className="mt-1 inline-block text-xs text-emerald-400 hover:text-emerald-300 hover:underline"
               >
                 Open details

--- a/src/components/nodes/WatchedNodesTable.tsx
+++ b/src/components/nodes/WatchedNodesTable.tsx
@@ -18,6 +18,7 @@ import { useMeshtasticApi } from '@/hooks/api/useApi';
 import { useMultiNodeMetrics } from '@/hooks/api/useMultiNodeMetrics';
 import { NodeMiniChart } from '@/components/nodes/NodeMiniChart';
 import { BatteryIcon, RouteIcon, Settings2 } from 'lucide-react';
+import { observedNodeDetailPath } from '@/lib/node-detail-routes';
 import { Button } from '@/components/ui/button';
 import { cn } from '@/lib/utils';
 import {
@@ -286,7 +287,7 @@ function WatchCard({
         <div>
           <FieldLabel>Node</FieldLabel>
           <Link
-            to={`/nodes/${node.internal_id}`}
+            to={observedNodeDetailPath(node) ?? '#'}
             className="font-medium text-teal-600 dark:text-teal-400 hover:underline"
           >
             {node.short_name || node.node_id_str}

--- a/src/components/nodes/WeatherNodeCard.tsx
+++ b/src/components/nodes/WeatherNodeCard.tsx
@@ -4,6 +4,7 @@ import { StaleReportedTime } from '@/components/nodes/StaleReportedTime';
 import { EnvironmentMetricsMiniChart } from './EnvironmentMetricsMiniChart';
 import { ChevronRight } from 'lucide-react';
 import { memo } from 'react';
+import { observedNodeDetailPath } from '@/lib/node-detail-routes';
 
 interface WeatherNodeCardProps {
   node: ObservedNode;
@@ -49,7 +50,7 @@ function WeatherNodeCardInner({ node, metrics, dateRange }: WeatherNodeCardProps
       </div>
       <div className="mt-auto flex justify-end pt-3">
         <Link
-          to={`/nodes/${node.internal_id}`}
+          to={observedNodeDetailPath(node) ?? '#'}
           className="inline-flex items-center gap-1.5 text-sm text-primary hover:underline"
         >
           Open node details

--- a/src/components/nodes/map-utils.test.ts
+++ b/src/components/nodes/map-utils.test.ts
@@ -9,16 +9,16 @@ function pt(lng: number, lat: number): Feature<Point> {
 }
 
 describe('buildNodePopupHtml', () => {
-  it('links to internal_id not meshtastic_node_id zero', () => {
+  it('links to mc: node_id_str not meshtastic_node_id zero', () => {
     const html = buildNodePopupHtml({
       internal_id: 'a1b2c3d4-e5f6-4789-a012-8456789abcde',
       meshtastic_node_id: 0,
-      node_id_str: 'mc:abc',
+      node_id_str: 'mc:deadbeefcafe',
       long_name: 'Test',
       short_name: 't',
       protocol: 2,
     });
-    expect(html).toContain('href="/nodes/a1b2c3d4-e5f6-4789-a012-8456789abcde"');
+    expect(html).toContain('href="/nodes/mc%3Adeadbeefcafe"');
     expect(html).not.toContain('href="/nodes/0"');
   });
 });

--- a/src/components/nodes/map-utils.ts
+++ b/src/components/nodes/map-utils.ts
@@ -156,11 +156,14 @@ export function buildNodePopupHtml(node: NodePopupData): string {
     node.constellationName != null && node.constellationName !== ''
       ? `Constellation: ${escapeHtml(node.constellationName)}`
       : null;
+  const detailsLink = detailsUrl
+    ? `<a href="${escapeHtml(detailsUrl)}">Open details</a>`
+    : '<span style="color: #666;">Details unavailable</span>';
   return `
   <strong>${escapeHtml(displayName)}</strong><br>
   Last seen: ${escapeHtml(lastSeen)}<br>
   ${constellationLine ? `<span style="color: #666;">${constellationLine}</span><br>` : ''}
-  <a href="${detailsUrl}">Open details</a>
+  ${detailsLink}
   `;
 }
 

--- a/src/components/traceroutes/ConstellationCoverageMap.tsx
+++ b/src/components/traceroutes/ConstellationCoverageMap.tsx
@@ -1,6 +1,6 @@
 import { useCallback, useMemo, useState } from 'react';
 import { Link } from 'react-router-dom';
-import { isObservedNodeInternalId, nodeDetailPath } from '@/lib/node-detail-routes';
+import { nodeDetailPath } from '@/lib/node-detail-routes';
 import { Popup } from 'react-map-gl/mapbox';
 import { ScatterplotLayer } from '@deck.gl/layers';
 import { H3HexagonLayer } from '@deck.gl/geo-layers';
@@ -208,10 +208,13 @@ export function ConstellationCoverageMap({
                 {selectedHeardGhost.node_id_str || `!${selectedHeardGhost.meshtastic_node_id.toString(16)}`}
               </div>
               <Link
-                to={nodeDetailPath({
-                  meshtastic_node_id: selectedHeardGhost.meshtastic_node_id,
-                  node_id_str: selectedHeardGhost.node_id_str,
-                })}
+                to={
+                  nodeDetailPath({
+                    meshtastic_node_id: selectedHeardGhost.meshtastic_node_id,
+                    node_id_str: selectedHeardGhost.node_id_str,
+                    protocol: 1,
+                  }) ?? '#'
+                }
                 className="mt-1 inline-block text-xs text-emerald-400 hover:text-emerald-300 hover:underline"
               >
                 Open details
@@ -299,10 +302,13 @@ export function ConstellationCoverageMap({
                 {selectedTarget.contributing_feeders === 1 ? '' : 's'}
               </div>
               <Link
-                to={nodeDetailPath({
-                  meshtastic_node_id: selectedTarget.meshtastic_node_id,
-                  node_id_str: selectedTarget.node_id_str,
-                })}
+                to={
+                  nodeDetailPath({
+                    meshtastic_node_id: selectedTarget.meshtastic_node_id,
+                    node_id_str: selectedTarget.node_id_str,
+                    protocol: 1,
+                  }) ?? '#'
+                }
                 className="mt-1 inline-block text-xs text-emerald-400 hover:text-emerald-300 hover:underline"
               >
                 Open details
@@ -338,13 +344,13 @@ export function ConstellationCoverageMap({
                 {selectedFeeder.node_id_str || `!${selectedFeeder.meshtastic_node_id.toString(16)}`}
               </div>
               <Link
-                to={nodeDetailPath({
-                  internal_id: isObservedNodeInternalId(selectedFeeder.managed_node_id)
-                    ? selectedFeeder.managed_node_id
-                    : undefined,
-                  meshtastic_node_id: selectedFeeder.meshtastic_node_id,
-                  node_id_str: selectedFeeder.node_id_str,
-                })}
+                to={
+                  nodeDetailPath({
+                    meshtastic_node_id: selectedFeeder.meshtastic_node_id,
+                    node_id_str: selectedFeeder.node_id_str,
+                    protocol: 1,
+                  }) ?? '#'
+                }
                 className="mt-1 inline-block text-xs text-emerald-400 hover:text-emerald-300 hover:underline"
               >
                 Open details

--- a/src/components/traceroutes/FeederCoverageMap.tsx
+++ b/src/components/traceroutes/FeederCoverageMap.tsx
@@ -8,7 +8,7 @@ import { concave, featureCollection, point as turfPoint } from '@turf/turf';
 import type { Feature, MultiPolygon, Polygon } from 'geojson';
 
 import { Link } from 'react-router-dom';
-import { isObservedNodeInternalId, nodeDetailPath } from '@/lib/node-detail-routes';
+import { nodeDetailPath } from '@/lib/node-detail-routes';
 import { X } from 'lucide-react';
 
 import { buildFeederIconLayer } from '@/components/map/FeederIconLayer';
@@ -267,10 +267,13 @@ export function FeederCoverageMap({
                 Smoothed: {(smoothedRate(selectedTarget.successes, selectedTarget.attempts) * 100).toFixed(0)}%
               </div>
               <Link
-                to={nodeDetailPath({
-                  meshtastic_node_id: selectedTarget.meshtastic_node_id,
-                  node_id_str: selectedTarget.node_id_str,
-                })}
+                to={
+                  nodeDetailPath({
+                    meshtastic_node_id: selectedTarget.meshtastic_node_id,
+                    node_id_str: selectedTarget.node_id_str,
+                    protocol: 1,
+                  }) ?? '#'
+                }
                 className="mt-1 inline-block text-xs text-emerald-400 hover:text-emerald-300 hover:underline"
               >
                 Open details
@@ -308,10 +311,13 @@ export function FeederCoverageMap({
                 {selectedHeardGhost.node_id_str || `!${selectedHeardGhost.meshtastic_node_id.toString(16)}`}
               </div>
               <Link
-                to={nodeDetailPath({
-                  meshtastic_node_id: selectedHeardGhost.meshtastic_node_id,
-                  node_id_str: selectedHeardGhost.node_id_str,
-                })}
+                to={
+                  nodeDetailPath({
+                    meshtastic_node_id: selectedHeardGhost.meshtastic_node_id,
+                    node_id_str: selectedHeardGhost.node_id_str,
+                    protocol: 1,
+                  }) ?? '#'
+                }
                 className="mt-1 inline-block text-xs text-emerald-400 hover:text-emerald-300 hover:underline"
               >
                 Open details
@@ -347,13 +353,13 @@ export function FeederCoverageMap({
                 {selectedFeederMarker.node_id_str || `!${selectedFeederMarker.meshtastic_node_id.toString(16)}`}
               </div>
               <Link
-                to={nodeDetailPath({
-                  internal_id: isObservedNodeInternalId(selectedFeederMarker.managed_node_id)
-                    ? selectedFeederMarker.managed_node_id
-                    : undefined,
-                  meshtastic_node_id: selectedFeederMarker.meshtastic_node_id,
-                  node_id_str: selectedFeederMarker.node_id_str,
-                })}
+                to={
+                  nodeDetailPath({
+                    meshtastic_node_id: selectedFeederMarker.meshtastic_node_id,
+                    node_id_str: selectedFeederMarker.node_id_str,
+                    protocol: 1,
+                  }) ?? '#'
+                }
                 className="mt-1 inline-block text-xs text-emerald-400 hover:text-emerald-300 hover:underline"
               >
                 Open details

--- a/src/components/traceroutes/TracerouteFlowDiagram.tsx
+++ b/src/components/traceroutes/TracerouteFlowDiagram.tsx
@@ -17,7 +17,7 @@ function FlowEndpointBadge({
 }) {
   return (
     <Link
-      to={nodeDetailPath({ meshtastic_node_id: nodeId })}
+      to={nodeDetailPath({ meshtastic_node_id: nodeId, protocol: 1 }) ?? '#'}
       onClick={(e) => e.stopPropagation()}
       className="inline-flex max-w-full rounded-md focus:outline-none focus:ring-2 focus:ring-ring focus:ring-offset-2"
     >
@@ -51,7 +51,10 @@ function NodeBadge({ node }: { node: TracerouteRouteNode }) {
 
   return (
     <Link
-      to={nodeDetailPath({ meshtastic_node_id: node.meshtastic_node_id, node_id_str: node.node_id_str })}
+      to={
+        nodeDetailPath({ meshtastic_node_id: node.meshtastic_node_id, node_id_str: node.node_id_str, protocol: 1 }) ??
+        '#'
+      }
       onClick={(e) => e.stopPropagation()}
       className="inline-flex max-w-full rounded-md focus:outline-none focus:ring-2 focus:ring-ring focus:ring-offset-2"
     >

--- a/src/components/traceroutes/TracerouteHeatmapBackboneRelayTable.tsx
+++ b/src/components/traceroutes/TracerouteHeatmapBackboneRelayTable.tsx
@@ -51,7 +51,13 @@ function RoleNodeTable({ nodes }: { nodes: HeatmapNode[] }) {
           <TableRow key={n.meshtastic_node_id}>
             <TableCell>
               <Link
-                to={nodeDetailPath({ meshtastic_node_id: n.meshtastic_node_id, node_id_str: n.node_id_str })}
+                to={
+                  nodeDetailPath({
+                    meshtastic_node_id: n.meshtastic_node_id,
+                    node_id_str: n.node_id_str,
+                    protocol: 1,
+                  }) ?? '#'
+                }
                 className="font-medium text-primary hover:underline"
               >
                 {getHeatmapNodeLabel(n)}

--- a/src/components/traceroutes/TracerouteHeatmapNodePanel.tsx
+++ b/src/components/traceroutes/TracerouteHeatmapNodePanel.tsx
@@ -78,10 +78,13 @@ export function TracerouteHeatmapNodePanel({
           Last seen: <span className="text-slate-300">{formatRecency(node.last_seen)}</span>
         </div>
         <Link
-          to={nodeDetailPath({
-            meshtastic_node_id: node.meshtastic_node_id,
-            node_id_str: node.node_id_str,
-          })}
+          to={
+            nodeDetailPath({
+              meshtastic_node_id: node.meshtastic_node_id,
+              node_id_str: node.node_id_str,
+              protocol: 1,
+            }) ?? '#'
+          }
           className="mt-1 inline-block text-xs text-emerald-400 hover:text-emerald-300 hover:underline"
         >
           Open details

--- a/src/lib/api/meshflow-api.ts
+++ b/src/lib/api/meshflow-api.ts
@@ -1,4 +1,5 @@
 import { BaseApi } from './base';
+import type { ObservedNodeLookupAmbiguous, ResolveObservedNodeResult } from '@/lib/observed-node-lookup';
 import {
   ObservedNode,
   ManagedNode,
@@ -164,12 +165,31 @@ export class MeshflowApi extends BaseApi {
   }
 
   /**
-   * Get one observed node by stable UUID `internal_id` (`GET /nodes/observed-nodes/{internal_id}/`).
-   * Legacy Meshtastic numeric bookmarks: resolve via list/search or api `by-meshtastic-id` redirect.
+   * Resolve observed node by path segment: UUID, `mt:`/`!`, `mc:`, or bare hex.
+   * Returns ambiguous result (HTTP 300) when bare hex matches multiple protocols.
    */
-  async getObservedNode(internalId: string): Promise<ObservedNode> {
-    const node = await this.get<ObservedNode>(`/nodes/observed-nodes/${internalId}/`);
-    return parseObservedNodeFromAPI(node);
+  async resolveObservedNodeLookup(lookupId: string): Promise<ResolveObservedNodeResult> {
+    const segment = encodeURIComponent(lookupId);
+    const response = await this.axios.get<ObservedNode | ObservedNodeLookupAmbiguous>(
+      `/nodes/observed-nodes/${segment}/`,
+      { validateStatus: (status) => status === 200 || status === 300 }
+    );
+    if (response.status === 300) {
+      const body = response.data as ObservedNodeLookupAmbiguous;
+      return { status: 'ambiguous', ambiguous: body };
+    }
+    return { status: 'ok', node: parseObservedNodeFromAPI(response.data as ObservedNode) };
+  }
+
+  /**
+   * Get one observed node (`GET /nodes/observed-nodes/{id}/`). Throws if lookup is ambiguous (300).
+   */
+  async getObservedNode(lookupId: string): Promise<ObservedNode> {
+    const result = await this.resolveObservedNodeLookup(lookupId);
+    if (result.status === 'ambiguous') {
+      throw new Error('Multiple nodes match this id');
+    }
+    return result.node;
   }
 
   /** @deprecated Use {@link getObservedNode} */

--- a/src/lib/mesh-protocol.ts
+++ b/src/lib/mesh-protocol.ts
@@ -1,4 +1,5 @@
 import type { MeshProtocol } from '@/lib/models';
+import { nodeDetailPath } from '@/lib/node-detail-routes';
 
 export type ProtocolSlug = 'meshtastic' | 'meshcore';
 
@@ -44,7 +45,7 @@ export const MESHTASTIC_CONFIG: ProtocolPageConfig = {
     nodes: '/nodes',
     managedNodes: '/nodes/managed-nodes',
     messages: '/messages',
-    nodeDetail: (internalId) => `/nodes/${internalId}`,
+    nodeDetail: (id) => nodeDetailPath({ internal_id: id, protocol: 1 }) ?? `/nodes/${id}`,
   },
   features: {
     constellationsOnMap: true,
@@ -70,7 +71,7 @@ export const MESHCORE_CONFIG: ProtocolPageConfig = {
     nodes: '/meshcore/nodes',
     managedNodes: '/meshcore/managed-nodes',
     messages: '/meshcore/messages',
-    nodeDetail: (internalId) => `/nodes/${internalId}`,
+    nodeDetail: (id) => nodeDetailPath({ internal_id: id, protocol: 2 }) ?? `/nodes/${id}`,
   },
   features: {
     constellationsOnMap: false,

--- a/src/lib/node-detail-routes.test.ts
+++ b/src/lib/node-detail-routes.test.ts
@@ -1,35 +1,54 @@
 import { describe, expect, it } from 'vitest';
-import { isObservedNodeInternalId, nodeDetailPath } from '@/lib/node-detail-routes';
+import { isObservedNodeInternalId, nodeDetailPath, observedNodeDetailPath } from '@/lib/node-detail-routes';
 
 const VALID_UUID = 'a1b2c3d4-e5f6-4789-a012-8456789abcde';
 
 describe('nodeDetailPath', () => {
-  it('prefers internal_id UUID', () => {
+  it('uses ! node_id_str for Meshtastic when protocol known', () => {
     expect(
       nodeDetailPath({
+        protocol: 1,
+        node_id_str: '!12345678',
         internal_id: VALID_UUID,
-        meshtastic_node_id: 42,
-        node_id_str: '!0000002a',
       })
-    ).toBe(`/nodes/${VALID_UUID}`);
+    ).toBe('/nodes/!12345678');
   });
 
-  it('uses legacy meshtastic numeric id when no UUID', () => {
-    expect(nodeDetailPath({ meshtastic_node_id: 42, node_id_str: '!0000002a' })).toBe('/nodes/42');
-  });
-
-  it('encodes MeshCore node_id_str when numeric id is zero', () => {
+  it('uses mc: for MeshCore when protocol known', () => {
     expect(
       nodeDetailPath({
-        meshtastic_node_id: 0,
-        node_id_str: 'mc:deadbeefcafe',
         protocol: 2,
+        node_id_str: 'mc:deadbeefcafe',
+        meshtastic_node_id: 0,
       })
     ).toBe('/nodes/mc%3Adeadbeefcafe');
+  });
+
+  it('builds ! from meshtastic_node_id when protocol Meshtastic and no node_id_str', () => {
+    expect(nodeDetailPath({ protocol: 1, meshtastic_node_id: 42 })).toBe('/nodes/!0000002a');
+  });
+
+  it('uses bare hex when protocol unknown', () => {
+    expect(nodeDetailPath({ node_id_str: 'abcdef01' })).toBe('/nodes/abcdef01');
+  });
+
+  it('returns null when no linkable id', () => {
+    expect(nodeDetailPath({ protocol: 2, meshtastic_node_id: 0 })).toBeNull();
   });
 
   it('isObservedNodeInternalId rejects mc prefix paths', () => {
     expect(isObservedNodeInternalId('mc:abc')).toBe(false);
     expect(isObservedNodeInternalId(VALID_UUID)).toBe(true);
+  });
+
+  it('observedNodeDetailPath prefers node_id_str over uuid', () => {
+    expect(
+      observedNodeDetailPath({
+        internal_id: VALID_UUID,
+        protocol: 1,
+        meshtastic_node_id: 0x12345678,
+        node_id_str: '!12345678',
+      })
+    ).toBe('/nodes/!12345678');
   });
 });

--- a/src/lib/node-detail-routes.ts
+++ b/src/lib/node-detail-routes.ts
@@ -1,6 +1,9 @@
-import type { ObservedNode } from '@/lib/models';
+import type { MeshProtocol, ObservedNode } from '@/lib/models';
 
 const UUID_RE = /^[0-9a-f]{8}-[0-9a-f]{4}-[1-5][0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/i;
+
+const PROTOCOL_MESHTASTIC: MeshProtocol = 1;
+const PROTOCOL_MESHCORE: MeshProtocol = 2;
 
 export function isObservedNodeInternalId(id: string): boolean {
   return UUID_RE.test(id);
@@ -10,30 +13,117 @@ export type NodeDetailLinkInput = {
   internal_id?: string | number | null;
   meshtastic_node_id?: number | null;
   node_id_str?: string | null;
-  protocol?: number | null;
+  protocol?: MeshProtocol | number | null;
 };
+
+function encodeNodeSegment(segment: string): string {
+  return `/nodes/${encodeURIComponent(segment)}`;
+}
+
+function meshtasticPathFromNodeIdStr(nodeIdStr: string): string {
+  const trimmed = nodeIdStr.trim();
+  if (trimmed.startsWith('!') || trimmed.toLowerCase().startsWith('mt:')) {
+    return encodeNodeSegment(trimmed);
+  }
+  const hex = trimmed.replace(/^!/, '').toLowerCase();
+  if (/^[0-9a-f]{8}$/.test(hex)) {
+    return encodeNodeSegment(`!${hex}`);
+  }
+  return encodeNodeSegment(trimmed);
+}
+
+function meshcorePathFromNodeIdStr(nodeIdStr: string): string {
+  const trimmed = nodeIdStr.trim();
+  if (trimmed.toLowerCase().startsWith('mc:')) {
+    return encodeNodeSegment(trimmed);
+  }
+  const hex = trimmed.replace(/^mc:/i, '').toLowerCase();
+  if (hex && /^[0-9a-f]+$/.test(hex)) {
+    return encodeNodeSegment(`mc:${hex}`);
+  }
+  return encodeNodeSegment(trimmed);
+}
+
+function barePathFromNodeIdStr(nodeIdStr: string): string {
+  const trimmed = nodeIdStr.trim();
+  if (trimmed.startsWith('!')) {
+    return encodeNodeSegment(trimmed);
+  }
+  if (trimmed.toLowerCase().startsWith('mc:')) {
+    return encodeNodeSegment(trimmed);
+  }
+  if (trimmed.toLowerCase().startsWith('mt:')) {
+    return encodeNodeSegment(trimmed);
+  }
+  const hex = trimmed.toLowerCase().replace(/^0x/, '');
+  if (hex && /^[0-9a-f]+$/.test(hex)) {
+    return encodeNodeSegment(hex);
+  }
+  return encodeNodeSegment(trimmed);
+}
 
 /**
  * React Router path for observed node detail (`/nodes/:id`).
- * Prefers stable `internal_id`, then legacy Meshtastic numeric id, then encoded `node_id_str` (MeshCore).
+ * Prefers protocol-specific `node_id_str` (!… / mc:…); bare hex when protocol unknown.
  */
-export function nodeDetailPath(input: NodeDetailLinkInput): string {
+export function nodeDetailPath(input: NodeDetailLinkInput): string | null {
+  const nodeIdStr = input.node_id_str?.trim();
+  const protocol = input.protocol;
+
+  if (protocol === PROTOCOL_MESHCORE) {
+    if (nodeIdStr) {
+      return meshcorePathFromNodeIdStr(nodeIdStr);
+    }
+    return null;
+  }
+
+  if (protocol === PROTOCOL_MESHTASTIC) {
+    if (nodeIdStr) {
+      return meshtasticPathFromNodeIdStr(nodeIdStr);
+    }
+    const numericId = input.meshtastic_node_id;
+    if (numericId != null && numericId > 0) {
+      return encodeNodeSegment(`!${numericId.toString(16).padStart(8, '0')}`);
+    }
+    return null;
+  }
+
+  if (nodeIdStr) {
+    return barePathFromNodeIdStr(nodeIdStr);
+  }
+
+  const numericId = input.meshtastic_node_id;
+  if (numericId != null && numericId > 0) {
+    return encodeNodeSegment(`!${numericId.toString(16).padStart(8, '0')}`);
+  }
+
   const rawInternalId = input.internal_id;
   const internalId = rawInternalId == null || rawInternalId === '' ? '' : String(rawInternalId).trim();
   if (internalId && isObservedNodeInternalId(internalId)) {
-    return `/nodes/${internalId}`;
+    return encodeNodeSegment(internalId);
   }
-  const numericId = input.meshtastic_node_id;
-  if (numericId != null && numericId > 0) {
-    return `/nodes/${numericId}`;
-  }
-  const nodeIdStr = input.node_id_str?.trim();
-  if (nodeIdStr) {
-    return `/nodes/${encodeURIComponent(nodeIdStr)}`;
-  }
-  return '/nodes/0';
+
+  return null;
 }
 
-export function observedNodeDetailPath(node: Pick<ObservedNode, 'internal_id'>): string {
-  return nodeDetailPath({ internal_id: node.internal_id });
+export function observedNodeDetailPath(
+  node: Pick<ObservedNode, 'node_id_str' | 'protocol' | 'meshtastic_node_id' | 'internal_id'>
+): string | null {
+  return nodeDetailPath({
+    node_id_str: node.node_id_str,
+    protocol: node.protocol,
+    meshtastic_node_id: node.meshtastic_node_id,
+    internal_id: node.internal_id,
+  });
+}
+
+/** Path segment for API lookup from a 300-choice row. */
+export function nodeDetailPathFromLookupChoice(choice: {
+  node_id_str: string;
+  protocol: MeshProtocol | number;
+}): string | null {
+  return nodeDetailPath({
+    node_id_str: choice.node_id_str,
+    protocol: choice.protocol as MeshProtocol,
+  });
 }

--- a/src/lib/observed-node-lookup.ts
+++ b/src/lib/observed-node-lookup.ts
@@ -1,0 +1,24 @@
+import type { MeshProtocol, ObservedNode } from '@/lib/models';
+
+export type ObservedNodeLookupChoice = {
+  internal_id: string;
+  protocol: MeshProtocol;
+  node_id_str: string;
+  short_name: string;
+  long_name: string;
+};
+
+export type ObservedNodeLookupAmbiguous = {
+  detail: string;
+  choices: ObservedNodeLookupChoice[];
+};
+
+export type ResolveObservedNodeResult =
+  | { status: 'ok'; node: ObservedNode }
+  | { status: 'ambiguous'; ambiguous: ObservedNodeLookupAmbiguous };
+
+export function isObservedNodeLookupAmbiguous(
+  value: ResolveObservedNodeResult
+): value is { status: 'ambiguous'; ambiguous: ObservedNodeLookupAmbiguous } {
+  return value.status === 'ambiguous';
+}

--- a/src/pages/nodes/DxMonitoringPage.tsx
+++ b/src/pages/nodes/DxMonitoringPage.tsx
@@ -15,6 +15,13 @@ import type {
   DxReasonCode,
 } from '@/lib/models';
 import { TRIGGER_TYPE_DX_WATCH, TRIGGER_TYPE_NEW_NODE_BASELINE } from '@/lib/traceroute-trigger-type';
+import { nodeDetailPath } from '@/lib/node-detail-routes';
+
+function dxObservedNodePath(node: { node_id_str: string; meshtastic_node_id: number }): string {
+  return (
+    nodeDetailPath({ node_id_str: node.node_id_str, protocol: 1, meshtastic_node_id: node.meshtastic_node_id }) ?? '#'
+  );
+}
 import {
   useDxActiveEventCount,
   useDxEventDetail,
@@ -431,7 +438,7 @@ export default function DxMonitoringPage() {
                       <TableCell>
                         <div className="flex flex-col gap-1 max-w-[16rem]">
                           <NodeLinkLabel
-                            to={`/nodes/${row.destination.internal_id}`}
+                            to={dxObservedNodePath(row.destination)}
                             {...formatDestinationLabel(row.destination)}
                           />
                           {row.destination.dx_metadata.exclude_from_detection && (
@@ -444,7 +451,7 @@ export default function DxMonitoringPage() {
                       <TableCell className="text-sm max-w-[12rem]">
                         {row.last_observer ? (
                           <NodeLinkLabel
-                            to={`/nodes/${row.last_observer.internal_id}`}
+                            to={dxObservedNodePath(row.last_observer)}
                             {...formatObserverLabel(row.last_observer)}
                           />
                         ) : (
@@ -535,7 +542,7 @@ export default function DxMonitoringPage() {
                 <div className="text-muted-foreground">Destination</div>
                 <div className="flex flex-wrap items-center gap-2 mt-1">
                   <NodeLinkLabel
-                    to={`/nodes/${detailQuery.data.destination.internal_id}`}
+                    to={dxObservedNodePath(detailQuery.data.destination)}
                     {...formatDestinationLabel(detailQuery.data.destination)}
                   />
                   {detailQuery.data.destination.dx_metadata.exclude_from_detection && (
@@ -574,7 +581,7 @@ export default function DxMonitoringPage() {
                             <TableCell className="text-xs whitespace-nowrap">{formatWhen(o.observed_at)}</TableCell>
                             <TableCell className="text-xs max-w-[12rem]">
                               <NodeLinkLabel
-                                to={`/nodes/${o.observer.internal_id}`}
+                                to={dxObservedNodePath(o.observer)}
                                 primary={obsLabel.primary}
                                 idSecondary={obsLabel.idSecondary}
                               />
@@ -683,7 +690,7 @@ export default function DxMonitoringPage() {
                                     <TableCell className="text-xs max-w-[10rem]">
                                       {row.source_node ? (
                                         <NodeLinkLabel
-                                          to={`/nodes/${row.source_node.internal_id}`}
+                                          to={dxObservedNodePath(row.source_node)}
                                           {...formatObserverLabel(row.source_node)}
                                         />
                                       ) : (
@@ -692,7 +699,7 @@ export default function DxMonitoringPage() {
                                     </TableCell>
                                     <TableCell className="text-xs max-w-[10rem]">
                                       <NodeLinkLabel
-                                        to={`/nodes/${row.destination.internal_id}`}
+                                        to={dxObservedNodePath(row.destination)}
                                         {...formatHopLabel(row.destination)}
                                       />
                                     </TableCell>

--- a/src/pages/nodes/ManagedNodesStatus.tsx
+++ b/src/pages/nodes/ManagedNodesStatus.tsx
@@ -450,11 +450,13 @@ function ProtocolManagedNodesPageContent({
                         </TableCell>
                         <TableCell>
                           <Link
-                            to={nodeDetailPath({
-                              meshtastic_node_id: node.meshtastic_node_id,
-                              node_id_str: node.node_id_str,
-                              protocol: node.protocol,
-                            })}
+                            to={
+                              nodeDetailPath({
+                                meshtastic_node_id: node.meshtastic_node_id,
+                                node_id_str: node.node_id_str,
+                                protocol: node.protocol,
+                              }) ?? '#'
+                            }
                             className="text-primary hover:underline"
                           >
                             {node.short_name ?? '—'}
@@ -462,11 +464,13 @@ function ProtocolManagedNodesPageContent({
                         </TableCell>
                         <TableCell>
                           <Link
-                            to={nodeDetailPath({
-                              meshtastic_node_id: node.meshtastic_node_id,
-                              node_id_str: node.node_id_str,
-                              protocol: node.protocol,
-                            })}
+                            to={
+                              nodeDetailPath({
+                                meshtastic_node_id: node.meshtastic_node_id,
+                                node_id_str: node.node_id_str,
+                                protocol: node.protocol,
+                              }) ?? '#'
+                            }
                             className="text-primary hover:underline"
                           >
                             {node.long_name ?? node.node_id_str}

--- a/src/pages/nodes/MeshInfrastructure.tsx
+++ b/src/pages/nodes/MeshInfrastructure.tsx
@@ -23,6 +23,7 @@ import { Label } from '@/components/ui/label';
 import { Badge } from '@/components/ui/badge';
 import { Button } from '@/components/ui/button';
 import { ObservedNode, type NodeWatch } from '@/lib/models';
+import { observedNodeDetailPath } from '@/lib/node-detail-routes';
 import { filterManagedNodesForMapDisplay } from '@/lib/managed-node-status';
 import { MeshWatchControls } from '@/components/nodes/MeshWatchControls';
 import { Battery, MapPinOff } from 'lucide-react';
@@ -326,7 +327,7 @@ function MeshInfrastructureContent() {
                         <div className="flex flex-col gap-0.5">
                           <div className="flex items-center gap-2">
                             <Link
-                              to={`/nodes/${node.internal_id}`}
+                              to={observedNodeDetailPath(node) ?? '#'}
                               className="font-medium text-primary hover:underline"
                             >
                               {node.long_name} ({node.short_name || node.node_id_str})
@@ -387,7 +388,10 @@ function MeshInfrastructureContent() {
                       </TableCell>
                       <TableCell>
                         <div className="flex flex-col items-start gap-1 sm:flex-row sm:items-center sm:gap-3">
-                          <Link to={`/nodes/${node.internal_id}`} className="text-primary text-sm hover:underline">
+                          <Link
+                            to={observedNodeDetailPath(node) ?? '#'}
+                            className="text-primary text-sm hover:underline"
+                          >
                             View details
                           </Link>
                           {managed != null && (
@@ -520,7 +524,7 @@ function MeshInfrastructureContent() {
                           <div className="flex flex-col gap-0.5">
                             <div className="flex items-center gap-2">
                               <Link
-                                to={`/nodes/${node.internal_id}`}
+                                to={observedNodeDetailPath(node) ?? '#'}
                                 className="font-medium text-primary hover:underline"
                               >
                                 {node.long_name} ({node.short_name || node.node_id_str})
@@ -609,7 +613,10 @@ function MeshInfrastructureContent() {
                         </TableCell>
                         <TableCell>
                           <div className="flex flex-col items-start gap-1 sm:flex-row sm:items-center sm:gap-3">
-                            <Link to={`/nodes/${node.internal_id}`} className="text-primary text-sm hover:underline">
+                            <Link
+                              to={observedNodeDetailPath(node) ?? '#'}
+                              className="text-primary text-sm hover:underline"
+                            >
                               View details
                             </Link>
                             {managed != null && (

--- a/src/pages/nodes/NodeDetails.tsx
+++ b/src/pages/nodes/NodeDetails.tsx
@@ -1,91 +1,19 @@
-import { Suspense, useEffect } from 'react';
-import { useNavigate, useParams } from 'react-router-dom';
+import { Suspense } from 'react';
+import { useParams } from 'react-router-dom';
 import { useQuery } from '@tanstack/react-query';
 import { NodeDetailContent } from '@/components/nodes/NodeDetailContent';
 import { useNodeDetailPageTabs } from '@/pages/nodes/useNodeDetailPageTabs';
 import { useMeshflowApi } from '@/hooks/api/useApi';
-import { isObservedNodeInternalId } from '@/lib/node-detail-routes';
-
-function LegacyMeshtasticNodeRedirect({ meshtasticNodeId }: { meshtasticNodeId: number }) {
-  const navigate = useNavigate();
-  const api = useMeshflowApi();
-  const { data, isError } = useQuery({
-    queryKey: ['observed-node-resolve', meshtasticNodeId],
-    queryFn: async () => {
-      const page = await api.getObservedNodes({ protocol: 'meshtastic', page_size: 1000 });
-      const match = page.results.find((n) => n.meshtastic_node_id === meshtasticNodeId);
-      if (!match) {
-        throw new Error('Node not found');
-      }
-      return match.internal_id;
-    },
-    retry: false,
-  });
-
-  useEffect(() => {
-    if (data) {
-      navigate(`/nodes/${data}`, { replace: true });
-    }
-  }, [data, navigate]);
-
-  if (isError) {
-    return (
-      <div className="p-8 text-center text-muted-foreground">
-        No observed node found for Meshtastic id {meshtasticNodeId}.
-      </div>
-    );
-  }
-
-  return (
-    <div className="flex min-h-screen items-center justify-center">
-      <div className="h-12 w-12 animate-spin rounded-full border-b-2 border-t-2 border-teal-500" />
-    </div>
-  );
-}
-
-function NodeIdStrRedirect({ nodeIdStr }: { nodeIdStr: string }) {
-  const navigate = useNavigate();
-  const api = useMeshflowApi();
-  const { data, isError } = useQuery({
-    queryKey: ['observed-node-resolve-str', nodeIdStr],
-    queryFn: async () => {
-      const results = await api.searchNodes(nodeIdStr);
-      const exact = results.find((n) => n.node_id_str === nodeIdStr);
-      const match = exact ?? results[0];
-      if (!match?.internal_id) {
-        throw new Error('Node not found');
-      }
-      return String(match.internal_id);
-    },
-    retry: false,
-  });
-
-  useEffect(() => {
-    if (data) {
-      navigate(`/nodes/${data}`, { replace: true });
-    }
-  }, [data, navigate]);
-
-  if (isError) {
-    return <div className="p-8 text-center text-muted-foreground">No observed node found for id {nodeIdStr}.</div>;
-  }
-
-  return (
-    <div className="flex min-h-screen items-center justify-center">
-      <div className="h-12 w-12 animate-spin rounded-full border-b-2 border-t-2 border-teal-500" />
-    </div>
-  );
-}
+import { NodeLookupPicker } from '@/pages/nodes/NodeLookupPicker';
+import { isObservedNodeLookupAmbiguous } from '@/lib/observed-node-lookup';
 
 export function NodeDetails() {
   const { id } = useParams<{ id: string }>();
   const { activeTab, onTabChange } = useNodeDetailPageTabs();
-
-  if (!id) {
-    return null;
-  }
+  const api = useMeshflowApi();
 
   const decodedId = (() => {
+    if (!id) return '';
     try {
       return decodeURIComponent(id);
     } catch {
@@ -93,17 +21,45 @@ export function NodeDetails() {
     }
   })();
 
-  if (/^\d+$/.test(decodedId)) {
-    return <LegacyMeshtasticNodeRedirect meshtasticNodeId={Number(decodedId)} />;
+  const { data, isPending, isError, error } = useQuery({
+    queryKey: ['observed-node-lookup', decodedId],
+    queryFn: () => api.resolveObservedNodeLookup(decodedId),
+    enabled: Boolean(decodedId),
+    retry: false,
+  });
+
+  if (!id) {
+    return null;
   }
 
-  if (decodedId.startsWith('mc:') || decodedId.startsWith('!')) {
-    return <NodeIdStrRedirect nodeIdStr={decodedId} />;
+  if (isPending) {
+    return (
+      <div className="flex min-h-screen items-center justify-center">
+        <div className="h-12 w-12 animate-spin rounded-full border-b-2 border-t-2 border-teal-500" />
+      </div>
+    );
   }
 
-  if (!isObservedNodeInternalId(decodedId)) {
-    return <div className="p-8 text-center text-muted-foreground">Invalid node id in URL.</div>;
+  if (isError) {
+    return (
+      <div className="p-8 text-center text-muted-foreground">
+        No observed node found for id {decodedId}.
+        {error instanceof Error && error.message ? (
+          <p className="mt-2 text-sm text-muted-foreground/80">{error.message}</p>
+        ) : null}
+      </div>
+    );
   }
+
+  if (data && isObservedNodeLookupAmbiguous(data)) {
+    return <NodeLookupPicker lookupId={decodedId} choices={data.ambiguous.choices} />;
+  }
+
+  if (!data || data.status !== 'ok') {
+    return null;
+  }
+
+  const internalId = String(data.node.internal_id);
 
   return (
     <Suspense
@@ -113,7 +69,7 @@ export function NodeDetails() {
         </div>
       }
     >
-      <NodeDetailContent internalId={decodedId} activeTab={activeTab} onTabChange={onTabChange} />
+      <NodeDetailContent internalId={internalId} activeTab={activeTab} onTabChange={onTabChange} />
     </Suspense>
   );
 }

--- a/src/pages/nodes/NodeLookupPicker.tsx
+++ b/src/pages/nodes/NodeLookupPicker.tsx
@@ -1,0 +1,64 @@
+import { Link, useNavigate } from 'react-router-dom';
+import { Button } from '@/components/ui/button';
+import { Card, CardContent, CardDescription, CardHeader, CardTitle } from '@/components/ui/card';
+import { nodeDetailPathFromLookupChoice } from '@/lib/node-detail-routes';
+import type { ObservedNodeLookupChoice } from '@/lib/observed-node-lookup';
+import { MESHCORE_CONFIG, MESHTASTIC_CONFIG } from '@/lib/mesh-protocol';
+
+type NodeLookupPickerProps = {
+  lookupId: string;
+  choices: ObservedNodeLookupChoice[];
+};
+
+export function NodeLookupPicker({ lookupId, choices }: NodeLookupPickerProps) {
+  const navigate = useNavigate();
+
+  return (
+    <div className="flex min-h-[60vh] items-center justify-center p-6">
+      <Card className="w-full max-w-lg">
+        <CardHeader>
+          <CardTitle>Which node did you mean?</CardTitle>
+          <CardDescription>
+            The id <span className="font-mono text-foreground">{lookupId}</span> matches nodes on more than one
+            protocol. Choose one to continue.
+          </CardDescription>
+        </CardHeader>
+        <CardContent className="flex flex-col gap-4">
+          {choices.map((choice) => {
+            const path = nodeDetailPathFromLookupChoice(choice);
+            const label =
+              choice.long_name || choice.short_name
+                ? `${choice.long_name || ''}${choice.short_name ? ` (${choice.short_name})` : ''}`.trim()
+                : choice.node_id_str;
+            const isMeshtastic = choice.protocol === 1;
+            const section = isMeshtastic ? MESHTASTIC_CONFIG.labels.section : MESHCORE_CONFIG.labels.section;
+            if (!path) {
+              return null;
+            }
+            return (
+              <Button
+                key={choice.internal_id}
+                size="lg"
+                variant="outline"
+                className="h-auto min-h-14 flex-col items-start gap-1 py-4 text-left"
+                asChild
+              >
+                <Link
+                  to={path}
+                  onClick={(e) => {
+                    e.preventDefault();
+                    navigate(path, { replace: true });
+                  }}
+                >
+                  <span className="text-base font-semibold">{section}</span>
+                  <span className="font-mono text-sm text-muted-foreground">{choice.node_id_str}</span>
+                  {label ? <span className="text-sm">{label}</span> : null}
+                </Link>
+              </Button>
+            );
+          })}
+        </CardContent>
+      </Card>
+    </div>
+  );
+}

--- a/src/pages/traceroutes/TracerouteDetailModal.tsx
+++ b/src/pages/traceroutes/TracerouteDetailModal.tsx
@@ -87,11 +87,13 @@ export function TracerouteDetailModal({ tracerouteId, open, onOpenChange }: Trac
             {traceroute ? (
               <>
                 <Link
-                  to={nodeDetailPath({
-                    meshtastic_node_id: traceroute.source_node.meshtastic_node_id,
-                    node_id_str: traceroute.source_node.node_id_str,
-                    protocol: traceroute.source_node.protocol,
-                  })}
+                  to={
+                    nodeDetailPath({
+                      meshtastic_node_id: traceroute.source_node.meshtastic_node_id,
+                      node_id_str: traceroute.source_node.node_id_str,
+                      protocol: traceroute.source_node.protocol,
+                    }) ?? '#'
+                  }
                   onClick={(e) => e.stopPropagation()}
                   className="font-medium text-primary underline-offset-4 hover:underline"
                 >
@@ -99,7 +101,7 @@ export function TracerouteDetailModal({ tracerouteId, open, onOpenChange }: Trac
                 </Link>
                 <span aria-hidden>→</span>
                 <Link
-                  to={observedNodeDetailPath(traceroute.target_node)}
+                  to={observedNodeDetailPath(traceroute.target_node) ?? '#'}
                   onClick={(e) => e.stopPropagation()}
                   className="font-medium text-primary underline-offset-4 hover:underline"
                 >
@@ -124,11 +126,13 @@ export function TracerouteDetailModal({ tracerouteId, open, onOpenChange }: Trac
               <Badge variant="outline" className="gap-1">
                 <span className="text-muted-foreground">Source:</span>
                 <Link
-                  to={nodeDetailPath({
-                    meshtastic_node_id: traceroute.source_node.meshtastic_node_id,
-                    node_id_str: traceroute.source_node.node_id_str,
-                    protocol: traceroute.source_node.protocol,
-                  })}
+                  to={
+                    nodeDetailPath({
+                      meshtastic_node_id: traceroute.source_node.meshtastic_node_id,
+                      node_id_str: traceroute.source_node.node_id_str,
+                      protocol: traceroute.source_node.protocol,
+                    }) ?? '#'
+                  }
                   onClick={(e) => e.stopPropagation()}
                   className="text-primary underline-offset-4 hover:underline"
                 >
@@ -138,7 +142,7 @@ export function TracerouteDetailModal({ tracerouteId, open, onOpenChange }: Trac
               <Badge variant="outline" className="gap-1">
                 <span className="text-muted-foreground">Target:</span>
                 <Link
-                  to={observedNodeDetailPath(traceroute.target_node)}
+                  to={observedNodeDetailPath(traceroute.target_node) ?? '#'}
                   onClick={(e) => e.stopPropagation()}
                   className="text-primary underline-offset-4 hover:underline"
                 >

--- a/src/pages/user/NodeSettings.tsx
+++ b/src/pages/user/NodeSettings.tsx
@@ -132,7 +132,10 @@ function NodeSettingsContent() {
                         </div>
                       </div>
                       <div className="mt-2 flex gap-2">
-                        <Link to={observedNodeDetailPath(node)} className="text-blue-500 hover:text-blue-700 text-sm">
+                        <Link
+                          to={observedNodeDetailPath(node) ?? '#'}
+                          className="text-blue-500 hover:text-blue-700 text-sm"
+                        >
                           View Node
                         </Link>
                         {!managedNodeIds.has(node.meshtastic_node_id) && (
@@ -749,12 +752,14 @@ function ManagedNodeSettings({
     <div className="space-y-4 pt-2">
       <div className="flex flex-wrap gap-2">
         <Link
-          to={nodeDetailPath({
-            internal_id: node.internal_id,
-            meshtastic_node_id: node.meshtastic_node_id,
-            node_id_str: node.node_id_str,
-            protocol: node.protocol,
-          })}
+          to={
+            nodeDetailPath({
+              internal_id: node.internal_id,
+              meshtastic_node_id: node.meshtastic_node_id,
+              node_id_str: node.node_id_str,
+              protocol: node.protocol,
+            }) ?? '#'
+          }
         >
           <Button variant="outline" size="sm">
             View Node Details


### PR DESCRIPTION
# Summary

Closes #280. Pair with **[meshflow-api #348](https://github.com/pskillen/meshflow-api/pull/348)** (deploy API first or together).

- **`nodeDetailPath`**: prefer `!…` / `mc:…` when protocol is known; bare hex when unknown; never `/nodes/0`
- **`NodeDetails`**: single API `resolveObservedNodeLookup`; **HTTP 300** → `NodeLookupPicker` (large protocol buttons)
- **Links audit**: maps, messages, node cards, traceroutes, infrastructure, DX, search — use prefixed paths
- Removed client-side 1000-node list scan and UUID redirect hacks

## Testing performed

- [x] `npm test` (301 tests)
- [x] `npm run lint` (warnings only)
- [ ] Manual: map click → `!` or `mc:` URL; bare hex bookmark → picker when ambiguous

## Deploy notes

Requires API #348 on the backend for resolve/300 behaviour.