### PR TITLE
fix(claim): filter claim feeders by observed node protocol

### DIFF
--- a/src/lib/mesh-protocol.test.ts
+++ b/src/lib/mesh-protocol.test.ts
@@ -1,5 +1,12 @@
 import { describe, it, expect } from 'vitest';
-import { MESHTASTIC_CONFIG, MESHCORE_CONFIG } from './mesh-protocol';
+import type { ManagedNode } from '@/lib/models';
+import {
+  filterManagedNodesForClaim,
+  meshProtocolFromManagedNode,
+  meshProtocolFromObservedNode,
+  MESHTASTIC_CONFIG,
+  MESHCORE_CONFIG,
+} from './mesh-protocol';
 
 describe('mesh-protocol config', () => {
   it('meshtastic routes use legacy paths', () => {
@@ -21,5 +28,26 @@ describe('mesh-protocol config', () => {
   it('meshcore uses meshcore role legend', () => {
     expect(MESHCORE_CONFIG.features.roleLegend).toBe('meshcore');
     expect(MESHTASTIC_CONFIG.features.roleLegend).toBe('meshtastic');
+  });
+});
+
+describe('claim feeder protocol filter', () => {
+  const mt = { protocol: 1, node_id_str: '!12345678' } as ManagedNode;
+  const mc = { protocol: 2, node_id_str: 'mc:aabbccddeeff' } as ManagedNode;
+  const legacyMt = { node_id_str: '!abcdef01' } as ManagedNode;
+
+  it('meshProtocolFromObservedNode respects mc: prefix', () => {
+    expect(meshProtocolFromObservedNode({ protocol: 1, node_id_str: 'mc:abc' })).toBe(2);
+  });
+
+  it('filterManagedNodesForClaim keeps only matching feeders', () => {
+    const all = [mt, mc, legacyMt];
+    expect(filterManagedNodesForClaim(all, 1).map((n) => n.node_id_str)).toEqual(['!12345678', '!abcdef01']);
+    expect(filterManagedNodesForClaim(all, 2).map((n) => n.node_id_str)).toEqual(['mc:aabbccddeeff']);
+  });
+
+  it('meshProtocolFromManagedNode uses node_id_str when protocol missing', () => {
+    expect(meshProtocolFromManagedNode({ node_id_str: 'mc:ff00' })).toBe(2);
+    expect(meshProtocolFromManagedNode({ node_id_str: '!00ff00ff' })).toBe(1);
   });
 });

--- a/src/lib/mesh-protocol.ts
+++ b/src/lib/mesh-protocol.ts
@@ -1,7 +1,31 @@
-import type { MeshProtocol } from '@/lib/models';
+import type { ManagedNode, MeshProtocol, ObservedNode } from '@/lib/models';
 import { nodeDetailPath } from '@/lib/node-detail-routes';
 
 export type ProtocolSlug = 'meshtastic' | 'meshcore';
+
+type ProtocolLike = MeshProtocol | ProtocolSlug | string | number | null | undefined;
+
+/** Normalize API/UI protocol values to 1 (Meshtastic) or 2 (MeshCore). */
+export function normalizeMeshProtocol(value: ProtocolLike): MeshProtocol {
+  if (value === 2 || value === 'meshcore' || value === '2') return 2;
+  if (value === 1 || value === 'meshtastic' || value === '1') return 1;
+  return 1;
+}
+
+export function meshProtocolFromObservedNode(node: Pick<ObservedNode, 'protocol' | 'node_id_str'>): MeshProtocol {
+  if (node.node_id_str?.toLowerCase().startsWith('mc:')) return 2;
+  return normalizeMeshProtocol(node.protocol);
+}
+
+export function meshProtocolFromManagedNode(node: Pick<ManagedNode, 'protocol' | 'node_id_str'>): MeshProtocol {
+  if (node.node_id_str?.toLowerCase().startsWith('mc:')) return 2;
+  return normalizeMeshProtocol(node.protocol);
+}
+
+/** Feeders eligible to receive a claim proof for the given observed node protocol. */
+export function filterManagedNodesForClaim(nodes: ManagedNode[], claimProtocol: MeshProtocol): ManagedNode[] {
+  return nodes.filter((n) => meshProtocolFromManagedNode(n) === claimProtocol);
+}
 
 export type ProtocolPageConfig = {
   slug: ProtocolSlug;

--- a/src/pages/nodes/ClaimNode.tsx
+++ b/src/pages/nodes/ClaimNode.tsx
@@ -12,14 +12,15 @@ import { Loader2, AlertCircle, CheckCircle2 } from 'lucide-react';
 import { NodeClaim } from '@/lib/models';
 import { StaleReportedTime } from '@/components/nodes/StaleReportedTime';
 import { filterManagedNodesForMapDisplay } from '@/lib/managed-node-status';
-import { MESHCORE_CONFIG, MESHTASTIC_CONFIG } from '@/lib/mesh-protocol';
+import {
+  filterManagedNodesForClaim,
+  meshProtocolFromObservedNode,
+  MESHCORE_CONFIG,
+  MESHTASTIC_CONFIG,
+} from '@/lib/mesh-protocol';
 import { observedNodeDetailPath } from '@/lib/node-detail-routes';
 
 const FALLBACK_POLL_MS = 30_000;
-
-function isMeshCoreNode(node: { protocol?: number; node_id_str?: string }): boolean {
-  return node.protocol === 2 || (node.node_id_str?.toLowerCase().startsWith('mc:') ?? false);
-}
 
 export function ClaimNode() {
   const { id } = useParams<{ id: string }>();
@@ -35,15 +36,16 @@ export function ClaimNode() {
   const pollingIntervalRef = useRef<ReturnType<typeof setInterval> | null>(null);
 
   const node = useNodeSuspense(routeId);
-  const meshCore = isMeshCoreNode(node);
+  const claimProtocol = meshProtocolFromObservedNode(node);
+  const meshCore = claimProtocol === 2;
   const protocolConfig = meshCore ? MESHCORE_CONFIG : MESHTASTIC_CONFIG;
   const lookupId = node.internal_id ?? routeId;
   const detailPath = observedNodeDetailPath(node) ?? `/nodes/${routeId}`;
 
   const { managedNodes } = useManagedNodesSuspense({ includeStatus: true });
   const feedersForClaim = useMemo(
-    () => (managedNodes ?? []).filter((m) => m.protocol === protocolConfig.protocol),
-    [managedNodes, protocolConfig.protocol]
+    () => filterManagedNodesForClaim(managedNodes ?? [], claimProtocol),
+    [managedNodes, claimProtocol]
   );
   const managedNodesForMap = useMemo(() => filterManagedNodesForMapDisplay(feedersForClaim), [feedersForClaim]);
   const isLoadingManagedNodes = !managedNodes;


### PR DESCRIPTION
## Summary

Follow-up to #300 (MeshCore node claims, #292). Hardens the claim page feeder list so only managed nodes matching the **observed node's protocol** appear on the map and in copy.

- Adds `normalizeMeshProtocol`, `meshProtocolFromObservedNode`, `meshProtocolFromManagedNode`, and `filterManagedNodesForClaim` in `mesh-protocol.ts`.
- Claim page uses these helpers instead of a raw `protocol` field comparison, so legacy feeders without `protocol` still resolve via `node_id_str` (`mc:` vs `!`).

Related: #292

## Testing performed

- `npm test -- --run src/lib/mesh-protocol.test.ts`
- Pre-commit: full `vitest run` (310 tests)