### PR TITLE
feat(routes): anonymous public browsing for observatory routes (#298)

### DIFF
--- a/docs/PERMISSIONS.md
+++ b/docs/PERMISSIONS.md
@@ -1,0 +1,31 @@
+# UI permissions and routes
+
+Parent API epic: [meshflow-api #346](https://github.com/pskillen/meshflow-api/issues/346). UI work: [#298](https://github.com/pskillen/meshflow-ui/issues/298).
+
+API contract: [meshflow-api `docs/permissions/README.md`](https://github.com/pskillen/meshflow-api/blob/main/docs/permissions/README.md).
+
+## Route matrix
+
+| Route                                                  | Guest (logged out) | User (JWT) | Notes                                         |
+| ------------------------------------------------------ | ------------------ | ---------- | --------------------------------------------- |
+| `/`, `/nodes`, `/nodes/:id`                            | yes                | yes        | Map/detail use redacted API fields when guest |
+| `/map`                                                 | yes                | yes        | Positions only when authenticated             |
+| `/messages`, `/meshcore/messages`                      | yes                | yes        |                                               |
+| `/traceroutes/*` (read pages)                          | yes                | yes        | Trigger UI needs feeder                       |
+| `/login`, `/auth/callback`                             | yes                | yes        |                                               |
+| `/nodes/:id/claim`, `/nodes/my-nodes`                  | no                 | yes        | Protected                                     |
+| `/user/*`, `/nodes/monitor`, `/nodes/dx-monitoring`    | no                 | yes        | Protected                                     |
+| `/nodes/infrastructure/export`, `/nodes/managed-nodes` | no                 | feeder+    | Protected; operator pages                     |
+| `/user/api-keys`                                       | no                 | feeder+    | Protected                                     |
+
+## Implementation
+
+- **Public routes** use `AppLayout` without `ProtectedRoute` ([`src/App.tsx`](../src/App.tsx)).
+- **Protected routes** wrap `AppLayout` in `ProtectedRoute`.
+- **API client** ([`src/lib/api/base.ts`](../src/lib/api/base.ts)): anonymous `GET` without a token does not force login redirect on 401.
+- **Playwright**: `VITE_BROWSER_TEST=true` still bypasses auth in `ProtectedRoute` ([`docs/TESTING.md`](TESTING.md)).
+
+## Follow-ups
+
+- Login CTAs on claim, watches, traceroute trigger for non-feeder users.
+- E2E test with real anonymous session (no `VITE_BROWSER_TEST`).

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -13,7 +13,6 @@ import { WebSocketProvider } from '@/providers/WebSocketProvider';
 
 import { NodesList } from '@/pages/nodes/NodesList';
 import { MeshInfrastructure } from '@/pages/nodes/MeshInfrastructure';
-import { InfrastructureExport } from '@/pages/nodes/InfrastructureExport';
 import { Weather } from '@/pages/Weather';
 import { NodeMap } from '@/pages/map/NodeMap';
 import { MessageHistory } from '@/pages/messages/MessageHistory';
@@ -38,6 +37,9 @@ const ManagedNodesStatus = lazy(() => import('@/pages/nodes/ManagedNodesStatus')
 const MeshCoreManagedNodesStatus = lazy(() =>
   import('@/pages/nodes/ManagedNodesStatus').then((m) => ({ default: m.MeshCoreManagedNodesStatus }))
 );
+const InfrastructureExport = lazy(() =>
+  import('@/pages/nodes/InfrastructureExport').then((m) => ({ default: m.InfrastructureExport }))
+);
 
 function App() {
   return (
@@ -47,49 +49,19 @@ function App() {
           <AuthProvider>
             <WebSocketProvider>
               <Routes>
-                {/* Public routes */}
                 <Route path="/login" element={<LoginPage />} />
                 <Route path="/auth/callback" element={<OAuthCallback />} />
 
-                {/* Protected routes with AppLayout */}
-                <Route
-                  element={
-                    <ProtectedRoute>
-                      <AppLayout />
-                    </ProtectedRoute>
-                  }
-                >
+                {/* Public observatory (guest or authenticated) — meshflow-ui #298 */}
+                <Route element={<AppLayout />}>
                   <Route path="/" element={<Dashboard />} />
                   <Route path="/nodes" element={<NodesList />} />
-                  <Route path="/nodes/infrastructure" element={<MeshInfrastructure />} />
-                  <Route path="/nodes/infrastructure/export" element={<InfrastructureExport />} />
-                  <Route
-                    path="/nodes/managed-nodes"
-                    element={
-                      <Suspense fallback={<div>Loading managed nodes...</div>}>
-                        <ManagedNodesStatus />
-                      </Suspense>
-                    }
-                  />
-                  <Route path="/weather" element={<Weather />} />
-                  <Route path="/nodes/my-nodes" element={<MyNodes />} />
-                  <Route path="/nodes/monitor" element={<MonitorNodes />} />
-                  <Route path="/nodes/dx-monitoring" element={<DxMonitoringPage />} />
-                  <Route path="/nodes/:id/claim" element={<ClaimNode />} />
                   <Route path="/nodes/:id" element={<NodeDetails />} />
                   <Route path="/map" element={<NodeMap />} />
-                  <Route path="/meshcore/map" element={<Navigate to="/meshcore/nodes" replace />} />
+                  <Route path="/messages" element={<MessageHistory />} />
                   <Route path="/meshcore/nodes" element={<MeshCoreNodesList />} />
                   <Route path="/meshcore/messages" element={<MeshCoreMessages />} />
-                  <Route
-                    path="/meshcore/managed-nodes"
-                    element={
-                      <Suspense fallback={<div>Loading managed nodes...</div>}>
-                        <MeshCoreManagedNodesStatus />
-                      </Suspense>
-                    }
-                  />
-                  <Route path="/messages" element={<MessageHistory />} />
+                  <Route path="/meshcore/map" element={<Navigate to="/meshcore/nodes" replace />} />
                   <Route path="/traceroutes/history" element={<TracerouteHistory />} />
                   <Route path="/traceroutes" element={<TraceroutesLanding />} />
                   <Route path="/traceroutes/heatmap" element={<Navigate to="/traceroutes/map/heat" replace />} />
@@ -110,13 +82,52 @@ function App() {
                     element={<ConstellationCoveragePage />}
                   />
                   <Route path="/traceroutes/map/coverage/constellation" element={<ConstellationCoveragePage />} />
+                  <Route path="/weather" element={<Weather />} />
+                </Route>
+
+                {/* Authenticated-only */}
+                <Route
+                  element={
+                    <ProtectedRoute>
+                      <AppLayout />
+                    </ProtectedRoute>
+                  }
+                >
+                  <Route path="/nodes/infrastructure" element={<MeshInfrastructure />} />
+                  <Route
+                    path="/nodes/infrastructure/export"
+                    element={
+                      <Suspense fallback={<div>Loading...</div>}>
+                        <InfrastructureExport />
+                      </Suspense>
+                    }
+                  />
+                  <Route
+                    path="/nodes/managed-nodes"
+                    element={
+                      <Suspense fallback={<div>Loading managed nodes...</div>}>
+                        <ManagedNodesStatus />
+                      </Suspense>
+                    }
+                  />
+                  <Route path="/nodes/my-nodes" element={<MyNodes />} />
+                  <Route path="/nodes/monitor" element={<MonitorNodes />} />
+                  <Route path="/nodes/dx-monitoring" element={<DxMonitoringPage />} />
+                  <Route path="/nodes/:id/claim" element={<ClaimNode />} />
+                  <Route
+                    path="/meshcore/managed-nodes"
+                    element={
+                      <Suspense fallback={<div>Loading managed nodes...</div>}>
+                        <MeshCoreManagedNodesStatus />
+                      </Suspense>
+                    }
+                  />
                   <Route path="/user/nodes" element={<NodeSettings />} />
                   <Route path="/user/settings" element={<SettingsPage />} />
                   <Route path="/user/api-keys" element={<ApiKeysPage />} />
                   <Route path="/user" element={<UserPage />} />
                 </Route>
 
-                {/* Catch all route */}
                 <Route path="*" element={<Navigate to="/" replace />} />
               </Routes>
             </WebSocketProvider>

--- a/src/lib/api/base.ts
+++ b/src/lib/api/base.ts
@@ -111,13 +111,18 @@ export abstract class BaseApi {
             throw apiError;
           }
         } else if (error.response?.status === 401 && !authService.getRefreshToken()) {
-          // If we get a 401 and there's no refresh token, notify authService
-          authService.handleSessionExpired({
-            message: 'Your session has expired. Please log in again.',
-            reason: 'session_expired',
-          });
+          const method = (originalRequest.method || 'get').toLowerCase();
+          const guestReadWithoutToken = !authService.getAccessToken() && method === 'get';
+          if (!guestReadWithoutToken) {
+            authService.handleSessionExpired({
+              message: 'Your session has expired. Please log in again.',
+              reason: 'session_expired',
+            });
+          }
           throw {
-            message: 'Your session has expired. Please log in again.',
+            message: guestReadWithoutToken
+              ? error.response?.data?.detail || 'Authentication required'
+              : 'Your session has expired. Please log in again.',
             status: 401,
             data: error.response?.data,
           } as ApiError;
@@ -162,10 +167,13 @@ export abstract class BaseApi {
 
         // Handle authentication errors (401)
         if (error.response?.status === 401) {
-          apiError.message = 'Your session has expired. Please log in again.';
+          const method = (originalRequest.method || 'get').toLowerCase();
+          const guestReadWithoutToken = !authService.getAccessToken() && method === 'get';
+          apiError.message = guestReadWithoutToken
+            ? error.response?.data?.detail || 'Authentication required'
+            : 'Your session has expired. Please log in again.';
 
-          // Notify authService for any 401 that wasn't handled by the refresh token logic
-          if (!originalRequest._retry) {
+          if (!originalRequest._retry && !guestReadWithoutToken) {
             authService.handleSessionExpired({
               message: apiError.message,
               reason: 'session_expired',


### PR DESCRIPTION
# Summary

Enables anonymous browsing of public observatory routes while keeping claim, API keys, monitor, and user settings behind authentication.

- Splits `App.tsx` routes: public pages use `AppLayout` only; protected actions still use `ProtectedRoute`.
- `base.ts`: anonymous GET without a JWT no longer triggers login redirect on 401 (guest API calls).
- `docs/PERMISSIONS.md`: UI route vs access-level matrix.

Depends on meshflow-api guest-read endpoints (parent issue #346). Deploy API before or with this change.

**Related API:** https://github.com/pskillen/meshflow-api/pull/354

Closes #298

## Testing performed

- Pre-commit: `tsc`, eslint, vitest (301 tests passing)
- Manual: verify public routes load without login; protected routes still redirect to login