### PR TITLE
feat(meshcore): show flood advert interval on managed-nodes table

### DIFF
--- a/src/lib/models.ts
+++ b/src/lib/models.ts
@@ -199,6 +199,8 @@ export interface ManagedNode {
   /** Last meshflow-bot version reported on connect (null if never reported). */
   bot_version?: string | null;
   bot_version_reported_at?: Date | string | null;
+  /** MeshCore: hours between flood-routed adverts sent by the bot (API default 6). */
+  mc_flood_advert_interval_hours?: number;
   position: {
     latitude: number | null;
     longitude: number | null;

--- a/src/pages/nodes/ManagedNodesStatus.tsx
+++ b/src/pages/nodes/ManagedNodesStatus.tsx
@@ -111,6 +111,11 @@ function renderBotVersionCell(node: ManagedNode) {
   );
 }
 
+function renderAnnouncePeriodCell(node: ManagedNode) {
+  const hours = node.mc_flood_advert_interval_hours ?? 6;
+  return `${hours}h`;
+}
+
 function ProtocolManagedNodesPageContent({
   config,
   managedNodes,
@@ -435,6 +440,7 @@ function ProtocolManagedNodesPageContent({
                     <TableHead>Radio last heard</TableHead>
                     <TableHead>Owner</TableHead>
                     <TableHead>Bot version</TableHead>
+                    {config.slug === 'meshcore' ? <TableHead>Announce period</TableHead> : null}
                     {config.features.autoTracerouteFilters ? <TableHead>Auto-TR</TableHead> : null}
                   </TableRow>
                 </TableHeader>
@@ -482,6 +488,7 @@ function ProtocolManagedNodesPageContent({
                         <TableCell>{renderTimestampCell(node.radio_last_heard)}</TableCell>
                         <TableCell>{node.owner.username}</TableCell>
                         <TableCell>{renderBotVersionCell(node)}</TableCell>
+                        {config.slug === 'meshcore' ? <TableCell>{renderAnnouncePeriodCell(node)}</TableCell> : null}
                         {config.features.autoTracerouteFilters ? (
                           <TableCell>{autoTracerouteBadge(node)}</TableCell>
                         ) : null}


### PR DESCRIPTION
## Summary

Show `mc_flood_advert_interval_hours` on `/meshcore/managed-nodes` in an **Announce period** column next to bot version.

Requires meshflow-api #357 / PR #359 merged (field on managed-nodes list).

## Test plan

- [x] `npm test`
- [ ] Open `/meshcore/managed-nodes` and confirm **Announce period** column (e.g. `6h`)