### PR TITLE
feat(claim): MeshCore claim flow, WebSocket success, protocol badge

### DIFF
--- a/src/components/nodes/MyNodeCard.test.tsx
+++ b/src/components/nodes/MyNodeCard.test.tsx
@@ -68,6 +68,13 @@ describe('MyNodeCard', () => {
     expect(screen.getByText('Claimed')).toBeInTheDocument();
   });
 
+  it('shows MeshCore protocol badge for meshcore nodes', () => {
+    renderCard({
+      node: makeNode({ protocol: 2, node_id_str: 'mc:aabbccddeeff', meshtastic_node_id: 0 }),
+    });
+    expect(screen.getByText('MeshCore')).toBeInTheDocument();
+  });
+
   it('shows No GPS position when coords missing', () => {
     renderCard({ node: makeNode({ latest_position: null }) });
     const badge = screen.getByText('No GPS position');

--- a/src/components/nodes/MyNodeCard.tsx
+++ b/src/components/nodes/MyNodeCard.tsx
@@ -15,6 +15,7 @@ import { observedNodeDetailPath } from '@/lib/node-detail-routes';
 import type { UseQueryResult } from '@tanstack/react-query';
 
 import { MeshWatchControls } from '@/components/nodes/MeshWatchControls';
+import { ProtocolBadge } from '@/components/nodes/ProtocolBadge';
 import { BatteryGauge } from '@/components/nodes/BatteryGauge';
 import { Badge } from '@/components/ui/badge';
 import { Button } from '@/components/ui/button';
@@ -90,7 +91,10 @@ export function MyNodeCard({
       <CardHeader className="pb-2 space-y-0">
         <div className="flex items-start justify-between gap-2">
           <div className="min-w-0 flex-1">
-            <h2 className="text-base font-semibold leading-tight truncate">{displayName}</h2>
+            <div className="flex flex-wrap items-center gap-2">
+              <h2 className="text-base font-semibold leading-tight truncate">{displayName}</h2>
+              <ProtocolBadge node={node} />
+            </div>
             {node.long_name ? <p className="text-sm text-muted-foreground truncate mt-0.5">{node.long_name}</p> : null}
             <p className="text-xs font-mono text-muted-foreground mt-1 truncate">{node.node_id_str}</p>
           </div>

--- a/src/components/nodes/ProtocolBadge.test.tsx
+++ b/src/components/nodes/ProtocolBadge.test.tsx
@@ -1,0 +1,15 @@
+import { describe, it, expect } from 'vitest';
+import { render, screen } from '@testing-library/react';
+import { ProtocolBadge } from './ProtocolBadge';
+
+describe('ProtocolBadge', () => {
+  it('shows MeshCore for protocol 2', () => {
+    render(<ProtocolBadge node={{ protocol: 2, node_id_str: 'mc:aabb' }} />);
+    expect(screen.getByText('MeshCore')).toBeInTheDocument();
+  });
+
+  it('shows Meshtastic for protocol 1', () => {
+    render(<ProtocolBadge node={{ protocol: 1, node_id_str: '!12345678' }} />);
+    expect(screen.getByText('Meshtastic')).toBeInTheDocument();
+  });
+});

--- a/src/components/nodes/ProtocolBadge.tsx
+++ b/src/components/nodes/ProtocolBadge.tsx
@@ -1,0 +1,13 @@
+import { Badge } from '@/components/ui/badge';
+import { MESHCORE_CONFIG, MESHTASTIC_CONFIG } from '@/lib/mesh-protocol';
+import type { ObservedNode } from '@/lib/models';
+
+export function ProtocolBadge({ node }: { node: Pick<ObservedNode, 'protocol' | 'node_id_str'> }) {
+  const isMeshCore = node.protocol === 2 || node.node_id_str?.toLowerCase().startsWith('mc:');
+  const label = isMeshCore ? MESHCORE_CONFIG.labels.section : MESHTASTIC_CONFIG.labels.section;
+  return (
+    <Badge variant="outline" className="text-xs font-normal">
+      {label}
+    </Badge>
+  );
+}

--- a/src/hooks/useNodeClaimWebSocket.test.ts
+++ b/src/hooks/useNodeClaimWebSocket.test.ts
@@ -1,0 +1,111 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { renderHook, act } from '@testing-library/react';
+import { useNodeClaimWebSocket } from './useNodeClaimWebSocket';
+
+const mockConfig = { apis: { meshBot: { baseUrl: 'http://127.0.0.1:8000' } } };
+
+vi.mock('@/providers/ConfigProvider', () => ({
+  useConfig: () => mockConfig,
+}));
+
+vi.mock('@/lib/auth/authService', () => ({
+  authService: { getAccessToken: () => 'test-jwt' },
+}));
+
+class MockWebSocket {
+  static instances: MockWebSocket[] = [];
+  url: string;
+  onopen: (() => void) | null = null;
+  onmessage: ((ev: { data: string }) => void) | null = null;
+  onclose: (() => void) | null = null;
+  onerror: (() => void) | null = null;
+
+  constructor(url: string) {
+    this.url = url;
+    MockWebSocket.instances.push(this);
+  }
+
+  close() {
+    this.onclose?.();
+  }
+}
+
+describe('useNodeClaimWebSocket', () => {
+  beforeEach(() => {
+    MockWebSocket.instances = [];
+    vi.stubGlobal('WebSocket', MockWebSocket as unknown as typeof WebSocket);
+  });
+
+  afterEach(() => {
+    vi.unstubAllGlobals();
+  });
+
+  it('connects to ws/claims with token when enabled', () => {
+    const onAccepted = vi.fn();
+    renderHook(() =>
+      useNodeClaimWebSocket({
+        nodeInternalId: 'uuid-1',
+        nodeIdStr: 'mc:aabb',
+        enabled: true,
+        onAccepted,
+      })
+    );
+
+    expect(MockWebSocket.instances).toHaveLength(1);
+    expect(MockWebSocket.instances[0].url).toContain('ws://127.0.0.1:8000/ws/claims/');
+    expect(MockWebSocket.instances[0].url).toContain('token=test-jwt');
+  });
+
+  it('calls onAccepted when event matches node', () => {
+    const onAccepted = vi.fn();
+    renderHook(() =>
+      useNodeClaimWebSocket({
+        nodeInternalId: 'uuid-1',
+        nodeIdStr: 'mc:aabbccddeeff',
+        enabled: true,
+        onAccepted,
+      })
+    );
+
+    const socket = MockWebSocket.instances[0];
+    act(() => {
+      socket.onopen?.();
+      socket.onmessage?.({
+        data: JSON.stringify({
+          event: 'node_claim_accepted',
+          node_internal_id: 'uuid-1',
+          node_id_str: 'mc:aabbccddeeff',
+          protocol: 2,
+          accepted_at: '2026-05-25T12:00:00Z',
+        }),
+      });
+    });
+
+    expect(onAccepted).toHaveBeenCalledTimes(1);
+    expect(onAccepted.mock.calls[0][0].accepted_at).toBe('2026-05-25T12:00:00Z');
+  });
+
+  it('ignores events for other nodes', () => {
+    const onAccepted = vi.fn();
+    renderHook(() =>
+      useNodeClaimWebSocket({
+        nodeInternalId: 'uuid-1',
+        nodeIdStr: 'mc:aabb',
+        enabled: true,
+        onAccepted,
+      })
+    );
+
+    MockWebSocket.instances[0].onmessage?.({
+      data: JSON.stringify({
+        event: 'node_claim_accepted',
+        node_internal_id: 'other-uuid',
+        node_id_str: 'mc:other',
+        protocol: 2,
+        accepted_at: '2026-05-25T12:00:00Z',
+      }),
+    });
+
+    expect(onAccepted).not.toHaveBeenCalled();
+  });
+});

--- a/src/hooks/useNodeClaimWebSocket.ts
+++ b/src/hooks/useNodeClaimWebSocket.ts
@@ -1,0 +1,88 @@
+import { useEffect, useRef, useState } from 'react';
+import { useConfig } from '@/providers/ConfigProvider';
+import { authService } from '@/lib/auth/authService';
+
+export type NodeClaimAcceptedEvent = {
+  event: 'node_claim_accepted';
+  node_internal_id: string;
+  node_id_str: string;
+  protocol: number;
+  accepted_at: string;
+};
+
+function matchesClaimTarget(
+  payload: NodeClaimAcceptedEvent,
+  nodeInternalId: string,
+  nodeIdStr: string | undefined
+): boolean {
+  if (payload.node_internal_id && nodeInternalId && payload.node_internal_id === nodeInternalId) {
+    return true;
+  }
+  if (payload.node_id_str && nodeIdStr) {
+    return payload.node_id_str.toLowerCase() === nodeIdStr.toLowerCase();
+  }
+  return false;
+}
+
+/**
+ * Subscribe to claim acceptance for the open node (ws/claims). Used on the claim page
+ * while the user sends the claim key from their radio.
+ */
+export function useNodeClaimWebSocket({
+  nodeInternalId,
+  nodeIdStr,
+  enabled,
+  onAccepted,
+}: {
+  nodeInternalId: string;
+  nodeIdStr: string | undefined;
+  enabled: boolean;
+  onAccepted: (event: NodeClaimAcceptedEvent) => void;
+}): { wsConnected: boolean } {
+  const config = useConfig();
+  const onAcceptedRef = useRef(onAccepted);
+  onAcceptedRef.current = onAccepted;
+  const [wsConnected, setWsConnected] = useState(false);
+  const socketRef = useRef<WebSocket | null>(null);
+
+  useEffect(() => {
+    if (!enabled || !nodeInternalId) {
+      setWsConnected(false);
+      return;
+    }
+
+    const token = authService.getAccessToken();
+    const baseUrl = config.apis.meshBot.baseUrl;
+    if (!token || !baseUrl) {
+      setWsConnected(false);
+      return;
+    }
+
+    const wsUrl = `${baseUrl.replace(/^http/, 'ws')}/ws/claims/?token=${token}`;
+    const socket = new WebSocket(wsUrl);
+    socketRef.current = socket;
+
+    socket.onopen = () => setWsConnected(true);
+    socket.onclose = () => setWsConnected(false);
+    socket.onerror = () => setWsConnected(false);
+
+    socket.onmessage = (event) => {
+      try {
+        const data = JSON.parse(event.data) as NodeClaimAcceptedEvent;
+        if (data.event !== 'node_claim_accepted') return;
+        if (!matchesClaimTarget(data, nodeInternalId, nodeIdStr)) return;
+        onAcceptedRef.current(data);
+      } catch {
+        // ignore malformed frames
+      }
+    };
+
+    return () => {
+      socket.close();
+      socketRef.current = null;
+      setWsConnected(false);
+    };
+  }, [enabled, nodeInternalId, nodeIdStr, config.apis.meshBot.baseUrl]);
+
+  return { wsConnected };
+}

--- a/src/pages/nodes/ClaimNode.tsx
+++ b/src/pages/nodes/ClaimNode.tsx
@@ -1,7 +1,9 @@
-import { useState, useEffect, useMemo } from 'react';
+import { useState, useEffect, useMemo, useCallback, useRef } from 'react';
 import { useParams, useNavigate, Link } from 'react-router-dom';
+import { useQueryClient } from '@tanstack/react-query';
 import { useNodeSuspense, useManagedNodesSuspense } from '@/hooks/api/useNodes';
 import { useMeshflowApi } from '@/hooks/api/useApi';
+import { useNodeClaimWebSocket } from '@/hooks/useNodeClaimWebSocket';
 import { ConstellationsMap } from '@/components/nodes/ConstellationsMap';
 import { Card, CardHeader, CardTitle, CardContent, CardDescription, CardFooter } from '@/components/ui/card';
 import { Button } from '@/components/ui/button';
@@ -10,61 +12,126 @@ import { Loader2, AlertCircle, CheckCircle2 } from 'lucide-react';
 import { NodeClaim } from '@/lib/models';
 import { StaleReportedTime } from '@/components/nodes/StaleReportedTime';
 import { filterManagedNodesForMapDisplay } from '@/lib/managed-node-status';
+import { MESHCORE_CONFIG, MESHTASTIC_CONFIG } from '@/lib/mesh-protocol';
+import { observedNodeDetailPath } from '@/lib/node-detail-routes';
+
+const FALLBACK_POLL_MS = 30_000;
+
+function isMeshCoreNode(node: { protocol?: number; node_id_str?: string }): boolean {
+  return node.protocol === 2 || (node.node_id_str?.toLowerCase().startsWith('mc:') ?? false);
+}
 
 export function ClaimNode() {
   const { id } = useParams<{ id: string }>();
-  const internalId = id ?? '';
+  const routeId = id ?? '';
   const navigate = useNavigate();
   const api = useMeshflowApi();
+  const queryClient = useQueryClient();
 
   const [claimKey, setClaimKey] = useState<string | null>(null);
   const [claimStatus, setClaimStatus] = useState<NodeClaim | undefined>(undefined);
   const [isLoading, setIsLoading] = useState(false);
   const [error, setError] = useState<string | null>(null);
-  const [pollingInterval, setPollingInterval] = useState<NodeJS.Timeout | null>(null);
+  const pollingIntervalRef = useRef<ReturnType<typeof setInterval> | null>(null);
 
-  const node = useNodeSuspense(internalId);
+  const node = useNodeSuspense(routeId);
+  const meshCore = isMeshCoreNode(node);
+  const protocolConfig = meshCore ? MESHCORE_CONFIG : MESHTASTIC_CONFIG;
+  const lookupId = node.internal_id ?? routeId;
+  const detailPath = observedNodeDetailPath(node) ?? `/nodes/${routeId}`;
+
   const { managedNodes } = useManagedNodesSuspense({ includeStatus: true });
-  const managedNodesForMap = useMemo(
-    () => (managedNodes ? filterManagedNodesForMapDisplay(managedNodes) : []),
-    [managedNodes]
+  const feedersForClaim = useMemo(
+    () => (managedNodes ?? []).filter((m) => m.protocol === protocolConfig.protocol),
+    [managedNodes, protocolConfig.protocol]
   );
+  const managedNodesForMap = useMemo(() => filterManagedNodesForMapDisplay(feedersForClaim), [feedersForClaim]);
   const isLoadingManagedNodes = !managedNodes;
-  const managedNodesError = false; // Suspense disables error state, so just set to false
 
-  // On mount, check for existing claim status and start polling if in progress
+  const handleClaimAccepted = useCallback(
+    (acceptedAt: string) => {
+      setClaimStatus((prev) => (prev ? { ...prev, accepted_at: acceptedAt } : prev));
+      if (pollingIntervalRef.current) {
+        clearInterval(pollingIntervalRef.current);
+        pollingIntervalRef.current = null;
+      }
+      queryClient.invalidateQueries({ queryKey: ['nodes', lookupId, 'claim'] });
+      queryClient.invalidateQueries({ queryKey: ['nodes', lookupId] });
+      queryClient.invalidateQueries({ queryKey: ['observed-nodes', 'mine'] });
+      setTimeout(() => navigate(detailPath), 3000);
+    },
+    [detailPath, lookupId, navigate, queryClient]
+  );
+
+  const claimPending = claimStatus !== undefined && !claimStatus.accepted_at;
+
+  const { wsConnected } = useNodeClaimWebSocket({
+    nodeInternalId: lookupId,
+    nodeIdStr: node.node_id_str,
+    enabled: claimPending,
+    onAccepted: (event) => handleClaimAccepted(event.accepted_at),
+  });
+
+  const checkClaimStatus = useCallback(async () => {
+    try {
+      const status = await api.getClaimStatus(lookupId);
+      setClaimStatus(status);
+      if (status?.accepted_at) {
+        handleClaimAccepted(status.accepted_at);
+      }
+    } catch (err) {
+      console.error('Error checking claim status:', err);
+    }
+  }, [api, handleClaimAccepted, lookupId]);
+
+  const startStatusPolling = useCallback(() => {
+    checkClaimStatus();
+    if (pollingIntervalRef.current) {
+      clearInterval(pollingIntervalRef.current);
+    }
+    pollingIntervalRef.current = setInterval(checkClaimStatus, FALLBACK_POLL_MS);
+  }, [checkClaimStatus]);
+
   useEffect(() => {
     let cancelled = false;
     async function checkInitialClaim() {
       try {
-        const status = await api.getClaimStatus(internalId);
+        const status = await api.getClaimStatus(lookupId);
         if (cancelled) return;
         if (status) {
           setClaimStatus(status);
           setClaimKey(status.claim_key);
-        } else {
-          // If not claimed, start polling for updates
-          startStatusPolling();
+          if (!status.accepted_at) {
+            startStatusPolling();
+          } else {
+            handleClaimAccepted(status.accepted_at);
+          }
         }
-        // If claimed, redirect is handled by existing logic
       } catch {
-        // Ignore error, user can still initiate claim
+        // user can still initiate claim
       }
     }
     checkInitialClaim();
     return () => {
       cancelled = true;
     };
-  }, [internalId]);
+  }, [api, handleClaimAccepted, lookupId, startStatusPolling]);
 
-  // Function to initiate the claim
+  useEffect(() => {
+    return () => {
+      if (pollingIntervalRef.current) {
+        clearInterval(pollingIntervalRef.current);
+      }
+    };
+  }, []);
+
   const initiateNodeClaim = async () => {
     setIsLoading(true);
     setError(null);
     try {
-      const response = await api.claimNode(internalId);
+      const response = await api.claimNode(lookupId);
       setClaimKey(response.claim_key);
-      // Start polling for status updates
+      setClaimStatus(response);
       startStatusPolling();
     } catch (err) {
       setError('Failed to initiate claim. Please try again.');
@@ -74,46 +141,6 @@ export function ClaimNode() {
     }
   };
 
-  // Function to check claim status
-  const checkClaimStatus = async () => {
-    try {
-      const status = await api.getClaimStatus(internalId);
-      setClaimStatus(status);
-
-      if (status && status.accepted_at) {
-        if (pollingInterval) {
-          clearInterval(pollingInterval);
-          setPollingInterval(null);
-        }
-        setTimeout(() => {
-          navigate(`/nodes/${internalId}`);
-        }, 3000);
-      }
-    } catch (err) {
-      console.error('Error checking claim status:', err);
-    }
-  };
-
-  // Start polling for status updates
-  const startStatusPolling = () => {
-    // Check immediately
-    checkClaimStatus();
-
-    // Then check every 5 seconds
-    const interval = setInterval(checkClaimStatus, 5000);
-    setPollingInterval(interval);
-  };
-
-  // Clean up polling interval on unmount
-  useEffect(() => {
-    return () => {
-      if (pollingInterval) {
-        clearInterval(pollingInterval);
-      }
-    };
-  }, [pollingInterval]);
-
-  // If the node is already claimed, redirect to node details
   if (node.owner) {
     return (
       <div className="container mx-auto px-4 py-8">
@@ -124,10 +151,22 @@ export function ClaimNode() {
             This node is already claimed by {node.owner.username}. You will be redirected to the node details page.
           </AlertDescription>
         </Alert>
-        <Button onClick={() => navigate(`/nodes/${internalId}`)}>Go to Node Details</Button>
+        <Button onClick={() => navigate(detailPath)}>Go to Node Details</Button>
       </div>
     );
   }
+
+  const instructionSteps = meshCore
+    ? [
+        'On your MeshCore device, open a contact (DM) to one of the MeshCore feeders listed below — not a channel/broadcast message.',
+        'Send a message that contains only the claim key shown above.',
+        'This page will update automatically when the feeder receives your message.',
+      ]
+    : [
+        'Send a direct message from your Meshtastic node to one of the managed nodes shown on the map below.',
+        'The message should contain only the claim key shown above.',
+        'This page will update automatically when a managed node receives your message.',
+      ];
 
   return (
     <div className="container mx-auto px-4 py-8">
@@ -138,12 +177,14 @@ export function ClaimNode() {
           <AlertDescription>{error}</AlertDescription>
         </Alert>
       )}
-      <Link to={`/nodes/${internalId}`} replace={true} className="text-blue-500 hover:text-blue-700 mb-4 inline-block">
+      <Link to={detailPath} replace={true} className="text-blue-500 hover:text-blue-700 mb-4 inline-block">
         ← Back to Node Details
       </Link>
 
       <div className="mb-6">
-        <h1 className="text-3xl font-bold">Claim Node: {node.short_name}</h1>
+        <h1 className="text-3xl font-bold">
+          Claim {protocolConfig.labels.section} Node: {node.short_name}
+        </h1>
         <p className="text-slate-600 dark:text-slate-400">{node.long_name}</p>
       </div>
 
@@ -197,9 +238,9 @@ export function ClaimNode() {
                   <AlertTitle>Instructions</AlertTitle>
                   <AlertDescription>
                     <ol className="list-decimal list-inside space-y-2 mt-2">
-                      <li>Send a direct message from your node to one of the managed nodes shown on the map below.</li>
-                      <li>The message should contain only the claim key shown above.</li>
-                      <li>Once the message is received, your node will be associated with your account.</li>
+                      {instructionSteps.map((step) => (
+                        <li key={step}>{step}</li>
+                      ))}
                     </ol>
                   </AlertDescription>
                 </Alert>
@@ -212,10 +253,15 @@ export function ClaimNode() {
               <CardDescription>
                 {claimStatus.accepted_at
                   ? 'Your node has been successfully claimed. You will be redirected to the node details page.'
-                  : 'Waiting for your message to be received by a managed node.'}
+                  : `Waiting for your ${meshCore ? 'contact message' : 'direct message'} to reach a ${protocolConfig.labels.section} feeder.`}
               </CardDescription>
             </CardHeader>
             <CardContent>
+              {claimPending && (
+                <p className="text-xs text-muted-foreground mb-3">
+                  {wsConnected ? 'Live updates connected' : 'Checking periodically (live updates unavailable)'}
+                </p>
+              )}
               <Alert
                 className={
                   claimStatus.accepted_at
@@ -232,43 +278,55 @@ export function ClaimNode() {
                 <AlertDescription>
                   {claimStatus.accepted_at
                     ? 'Your node has been successfully claimed. You will be redirected to the node details page.'
-                    : `Waiting for your message to be received by a managed node.`}
+                    : `Send the claim key from your ${protocolConfig.labels.section} node to a feeder below.`}
                 </AlertDescription>
               </Alert>
             </CardContent>
           </Card>
           <Card className="mb-6">
             <CardHeader>
-              <CardTitle>Managed Nodes</CardTitle>
-              <CardDescription>Send your claim message to one of these nodes</CardDescription>
+              <CardTitle>{protocolConfig.labels.managedNodesTitle}</CardTitle>
+              <CardDescription>
+                Send your claim message to one of these {protocolConfig.labels.section} feeders
+                {meshCore ? (
+                  <>
+                    {' '}
+                    (
+                    <Link to={protocolConfig.routes.managedNodes} className="text-teal-600 hover:underline">
+                      view all
+                    </Link>
+                    )
+                  </>
+                ) : null}
+              </CardDescription>
             </CardHeader>
             <CardContent>
               {isLoadingManagedNodes ? (
                 <div className="flex items-center justify-center h-40">
                   <Loader2 className="h-8 w-8 animate-spin text-blue-500" />
                 </div>
-              ) : managedNodesError ? (
-                <Alert variant="destructive">
-                  <AlertCircle className="h-4 w-4" />
-                  <AlertTitle>Error</AlertTitle>
-                  <AlertDescription>
-                    Failed to load managed nodes. Please refresh the page and try again.
-                  </AlertDescription>
-                </Alert>
-              ) : managedNodes && managedNodes.length > 0 ? (
-                <>
-                  <div className="mb-4">
-                    <div className="h-[400px] w-full">
-                      <ConstellationsMap nodes={managedNodesForMap} />
-                    </div>
+              ) : feedersForClaim.length > 0 ? (
+                <div className="mb-4">
+                  <div className="h-[400px] w-full">
+                    <ConstellationsMap nodes={managedNodesForMap} />
                   </div>
-                </>
+                </div>
               ) : (
                 <Alert>
                   <AlertCircle className="h-4 w-4" />
-                  <AlertTitle>No Managed Nodes</AlertTitle>
+                  <AlertTitle>No {protocolConfig.labels.section} Feeders</AlertTitle>
                   <AlertDescription>
-                    There are no managed nodes available to receive your claim message.
+                    There are no {protocolConfig.labels.section} managed nodes available to receive your claim message.
+                    {meshCore ? (
+                      <>
+                        {' '}
+                        See{' '}
+                        <Link to={protocolConfig.routes.managedNodes} className="text-teal-600 hover:underline">
+                          MeshCore managed nodes
+                        </Link>
+                        .
+                      </>
+                    ) : null}
                   </AlertDescription>
                 </Alert>
               )}


### PR DESCRIPTION
## Summary

- Protocol-aware claim page copy and feeder map filtered by Meshtastic vs MeshCore.
- `useNodeClaimWebSocket` subscribes to `ws/claims/` for instant claim success (30s poll fallback).
- Protocol badge on My Nodes cards.

## Test plan

- [x] `npm test -- --run src/hooks/useNodeClaimWebSocket.test.ts src/components/nodes/ProtocolBadge.test.tsx src/components/nodes/MyNodeCard.test.tsx`
- [ ] Manual: claim MC node, send DM from phone, confirm success without waiting for poll

Requires meshflow-api PR (claim verification + WebSocket) deployed or running locally.

Closes #292.