### PR TITLE
feat(nodes): MeshCore feeder enrollment wizard (#293)

### DIFF
--- a/src/components/nodes/BotSetupInstructions.test.tsx
+++ b/src/components/nodes/BotSetupInstructions.test.tsx
@@ -71,6 +71,26 @@ describe('BotSetupInstructions', () => {
     expect(embeddedContent).toContain('TEXT_MESSAGE_MAX_HOPS=7');
   });
 
+  it('uses STORAGE_API_VERSION=3 for Meshtastic compose', () => {
+    const { container } = render(
+      <BotSetupInstructions apiKey="test-key" apiBaseUrl="https://api.example.com" protocol="meshtastic" />
+    );
+    const embeddedContent = getEmbeddedDockerComposeContent(container);
+    expect(embeddedContent).toContain('STORAGE_API_VERSION=3');
+    expect(embeddedContent).not.toContain('STORAGE_API_VERSION=2');
+  });
+
+  it('renders MeshCore compose with RADIO_PROTOCOL=meshcore', () => {
+    const { container } = render(
+      <BotSetupInstructions apiKey="test-key" apiBaseUrl="https://api.example.com" protocol="meshcore" />
+    );
+    const pres = container.querySelectorAll('pre');
+    const meshcoreCompose = Array.from(pres).find((pre) => (pre.textContent || '').includes('RADIO_PROTOCOL=meshcore'));
+    expect(meshcoreCompose).toBeTruthy();
+    expect(meshcoreCompose?.textContent).toContain('MESHCORE_UPLOAD_ENABLED=true');
+    expect(meshcoreCompose?.textContent).toContain('STORAGE_API_VERSION=3');
+  });
+
   it('omits hop limit env vars when hopLimit is out of range', () => {
     const { container } = render(
       <BotSetupInstructions

--- a/src/components/nodes/BotSetupInstructions.tsx
+++ b/src/components/nodes/BotSetupInstructions.tsx
@@ -3,12 +3,15 @@ import { Button } from '@/components/ui/button';
 import { Tabs, TabsContent, TabsList, TabsTrigger } from '@/components/ui/tabs';
 import { Copy, Download, ExternalLink } from 'lucide-react';
 
+export type BotSetupProtocol = 'meshtastic' | 'meshcore';
+
 export interface BotDefaults {
   ignorePortnums?: string | null;
   hopLimit?: number | null;
 }
 
 interface BotSetupInstructionsProps {
+  protocol?: BotSetupProtocol;
   apiKey: string;
   apiBaseUrl: string;
   nodeShortName?: string;
@@ -19,7 +22,7 @@ function deriveWsUrl(httpUrl: string): string {
   return httpUrl.replace(/^http:\/\//, 'ws://').replace(/^https:\/\//, 'wss://');
 }
 
-function buildBotEnvVars(botDefaults?: BotDefaults): string[] {
+function buildMeshtasticBotEnvVars(botDefaults?: BotDefaults): string[] {
   const lines: string[] = [];
   if (botDefaults?.ignorePortnums?.trim()) {
     lines.push(`      - IGNORE_PORTNUMS=${botDefaults.ignorePortnums.trim()}`);
@@ -32,7 +35,7 @@ function buildBotEnvVars(botDefaults?: BotDefaults): string[] {
   return lines;
 }
 
-function buildBotEnvVarsForEnvFile(botDefaults?: BotDefaults): string[] {
+function buildMeshtasticBotEnvVarsForEnvFile(botDefaults?: BotDefaults): string[] {
   const lines: string[] = [];
   if (botDefaults?.ignorePortnums?.trim()) {
     lines.push(`IGNORE_PORTNUMS=${botDefaults.ignorePortnums.trim()}`);
@@ -45,9 +48,13 @@ function buildBotEnvVarsForEnvFile(botDefaults?: BotDefaults): string[] {
   return lines;
 }
 
-function generateDockerComposeEmbedded(apiBaseUrl: string, apiKey: string, botDefaults?: BotDefaults): string {
+function generateMeshtasticDockerComposeEmbedded(
+  apiBaseUrl: string,
+  apiKey: string,
+  botDefaults?: BotDefaults
+): string {
   const wsUrl = deriveWsUrl(apiBaseUrl);
-  const botEnvLines = buildBotEnvVars(botDefaults);
+  const botEnvLines = buildMeshtasticBotEnvVars(botDefaults);
   const botEnvBlock = botEnvLines.length > 0 ? '\n' + botEnvLines.join('\n') : '';
   return `---
 services:
@@ -60,7 +67,7 @@ services:
       - ADMIN_NODES='!xxxxxxxx'          # Your admin node ID(s) - find in Meshtastic app or node details
       - STORAGE_API_ROOT=${apiBaseUrl}
       - STORAGE_API_TOKEN=${apiKey}
-      - STORAGE_API_VERSION=2
+      - STORAGE_API_VERSION=3
       - MESHFLOW_WS_URL=${wsUrl}${botEnvBlock}
     volumes:
       - ./data:/app/data
@@ -77,13 +84,48 @@ services:
 `;
 }
 
-function generateDockerComposeSeparate(): string {
+function generateMeshCoreDockerComposeEmbedded(apiBaseUrl: string, apiKey: string): string {
+  const wsUrl = deriveWsUrl(apiBaseUrl);
+  return `---
+services:
+  meshflow-meshcore-bot:
+    image: ghcr.io/pskillen/meshflow-bot:latest
+    container_name: meshflow-meshcore-bot
+    restart: unless-stopped
+    devices:
+      - /dev/ttyUSB0:/dev/ttyUSB0   # Adjust for your serial device; or use BLE env vars instead
+    environment:
+      - RADIO_PROTOCOL=meshcore
+      - MESHCORE_SERIAL_DEVICE=/dev/ttyUSB0
+      # - MESHCORE_BLE_ADDRESS=AA:BB:CC:DD:EE:FF
+      - MESHCORE_UPLOAD_ENABLED=true
+      - STORAGE_API_ROOT=${apiBaseUrl}
+      - STORAGE_API_TOKEN=${apiKey}
+      - STORAGE_API_VERSION=3
+      - MESHFLOW_WS_URL=${wsUrl}
+    volumes:
+      - ./data:/app/data
+    depends_on:
+      - watchtower
+
+  watchtower:
+    image: containrrr/watchtower
+    container_name: watchtower
+    restart: unless-stopped
+    volumes:
+      - /var/run/docker.sock:/var/run/docker.sock
+    command: --interval 3600 meshflow-meshcore-bot
+`;
+}
+
+function generateDockerComposeSeparate(protocol: BotSetupProtocol): string {
+  const serviceName = protocol === 'meshcore' ? 'meshflow-meshcore-bot' : 'meshflow-bot';
   return `---
 # Place .env in this directory with STORAGE_API_ROOT, STORAGE_API_TOKEN, etc.
 services:
-  meshflow-bot:
+  ${serviceName}:
     image: ghcr.io/pskillen/meshflow-bot:latest
-    container_name: meshflow-bot
+    container_name: ${serviceName}
     restart: unless-stopped
     env_file: .env
     volumes:
@@ -97,15 +139,15 @@ services:
     restart: unless-stopped
     volumes:
       - /var/run/docker.sock:/var/run/docker.sock
-    command: --interval 3600 meshflow-bot
+    command: --interval 3600 ${serviceName}
 `;
 }
 
-function generateEnvFile(apiBaseUrl: string, apiKey: string, botDefaults?: BotDefaults): string {
+function generateMeshtasticEnvFile(apiBaseUrl: string, apiKey: string, botDefaults?: BotDefaults): string {
   const wsUrl = deriveWsUrl(apiBaseUrl);
-  const botEnvLines = buildBotEnvVarsForEnvFile(botDefaults);
+  const botEnvLines = buildMeshtasticBotEnvVarsForEnvFile(botDefaults);
   const botEnvBlock = botEnvLines.length > 0 ? '\n\n' + botEnvLines.join('\n') : '';
-  return `# Meshflow Bot configuration
+  return `# Meshflow Bot configuration (Meshtastic)
 # Copy this file to .env in the same directory as docker-compose.yaml
 
 MESHTASTIC_IP=meshtastic.local
@@ -113,8 +155,25 @@ ADMIN_NODES='!xxxxxxxx'
 
 STORAGE_API_ROOT=${apiBaseUrl}
 STORAGE_API_TOKEN=${apiKey}
-STORAGE_API_VERSION=2
+STORAGE_API_VERSION=3
 MESHFLOW_WS_URL=${wsUrl}${botEnvBlock}
+`;
+}
+
+function generateMeshCoreEnvFile(apiBaseUrl: string, apiKey: string): string {
+  const wsUrl = deriveWsUrl(apiBaseUrl);
+  return `# Meshflow Bot configuration (MeshCore)
+# Copy this file to .env in the same directory as docker-compose.yaml
+
+RADIO_PROTOCOL=meshcore
+MESHCORE_SERIAL_DEVICE=/dev/ttyUSB0
+# MESHCORE_BLE_ADDRESS=AA:BB:CC:DD:EE:FF
+MESHCORE_UPLOAD_ENABLED=true
+
+STORAGE_API_ROOT=${apiBaseUrl}
+STORAGE_API_TOKEN=${apiKey}
+STORAGE_API_VERSION=3
+MESHFLOW_WS_URL=${wsUrl}
 `;
 }
 
@@ -128,13 +187,28 @@ function downloadFile(filename: string, content: string) {
   URL.revokeObjectURL(url);
 }
 
-export function BotSetupInstructions({ apiKey, apiBaseUrl, botDefaults }: BotSetupInstructionsProps) {
+export function BotSetupInstructions({
+  protocol = 'meshtastic',
+  apiKey,
+  apiBaseUrl,
+  botDefaults,
+}: BotSetupInstructionsProps) {
   const [format, setFormat] = useState<'embedded' | 'separate'>('embedded');
   const [copied, setCopied] = useState<'compose' | 'env' | null>(null);
 
-  const dockerComposeEmbedded = generateDockerComposeEmbedded(apiBaseUrl, apiKey, botDefaults);
-  const dockerComposeSeparate = generateDockerComposeSeparate();
-  const envContent = generateEnvFile(apiBaseUrl, apiKey, botDefaults);
+  const isMeshCore = protocol === 'meshcore';
+
+  const dockerComposeEmbedded = isMeshCore
+    ? generateMeshCoreDockerComposeEmbedded(apiBaseUrl, apiKey)
+    : generateMeshtasticDockerComposeEmbedded(apiBaseUrl, apiKey, botDefaults);
+  const dockerComposeSeparate = generateDockerComposeSeparate(protocol);
+  const envContent = isMeshCore
+    ? generateMeshCoreEnvFile(apiBaseUrl, apiKey)
+    : generateMeshtasticEnvFile(apiBaseUrl, apiKey, botDefaults);
+
+  const docsUrl = isMeshCore
+    ? 'https://github.com/pskillen/meshflow-bot/blob/main/docs/MESHCORE.md'
+    : 'https://github.com/pskillen/meshflow-bot';
 
   const handleCopy = (text: string, type: 'compose' | 'env') => {
     navigator.clipboard.writeText(text);
@@ -157,13 +231,32 @@ export function BotSetupInstructions({ apiKey, apiBaseUrl, botDefaults }: BotSet
             <code className="rounded bg-muted px-1">docker-compose.yaml</code>
           </li>
         )}
-        <li>
-          Edit <code className="rounded bg-muted px-1">MESHTASTIC_IP</code> and{' '}
-          <code className="rounded bg-muted px-1">ADMIN_NODES</code> for your setup
-        </li>
+        {isMeshCore ? (
+          <>
+            <li>
+              Set <code className="rounded bg-muted px-1">MESHCORE_SERIAL_DEVICE</code> or{' '}
+              <code className="rounded bg-muted px-1">MESHCORE_BLE_ADDRESS</code> for your hardware
+            </li>
+            <li>
+              Ensure <code className="rounded bg-muted px-1">ManagedNode.mc_pubkey</code> in the API matches your device
+              (64 hex)
+            </li>
+          </>
+        ) : (
+          <li>
+            Edit <code className="rounded bg-muted px-1">MESHTASTIC_IP</code> and{' '}
+            <code className="rounded bg-muted px-1">ADMIN_NODES</code> for your setup
+          </li>
+        )}
         <li>
           Run <code className="rounded bg-muted px-1">docker compose up -d</code>
         </li>
+        {isMeshCore ? (
+          <li>
+            Confirm logs show <code className="rounded bg-muted px-1">mc-channel-sync</code> and feeder ingest URLs
+            under <code className="rounded bg-muted px-1">/api/meshcore/feeders/</code>
+          </li>
+        ) : null}
       </ol>
 
       <Tabs value={format} onValueChange={(v) => setFormat(v as 'embedded' | 'separate')}>
@@ -243,15 +336,15 @@ export function BotSetupInstructions({ apiKey, apiBaseUrl, botDefaults }: BotSet
         </TabsContent>
       </Tabs>
 
-      <div className="pt-2">
+      <div className="pt-2 flex flex-wrap gap-4">
         <a
-          href="https://github.com/pskillen/meshflow-bot"
+          href={docsUrl}
           target="_blank"
           rel="noopener noreferrer"
           className="inline-flex items-center text-sm text-primary hover:underline"
         >
           <ExternalLink className="h-4 w-4 mr-1" />
-          Meshflow Bot on GitHub
+          {isMeshCore ? 'MeshCore bot docs' : 'Meshflow Bot on GitHub'}
         </a>
       </div>
     </div>

--- a/src/components/nodes/NodeOutgoingTraceroutesSection.test.tsx
+++ b/src/components/nodes/NodeOutgoingTraceroutesSection.test.tsx
@@ -49,7 +49,7 @@ function renderSection(managed: ManagedNode) {
   const client = new QueryClient({ defaultOptions: { queries: { retry: false } } });
   return render(
     <QueryClientProvider client={client}>
-      <NodeOutgoingTraceroutesSection nodeId={managed.meshtastic_node_id} managed={managed} />
+      <NodeOutgoingTraceroutesSection nodeId={managed.meshtastic_node_id!} managed={managed} />
     </QueryClientProvider>
   );
 }

--- a/src/components/nodes/NodeOutgoingTraceroutesSection.tsx
+++ b/src/components/nodes/NodeOutgoingTraceroutesSection.tsx
@@ -51,7 +51,7 @@ export function NodeOutgoingTraceroutesSection({ nodeId, managed }: NodeOutgoing
   const handleRepeat = (tr: AutoTraceRoute) => {
     triggerMutation.mutate(
       {
-        managedNodeId: tr.source_node.meshtastic_node_id,
+        managedNodeId: tr.source_node.meshtastic_node_id!,
         targetNodeId: tr.target_node.meshtastic_node_id,
         targetStrategy:
           tr.target_strategy === 'intra_zone' ||

--- a/src/components/nodes/NodeTracerouteHistorySection.tsx
+++ b/src/components/nodes/NodeTracerouteHistorySection.tsx
@@ -67,7 +67,7 @@ export function NodeTracerouteHistorySection({ nodeId, observedNode }: NodeTrace
   const handleRepeat = (tr: AutoTraceRoute) => {
     triggerMutation.mutate(
       {
-        managedNodeId: tr.source_node.meshtastic_node_id,
+        managedNodeId: tr.source_node.meshtastic_node_id!,
         targetNodeId: tr.target_node.meshtastic_node_id,
         targetStrategy:
           tr.target_strategy === 'intra_zone' ||

--- a/src/components/nodes/NodesAndConstellationsMap.tsx
+++ b/src/components/nodes/NodesAndConstellationsMap.tsx
@@ -22,8 +22,8 @@ const UNCERTAINTY_THRESHOLD_M = 200;
 
 export type MapNode = ObservedNode | ManagedNode;
 
-function getNodeId(node: MapNode): number {
-  return node.meshtastic_node_id;
+function getNodeId(node: MapNode): string {
+  return node.node_id_str || ('internal_id' in node && node.internal_id) || String(node.meshtastic_node_id ?? '');
 }
 
 function getNodePosition(node: MapNode): { lat: number; lng: number } | null {
@@ -57,7 +57,8 @@ export interface NodesAndConstellationsMapProps {
   onMapMove?: (center: L.LatLng, zoom: number) => void;
   onNodeSelect?: (node: MapNode | null) => boolean;
   /** When provided, highlights this node (e.g. selection from external source like search) */
-  selectedNodeId?: number | null;
+  /** Meshtastic numeric id or map identity string (`node_id_str` / `internal_id`). */
+  selectedNodeId?: string | number | null;
   /** Optional custom label for observed node markers (e.g. weather metrics) */
   getMarkerLabel?: (node: ObservedNode) => string;
   /** Optional opacity 0-1 for observed node markers (e.g. age-based fading) */
@@ -110,7 +111,7 @@ export function NodesAndConstellationsMap({
   const tileLayerRef = useRef<L.TileLayer | null>(null);
   const polygonsRef = useRef<L.Polygon[]>([]);
   const markersRef = useRef<L.Marker[]>([]);
-  const [internalSelectedNodeId, setInternalSelectedNodeId] = useState<number | null>(null);
+  const [internalSelectedNodeId, setInternalSelectedNodeId] = useState<string | null>(null);
   const selectedNodeId = selectedNodeIdProp ?? internalSelectedNodeId;
   const lastViewRef = useRef<{ center: L.LatLng; zoom: number } | null>(null);
   const onMapMoveRef = useRef(onMapMove);
@@ -269,7 +270,7 @@ export function NodesAndConstellationsMap({
     markersRef.current.forEach((m) => m.remove());
     markersRef.current = [];
 
-    const managedNodeIds = new Set(managedNodes.map((n) => n.meshtastic_node_id));
+    const managedNodeIds = new Set(managedNodes.map((n) => getNodeId(n)));
     const filteredManaged =
       filterConstellationIds != null && filterConstellationIds.length > 0
         ? managedNodes.filter((n) => n.constellation && filterConstellationIds.includes(n.constellation.id))
@@ -368,7 +369,7 @@ export function NodesAndConstellationsMap({
             ...filteredManaged.filter((n) => getNodePosition(n) != null),
           ]
         : filteredManaged.filter((n) => getNodePosition(n) != null);
-      const seen = new Set<number>();
+      const seen = new Set<string>();
       nodesWithUncertainty.forEach((node) => {
         const id = getNodeId(node);
         if (seen.has(id)) return;
@@ -404,13 +405,13 @@ export function NodesAndConstellationsMap({
     // When !showConstellation: draw all observed nodes (including managed) with role colors
     const observedLayer = showConstellation
       ? showUnmanagedNodes
-        ? observedNodes.filter((o) => !managedNodeIds.has(o.meshtastic_node_id))
+        ? observedNodes.filter((o) => !managedNodeIds.has(getNodeId(o)))
         : []
       : observedNodes;
 
-    const managedNodeConstellationMap = new Map<number, string>();
+    const managedNodeConstellationMap = new Map<string, string>();
     filteredManaged.forEach((n) => {
-      if (n.constellation?.name) managedNodeConstellationMap.set(n.meshtastic_node_id, n.constellation.name);
+      if (n.constellation?.name) managedNodeConstellationMap.set(getNodeId(n), n.constellation.name);
     });
 
     const hasSelection = selectedNodeId != null;
@@ -418,7 +419,8 @@ export function NodesAndConstellationsMap({
       const pos = getNodePosition(node);
       if (!pos) return;
       const position: L.LatLngExpression = [pos.lat, pos.lng];
-      const isSelected = selectedNodeId === node.meshtastic_node_id;
+      const isSelected =
+        selectedNodeId != null && (selectedNodeId === getNodeId(node) || selectedNodeId === node.meshtastic_node_id);
       const label = getMarkerLabel
         ? getMarkerLabel(node as ObservedNode)
         : node.short_name || node.node_id_str?.toString().slice(-4) || '?';
@@ -445,12 +447,12 @@ export function NodesAndConstellationsMap({
             dimmed,
             opacity,
             grayscale,
-            getNodeAlertRing?.(node.meshtastic_node_id) ?? undefined
+            (node.meshtastic_node_id != null ? getNodeAlertRing?.(node.meshtastic_node_id) : undefined) ?? undefined
           );
       const marker = L.marker(position, { icon });
       marker.on('click', () => handleMarkerClick(node));
       if (enableBubbles) {
-        const constellationName = managedNodeConstellationMap.get(node.meshtastic_node_id) ?? null;
+        const constellationName = managedNodeConstellationMap.get(getNodeId(node)) ?? null;
         marker.bindPopup(buildNodePopupHtml({ ...node, constellationName }));
       }
       marker.addTo(map);
@@ -464,7 +466,9 @@ export function NodesAndConstellationsMap({
         c.nodes.forEach((node) => {
           if (node.position?.latitude == null || node.position?.longitude == null) return;
           const position: L.LatLngExpression = [node.position.latitude, node.position.longitude];
-          const isSelected = selectedNodeId === node.meshtastic_node_id;
+          const isSelected =
+            selectedNodeId != null &&
+            (selectedNodeId === getNodeId(node) || selectedNodeId === node.meshtastic_node_id);
           const marker = L.marker(position, {
             icon: createNodeIcon(
               node.short_name || node.node_id_str?.slice(4, 8) || '?',
@@ -473,7 +477,7 @@ export function NodesAndConstellationsMap({
               hasSelection && !isSelected,
               undefined,
               undefined,
-              getNodeAlertRing?.(node.meshtastic_node_id) ?? undefined
+              (node.meshtastic_node_id != null ? getNodeAlertRing?.(node.meshtastic_node_id) : undefined) ?? undefined
             ),
           });
           marker.on('click', () => handleMarkerClick(node));

--- a/src/components/nodes/SetupManagedNode.tsx
+++ b/src/components/nodes/SetupManagedNode.tsx
@@ -27,6 +27,8 @@ import L from 'leaflet';
 import 'leaflet/dist/leaflet.css';
 import { useMapTileUrl } from '@/hooks/useMapTileUrl';
 import { useConstellationsSuspense } from '@/hooks/api/useConstellations';
+import { meshProtocolFromObservedNode, normalizeMeshProtocol } from '@/lib/mesh-protocol';
+import { isMeshCoreEnrollment, normalizeMcPubkeyInput } from '@/lib/managed-node-enrollment';
 
 interface SetupManagedNodeProps {
   node: ObservedNode;
@@ -37,12 +39,14 @@ interface SetupManagedNodeProps {
 function formatManagedNodeCreateError(err: unknown): string {
   if (axios.isAxiosError(err) && err.response?.data && typeof err.response.data === 'object') {
     const data = err.response.data as Record<string, unknown>;
-    const nid = data.meshtastic_node_id;
-    if (Array.isArray(nid) && nid.length > 0) {
-      return String(nid[0]);
-    }
-    if (typeof nid === 'string') {
-      return nid;
+    for (const field of ['mc_pubkey', 'meshtastic_node_id'] as const) {
+      const val = data[field];
+      if (Array.isArray(val) && val.length > 0) {
+        return String(val[0]);
+      }
+      if (typeof val === 'string') {
+        return val;
+      }
     }
     if (data.detail != null) {
       return String(data.detail);
@@ -51,7 +55,7 @@ function formatManagedNodeCreateError(err: unknown): string {
   return 'Failed to create managed node. Please try again.';
 }
 
-type SetupStep = 'constellation' | 'location' | 'channels' | 'api-key' | 'instructions';
+type SetupStep = 'constellation' | 'pubkey' | 'location' | 'channels' | 'api-key' | 'instructions';
 
 export function SetupManagedNode({ node, isOpen, onClose }: SetupManagedNodeProps) {
   const navigate = useNavigate();
@@ -70,6 +74,10 @@ export function SetupManagedNode({ node, isOpen, onClose }: SetupManagedNodeProp
   const [isLoading, setIsLoading] = useState(false);
   const [error, setError] = useState<string | null>(null);
   const [createdApiKey, setCreatedApiKey] = useState<NodeApiKey | null>(null);
+  const [mcPubkey, setMcPubkey] = useState('');
+
+  const enrollmentProtocol = meshProtocolFromObservedNode(node);
+  const isMeshCore = isMeshCoreEnrollment(enrollmentProtocol);
 
   // Location state
   const [nodeLocation, setNodeLocation] = useState<{ lat: number; lng: number } | null>(null);
@@ -124,6 +132,7 @@ export function SetupManagedNode({ node, isOpen, onClose }: SetupManagedNodeProp
       setIsLoading(false);
       setError(null);
       setCreatedApiKey(null);
+      setMcPubkey(observedNode.mc_pubkey?.toLowerCase() ?? '');
 
       // Reset location and channel mappings
       setNodeLocation(null);
@@ -148,13 +157,21 @@ export function SetupManagedNode({ node, isOpen, onClose }: SetupManagedNodeProp
         markerRef.current = null;
       }
     }
-  }, [isOpen, node]);
+  }, [isOpen, node, observedNode.mc_pubkey]);
 
   const handleNextStep = () => {
     if (currentStep === 'constellation') {
+      setCurrentStep(isMeshCore ? 'pubkey' : 'location');
+    } else if (currentStep === 'pubkey') {
+      const result = normalizeMcPubkeyInput(mcPubkey);
+      if (!result.ok) {
+        setError(result.message);
+        return;
+      }
+      setError(null);
       setCurrentStep('location');
     } else if (currentStep === 'location') {
-      setCurrentStep('channels');
+      setCurrentStep(isMeshCore ? 'api-key' : 'channels');
     } else if (currentStep === 'channels') {
       setCurrentStep('api-key');
     } else if (currentStep === 'api-key') {
@@ -164,11 +181,13 @@ export function SetupManagedNode({ node, isOpen, onClose }: SetupManagedNodeProp
 
   const handlePreviousStep = () => {
     if (currentStep === 'location') {
+      setCurrentStep(isMeshCore ? 'pubkey' : 'constellation');
+    } else if (currentStep === 'pubkey') {
       setCurrentStep('constellation');
     } else if (currentStep === 'channels') {
       setCurrentStep('location');
     } else if (currentStep === 'api-key') {
-      setCurrentStep('channels');
+      setCurrentStep(isMeshCore ? 'location' : 'channels');
     } else if (currentStep === 'instructions') {
       setCurrentStep('api-key');
     }
@@ -271,9 +290,10 @@ export function SetupManagedNode({ node, isOpen, onClose }: SetupManagedNodeProp
 
   // Handle channel mapping changes
   const handleChannelChange = (channelIndex: number, channelId: number | null) => {
+    const key = `meshtastic_channel_${channelIndex}` as keyof typeof channelMappings;
     setChannelMappings((prev) => ({
       ...prev,
-      [`channel_${channelIndex}`]: channelId,
+      [key]: channelId,
     }));
   };
 
@@ -295,33 +315,54 @@ export function SetupManagedNode({ node, isOpen, onClose }: SetupManagedNodeProp
     }
 
     try {
-      // Create the managed node with location and channel mappings
-      const managedNode = await api.createManagedNode(
-        node.meshtastic_node_id,
-        selectedConstellation,
-        nodeName,
-        user.id,
-        {
+      let managedNode;
+      if (isMeshCore) {
+        const pubkeyResult = normalizeMcPubkeyInput(mcPubkey);
+        if (!pubkeyResult.ok) {
+          setError(pubkeyResult.message);
+          setIsLoading(false);
+          return;
+        }
+        managedNode = await api.createMeshCoreManagedNode(
+          pubkeyResult.value,
+          selectedConstellation,
+          nodeName,
+          user.id,
+          {
+            defaultLocationLatitude: nodeLocation?.lat,
+            defaultLocationLongitude: nodeLocation?.lng,
+          }
+        );
+      } else {
+        if (node.meshtastic_node_id == null || node.meshtastic_node_id <= 0) {
+          setError('This observed node has no Meshtastic node id and cannot be enrolled as a managed feeder.');
+          setIsLoading(false);
+          return;
+        }
+        managedNode = await api.createManagedNode(node.meshtastic_node_id, selectedConstellation, nodeName, user.id, {
           defaultLocationLatitude: nodeLocation?.lat,
           defaultLocationLongitude: nodeLocation?.lng,
           channels: channelMappings,
-        }
-      );
-
-      // Handle API key
-      if (apiKeyOption === 'existing' && selectedApiKey) {
-        // Add node to existing API key
-        await api.addNodeToApiKey(selectedApiKey, managedNode.meshtastic_node_id);
-      } else if (apiKeyOption === 'new' && newApiKeyName) {
-        // Create new API key
-        const apiKey = await api.createApiKey(newApiKeyName, selectedConstellation);
-        setCreatedApiKey(apiKey);
-
-        // Add node to new API key
-        await api.addNodeToApiKey(apiKey.id, managedNode.meshtastic_node_id);
+        });
       }
 
-      // Move to instructions step
+      const internalId = managedNode.internal_id;
+      if (!internalId) {
+        setError('Managed node was created but no internal id was returned.');
+        setIsLoading(false);
+        return;
+      }
+
+      const linkTarget = { managedNodeInternalId: internalId };
+
+      if (apiKeyOption === 'existing' && selectedApiKey) {
+        await api.addNodeToApiKey(selectedApiKey, linkTarget);
+      } else if (apiKeyOption === 'new' && newApiKeyName) {
+        const apiKey = await api.createApiKey(newApiKeyName, selectedConstellation);
+        setCreatedApiKey(apiKey);
+        await api.addNodeToApiKey(apiKey.id, linkTarget);
+      }
+
       setCurrentStep('instructions');
     } catch (err) {
       console.error('Error creating managed node:', err);
@@ -336,12 +377,15 @@ export function SetupManagedNode({ node, isOpen, onClose }: SetupManagedNodeProp
     selectedConstellation != null ? constellations.find((c) => c.id === selectedConstellation) : null;
   const selectedConstellationChannels = selectedConstellationObj?.channels || [];
 
+  const eligibleConstellations = constellations.filter((c) => normalizeMeshProtocol(c.protocol) === enrollmentProtocol);
+
   const renderConstellationStep = () => (
     <>
       <DialogHeader>
-        <DialogTitle>Set Up Managed Node</DialogTitle>
+        <DialogTitle>Set Up {isMeshCore ? 'MeshCore Feeder' : 'Managed Node'}</DialogTitle>
         <DialogDescription>
-          Select a constellation for your managed node. A constellation is a group of nodes that work together.
+          Select a {isMeshCore ? 'MeshCore' : 'Meshtastic'} constellation for your feeder. A constellation is a regional
+          group of nodes that work together.
         </DialogDescription>
       </DialogHeader>
 
@@ -363,13 +407,18 @@ export function SetupManagedNode({ node, isOpen, onClose }: SetupManagedNodeProp
               <SelectValue placeholder="Select a constellation" />
             </SelectTrigger>
             <SelectContent>
-              {constellations.map((constellation) => (
+              {eligibleConstellations.map((constellation) => (
                 <SelectItem key={constellation.id} value={constellation.id.toString()}>
                   {constellation.name}
                 </SelectItem>
               ))}
             </SelectContent>
           </Select>
+          {eligibleConstellations.length === 0 ? (
+            <p className="text-sm text-amber-600 dark:text-amber-500">
+              No {isMeshCore ? 'MeshCore' : 'Meshtastic'} constellations are available. Ask an admin to create one.
+            </p>
+          ) : null}
         </div>
       </div>
 
@@ -377,7 +426,56 @@ export function SetupManagedNode({ node, isOpen, onClose }: SetupManagedNodeProp
         <Button variant="outline" onClick={onClose}>
           Cancel
         </Button>
-        <Button onClick={handleNextStep} disabled={!selectedConstellation || !nodeName}>
+        <Button
+          onClick={handleNextStep}
+          disabled={!selectedConstellation || !nodeName || eligibleConstellations.length === 0}
+        >
+          Next
+        </Button>
+      </DialogFooter>
+    </>
+  );
+
+  const renderPubkeyStep = () => (
+    <>
+      <DialogHeader>
+        <DialogTitle>Feeder public key</DialogTitle>
+        <DialogDescription>
+          Enter the full 64-character hexadecimal public key of your MeshCore radio. After connecting the bot once, find
+          it in bot logs as <code className="rounded bg-muted px-1">SELF_INFO</code> or the device pubkey field.
+        </DialogDescription>
+      </DialogHeader>
+
+      <div className="space-y-4 py-4">
+        <div className="space-y-2">
+          <Label htmlFor="mc-pubkey">mc_pubkey (64 hex)</Label>
+          <Input
+            id="mc-pubkey"
+            value={mcPubkey}
+            onChange={(e) => setMcPubkey(e.target.value)}
+            placeholder="a1b2c3d4… (64 characters)"
+            className="font-mono text-sm"
+            autoComplete="off"
+            spellCheck={false}
+          />
+          {observedNode.mc_pubkey ? (
+            <p className="text-xs text-slate-500 dark:text-slate-400">
+              Pre-filled from this observed node. Confirm it matches the physical feeder you will connect.
+            </p>
+          ) : (
+            <p className="text-xs text-slate-500 dark:text-slate-400">
+              If you do not know the pubkey yet, connect the bot with upload disabled, copy the pubkey from logs, then
+              return here.
+            </p>
+          )}
+        </div>
+      </div>
+
+      <DialogFooter>
+        <Button variant="outline" onClick={handlePreviousStep}>
+          Back
+        </Button>
+        <Button onClick={handleNextStep} disabled={!mcPubkey.trim()}>
           Next
         </Button>
       </DialogFooter>
@@ -451,7 +549,11 @@ export function SetupManagedNode({ node, isOpen, onClose }: SetupManagedNodeProp
                     Channel {channelIndex}:
                   </Label>
                   <Select
-                    value={channelMappings[`channel_${channelIndex}` as keyof typeof channelMappings]?.toString() || ''}
+                    value={
+                      channelMappings[
+                        `meshtastic_channel_${channelIndex}` as keyof typeof channelMappings
+                      ]?.toString() || ''
+                    }
                     onValueChange={(value) => handleChannelChange(channelIndex, value ? Number(value) : null)}
                   >
                     <SelectTrigger id={`channel-${channelIndex}`} className="flex-1">
@@ -595,11 +697,12 @@ export function SetupManagedNode({ node, isOpen, onClose }: SetupManagedNodeProp
 
         {effectiveApiKey && config ? (
           <BotSetupInstructions
+            protocol={isMeshCore ? 'meshcore' : 'meshtastic'}
             apiKey={effectiveApiKey}
             apiBaseUrl={config.apis.meshBot.baseUrl}
             nodeShortName={nodeName}
             botDefaults={
-              selectedConstellation != null
+              !isMeshCore && selectedConstellation != null
                 ? (() => {
                     const c = constellations.find((x) => x.id === selectedConstellation);
                     return c
@@ -657,6 +760,8 @@ export function SetupManagedNode({ node, isOpen, onClose }: SetupManagedNodeProp
           </div>
         ) : currentStep === 'constellation' ? (
           renderConstellationStep()
+        ) : currentStep === 'pubkey' ? (
+          renderPubkeyStep()
         ) : currentStep === 'location' ? (
           renderLocationStep()
         ) : currentStep === 'channels' ? (

--- a/src/components/nodes/map-utils.ts
+++ b/src/components/nodes/map-utils.ts
@@ -131,7 +131,7 @@ function percentileSorted(sorted: number[], p: number): number {
 
 /** Minimal node fields for popup content */
 export interface NodePopupData extends NodeDetailLinkInput {
-  meshtastic_node_id: number;
+  meshtastic_node_id?: number | null;
   long_name: string | null;
   short_name: string | null;
   /** Date or ISO string – API may return either; we normalize to locale format */

--- a/src/components/traceroutes/AutoTargetPreviewMap.tsx
+++ b/src/components/traceroutes/AutoTargetPreviewMap.tsx
@@ -89,7 +89,7 @@ export function AutoTargetPreviewMap({
     const hours = mergedGeo.selector_params!.last_heard_within_hours;
     const cutoff = new Date(Date.now() - hours * 60 * 60 * 1000);
     return {
-      feederNodeId: feeder.meshtastic_node_id,
+      feederNodeId: feeder.meshtastic_node_id!,
       managedNodeIds,
       lastHeardCutoff: cutoff,
       geo: mergedGeo,
@@ -243,11 +243,11 @@ export function AutoTargetPreviewMap({
         {
           lat: feederLat,
           lng: feederLng,
-          meshtastic_node_id: feeder.meshtastic_node_id,
+          meshtastic_node_id: feeder.meshtastic_node_id ?? 0,
           node_id_str: feeder.node_id_str,
           short_name: feeder.short_name,
           long_name: feeder.long_name,
-          managed_node_id: String(feeder.meshtastic_node_id),
+          managed_node_id: String(feeder.meshtastic_node_id ?? feeder.node_id_str),
         },
       ],
       { id: 'auto-target-feeder-icons', size: 36, pickable: true }

--- a/src/components/traceroutes/TracerouteFlowDiagram.tsx
+++ b/src/components/traceroutes/TracerouteFlowDiagram.tsx
@@ -111,13 +111,13 @@ export function TracerouteFlowDiagram({ traceroute }: { traceroute: AutoTraceRou
         <div className="flex flex-wrap items-center gap-2">
           <FlowEndpointBadge
             label={sourceLabel}
-            nodeId={sourceNodeId}
+            nodeId={sourceNodeId!}
             directionColor="bg-blue-500/20 text-blue-700 dark:text-blue-300"
           />
           <ArrowRight className="h-4 w-4 shrink-0 text-muted-foreground" />
           <FlowEndpointBadge
             label={targetLabel}
-            nodeId={targetNodeId}
+            nodeId={targetNodeId!}
             directionColor="bg-green-500/20 text-green-700 dark:text-green-300"
           />
         </div>
@@ -131,10 +131,10 @@ export function TracerouteFlowDiagram({ traceroute }: { traceroute: AutoTraceRou
         <h4 className="mb-2 text-sm font-medium text-muted-foreground">Outbound</h4>
         <FlowRow
           startLabel={sourceLabel}
-          startNodeId={sourceNodeId}
+          startNodeId={sourceNodeId!}
           nodes={routeNodes}
           endLabel={targetLabel}
-          endNodeId={targetNodeId}
+          endNodeId={targetNodeId!}
           directionColor="bg-blue-500/20 text-blue-700 dark:text-blue-300"
         />
       </div>
@@ -143,10 +143,10 @@ export function TracerouteFlowDiagram({ traceroute }: { traceroute: AutoTraceRou
           <h4 className="mb-2 text-sm font-medium text-muted-foreground">Return</h4>
           <FlowRow
             startLabel={targetLabel}
-            startNodeId={targetNodeId}
+            startNodeId={targetNodeId!}
             nodes={routeBackNodes}
             endLabel={sourceLabel}
-            endNodeId={sourceNodeId}
+            endNodeId={sourceNodeId!}
             directionColor="bg-green-500/20 text-green-700 dark:text-green-300"
           />
         </div>

--- a/src/hooks/api/useNodeClaims.ts
+++ b/src/hooks/api/useNodeClaims.ts
@@ -100,7 +100,7 @@ export function useDeleteManagedNode() {
   const queryClient = useQueryClient();
 
   return useMutation({
-    mutationFn: (meshtasticNodeId: number) => api.deleteManagedNode(meshtasticNodeId),
+    mutationFn: (managedNodeInternalId: string) => api.deleteManagedNode(managedNodeInternalId),
     onSuccess: () => {
       queryClient.invalidateQueries({ queryKey: ['managed-nodes'] });
       queryClient.invalidateQueries({ queryKey: ['managed-nodes', 'mine'] });

--- a/src/lib/api/meshflow-api.ts
+++ b/src/lib/api/meshflow-api.ts
@@ -18,7 +18,8 @@ import {
   TextMessage,
   TextMessageResponse,
   NodeClaim,
-  CreateManagedNode,
+  CreateMeshtasticManagedNode,
+  CreateMeshCoreManagedNode,
   NodeApiKey,
   CreateNodeApiKey,
   AutoTraceRoute,
@@ -556,7 +557,7 @@ export class MeshflowApi extends BaseApi {
   }
 
   async patchManagedNode(
-    nodeId: number,
+    managedNodeInternalId: string,
     body: {
       meshtastic_channel_0?: number | null;
       meshtastic_channel_1?: number | null;
@@ -568,11 +569,11 @@ export class MeshflowApi extends BaseApi {
       meshtastic_channel_7?: number | null;
     }
   ): Promise<OwnedManagedNode> {
-    return this.patch<OwnedManagedNode>(`/nodes/managed-nodes/${nodeId}/`, body);
+    return this.patch<OwnedManagedNode>(`/nodes/managed-nodes/${managedNodeInternalId}/`, body);
   }
 
   /**
-   * Create a managed node
+   * Create a Meshtastic managed node.
    */
   async createManagedNode(
     nodeId: number,
@@ -594,7 +595,8 @@ export class MeshflowApi extends BaseApi {
       };
     }
   ): Promise<OwnedManagedNode> {
-    const data: CreateManagedNode = {
+    const data: CreateMeshtasticManagedNode = {
+      protocol: 1,
       meshtastic_node_id: nodeId,
       constellation_id: constellationId,
       name: name,
@@ -615,11 +617,37 @@ export class MeshflowApi extends BaseApi {
   }
 
   /**
+   * Create a MeshCore feeder managed node.
+   */
+  async createMeshCoreManagedNode(
+    mcPubkey: string,
+    constellationId: number,
+    name: string,
+    ownerId: number | null,
+    options?: {
+      defaultLocationLatitude?: number;
+      defaultLocationLongitude?: number;
+    }
+  ): Promise<OwnedManagedNode> {
+    const data: CreateMeshCoreManagedNode = {
+      protocol: 2,
+      mc_pubkey: mcPubkey,
+      constellation_id: constellationId,
+      name,
+      owner_id: ownerId,
+      default_location_latitude: options?.defaultLocationLatitude ?? null,
+      default_location_longitude: options?.defaultLocationLongitude ?? null,
+    };
+
+    return this.post<OwnedManagedNode>('/nodes/managed-nodes/', data);
+  }
+
+  /**
    * Soft-delete (un-manage) a managed node: removes API-key links and hides the row from listings.
    * Does not clear the observed-node claim.
    */
-  async deleteManagedNode(nodeId: number): Promise<void> {
-    await this.delete<void>(`/nodes/managed-nodes/${nodeId}/`);
+  async deleteManagedNode(managedNodeInternalId: string): Promise<void> {
+    await this.delete<void>(`/nodes/managed-nodes/${managedNodeInternalId}/`);
   }
 
   // ===== API Keys =====
@@ -647,15 +675,29 @@ export class MeshflowApi extends BaseApi {
   /**
    * Add a node to an API key
    */
-  async addNodeToApiKey(apiKeyId: string, nodeId: number): Promise<NodeApiKey> {
-    return this.post<NodeApiKey>(`/nodes/api-keys/${apiKeyId}/add_node/`, { meshtastic_node_id: nodeId });
+  async addNodeToApiKey(
+    apiKeyId: string,
+    target: { managedNodeInternalId: string } | { meshtasticNodeId: number }
+  ): Promise<NodeApiKey> {
+    const body =
+      'managedNodeInternalId' in target
+        ? { managed_node_internal_id: target.managedNodeInternalId }
+        : { meshtastic_node_id: target.meshtasticNodeId };
+    return this.post<NodeApiKey>(`/nodes/api-keys/${apiKeyId}/add_node/`, body);
   }
 
   /**
    * Remove a node from an API key
    */
-  async removeNodeFromApiKey(apiKeyId: string, nodeId: number): Promise<NodeApiKey> {
-    return this.post<NodeApiKey>(`/nodes/api-keys/${apiKeyId}/remove_node/`, { meshtastic_node_id: nodeId });
+  async removeNodeFromApiKey(
+    apiKeyId: string,
+    target: { managedNodeInternalId: string } | { meshtasticNodeId: number }
+  ): Promise<NodeApiKey> {
+    const body =
+      'managedNodeInternalId' in target
+        ? { managed_node_internal_id: target.managedNodeInternalId }
+        : { meshtastic_node_id: target.meshtasticNodeId };
+    return this.post<NodeApiKey>(`/nodes/api-keys/${apiKeyId}/remove_node/`, body);
   }
 
   /**

--- a/src/lib/managed-node-enrollment.test.ts
+++ b/src/lib/managed-node-enrollment.test.ts
@@ -1,0 +1,99 @@
+import { describe, expect, it } from 'vitest';
+import {
+  apiKeyLinkedInternalIds,
+  apiKeyLinksManagedNode,
+  isObservedNodeManaged,
+  normalizeMcPubkeyInput,
+} from './managed-node-enrollment';
+import type { ManagedNode, NodeApiKey, ObservedNode } from './models';
+
+describe('normalizeMcPubkeyInput', () => {
+  it('accepts 64 hex and lowercases', () => {
+    const hex = 'a'.repeat(64);
+    expect(normalizeMcPubkeyInput(hex.toUpperCase())).toEqual({ ok: true, value: hex });
+  });
+
+  it('rejects wrong length', () => {
+    expect(normalizeMcPubkeyInput('abc')).toEqual({
+      ok: false,
+      message: 'Pubkey must be exactly 64 hexadecimal characters (lowercase).',
+    });
+  });
+});
+
+describe('isObservedNodeManaged', () => {
+  const mcObserved: Pick<ObservedNode, 'protocol' | 'node_id_str' | 'meshtastic_node_id' | 'mc_pubkey' | 'internal_id'> =
+    {
+      protocol: 2,
+      node_id_str: 'mc:aabbccddeeff',
+      meshtastic_node_id: 0,
+      mc_pubkey: 'b'.repeat(64),
+      internal_id: 'obs-1',
+    };
+
+  it('matches MeshCore by mc_pubkey', () => {
+    const managed: Pick<ManagedNode, 'protocol' | 'node_id_str' | 'meshtastic_node_id' | 'mc_pubkey' | 'internal_id'> =
+      {
+        protocol: 2,
+        node_id_str: 'mc:aabbccddeeff',
+        meshtastic_node_id: null,
+        mc_pubkey: 'B'.repeat(64),
+        internal_id: 'mgr-1',
+      };
+    expect(isObservedNodeManaged(mcObserved, [managed])).toBe(true);
+  });
+
+  it('matches Meshtastic by meshtastic_node_id', () => {
+    const observed = {
+      protocol: 1 as const,
+      node_id_str: '!0000002a',
+      meshtastic_node_id: 42,
+      mc_pubkey: null,
+      internal_id: 'obs-mt',
+    };
+    const managed = {
+      protocol: 1 as const,
+      node_id_str: '!0000002a',
+      meshtastic_node_id: 42,
+      mc_pubkey: null,
+      internal_id: 'mgr-mt',
+    };
+    expect(isObservedNodeManaged(observed, [managed])).toBe(true);
+  });
+});
+
+describe('apiKeyLinksManagedNode', () => {
+  const mcNode: Pick<ManagedNode, 'internal_id' | 'meshtastic_node_id' | 'protocol'> = {
+    internal_id: 'uuid-mc',
+    meshtastic_node_id: null,
+    protocol: 2,
+  };
+
+  it('uses linked_managed_nodes for MeshCore', () => {
+    const key = {
+      nodes: [],
+      linked_managed_nodes: [{ internal_id: 'uuid-mc', node_id_str: 'mc:abc', protocol: 2, meshtastic_node_id: null }],
+    } as unknown as NodeApiKey;
+    expect(apiKeyLinksManagedNode(key, mcNode)).toBe(true);
+  });
+
+  it('falls back to legacy nodes list for Meshtastic', () => {
+    const mtNode = { internal_id: 'uuid-mt', meshtastic_node_id: 100, protocol: 1 as const };
+    const key = { nodes: [100], linked_managed_nodes: [] } as unknown as NodeApiKey;
+    expect(apiKeyLinksManagedNode(key, mtNode)).toBe(true);
+  });
+});
+
+describe('apiKeyLinkedInternalIds', () => {
+  it('merges linked_managed_nodes and legacy numeric nodes', () => {
+    const key = {
+      nodes: [7],
+      linked_managed_nodes: [{ internal_id: 'uuid-mc', node_id_str: 'mc:x', protocol: 2, meshtastic_node_id: null }],
+    } as unknown as NodeApiKey;
+    const managed = [
+      { internal_id: 'uuid-mt', meshtastic_node_id: 7 },
+      { internal_id: 'uuid-mc', meshtastic_node_id: null },
+    ];
+    expect(apiKeyLinkedInternalIds(key, managed).sort()).toEqual(['uuid-mc', 'uuid-mt']);
+  });
+});

--- a/src/lib/managed-node-enrollment.ts
+++ b/src/lib/managed-node-enrollment.ts
@@ -1,0 +1,81 @@
+import type { ManagedNode, NodeApiKey, ObservedNode } from '@/lib/models';
+import { meshProtocolFromManagedNode, meshProtocolFromObservedNode, normalizeMeshProtocol } from '@/lib/mesh-protocol';
+
+const MC_PUBKEY_RE = /^[0-9a-f]{64}$/i;
+
+/** Normalize and validate a MeshCore feeder pubkey (64 hex). */
+export function normalizeMcPubkeyInput(raw: string): { ok: true; value: string } | { ok: false; message: string } {
+  const trimmed = raw.trim().toLowerCase().replace(/\s/g, '');
+  if (!trimmed) {
+    return { ok: false, message: 'Feeder pubkey is required (64 hexadecimal characters).' };
+  }
+  if (!MC_PUBKEY_RE.test(trimmed)) {
+    return { ok: false, message: 'Pubkey must be exactly 64 hexadecimal characters (lowercase).' };
+  }
+  return { ok: true, value: trimmed };
+}
+
+export function isMeshCoreEnrollment(protocol: ReturnType<typeof normalizeMeshProtocol>): boolean {
+  return protocol === 2;
+}
+
+/** Whether an observed node already has a matching managed feeder row. */
+export function isObservedNodeManaged(
+  observed: Pick<ObservedNode, 'protocol' | 'node_id_str' | 'meshtastic_node_id' | 'mc_pubkey' | 'internal_id'>,
+  managedNodes: Pick<ManagedNode, 'protocol' | 'node_id_str' | 'meshtastic_node_id' | 'mc_pubkey' | 'internal_id'>[]
+): boolean {
+  const observedProtocol = meshProtocolFromObservedNode(observed);
+  return managedNodes.some((managed) => {
+    const managedProtocol = meshProtocolFromManagedNode(managed);
+    if (managedProtocol !== observedProtocol) return false;
+    if (observedProtocol === 2) {
+      if (observed.mc_pubkey && managed.mc_pubkey) {
+        return observed.mc_pubkey.toLowerCase() === managed.mc_pubkey.toLowerCase();
+      }
+      if (observed.node_id_str && managed.node_id_str) {
+        return observed.node_id_str.toLowerCase() === managed.node_id_str.toLowerCase();
+      }
+      return false;
+    }
+    return (
+      observed.meshtastic_node_id != null &&
+      observed.meshtastic_node_id > 0 &&
+      managed.meshtastic_node_id === observed.meshtastic_node_id
+    );
+  });
+}
+
+/** API key is linked to this managed node (MeshCore uses linked_managed_nodes; MT uses legacy nodes list). */
+export function apiKeyLinksManagedNode(
+  key: NodeApiKey,
+  node: Pick<ManagedNode, 'internal_id' | 'meshtastic_node_id' | 'protocol'>
+): boolean {
+  const internalId = node.internal_id;
+  if (internalId && key.linked_managed_nodes?.some((l) => l.internal_id === internalId)) {
+    return true;
+  }
+  if (node.protocol !== 2 && node.meshtastic_node_id != null && node.meshtastic_node_id > 0) {
+    return key.nodes?.includes(node.meshtastic_node_id) ?? false;
+  }
+  return false;
+}
+
+export function managedNodeStableKey(node: Pick<ManagedNode, 'internal_id' | 'meshtastic_node_id'>): string {
+  return node.internal_id ?? String(node.meshtastic_node_id);
+}
+
+/** Internal IDs currently linked to an API key (MeshCore + Meshtastic). */
+export function apiKeyLinkedInternalIds(
+  key: NodeApiKey,
+  managedNodes: Pick<ManagedNode, 'internal_id' | 'meshtastic_node_id'>[]
+): string[] {
+  const ids = new Set<string>();
+  for (const link of key.linked_managed_nodes ?? []) {
+    if (link.internal_id) ids.add(link.internal_id);
+  }
+  for (const nid of key.nodes ?? []) {
+    const match = managedNodes.find((m) => m.meshtastic_node_id === nid);
+    if (match?.internal_id) ids.add(match.internal_id);
+  }
+  return [...ids];
+}

--- a/src/lib/models.ts
+++ b/src/lib/models.ts
@@ -173,7 +173,10 @@ export interface MeshCorePacketListItem {
 // ManagedNode from Meshflow API v2
 export interface ManagedNode {
   protocol?: MeshProtocol;
-  meshtastic_node_id: number;
+  /** Meshtastic numeric id; null for MeshCore feeders. */
+  meshtastic_node_id: number | null;
+  mc_pubkey?: string | null;
+  internal_id?: string;
   long_name: string | null;
   short_name: string | null;
   last_heard: Date | null;
@@ -241,7 +244,15 @@ export interface OwnedManagedNode extends ManagedNode {
   default_location_longitude?: number | null;
 }
 
-export interface CreateManagedNode {
+export interface LinkedManagedNodeRef {
+  internal_id: string;
+  node_id_str: string;
+  protocol: MeshProtocol;
+  meshtastic_node_id: number | null;
+}
+
+export interface CreateMeshtasticManagedNode {
+  protocol?: 1;
   meshtastic_node_id: number;
   constellation_id: number;
   name: string;
@@ -257,6 +268,19 @@ export interface CreateManagedNode {
   meshtastic_channel_6: number | null;
   meshtastic_channel_7: number | null;
 }
+
+export interface CreateMeshCoreManagedNode {
+  protocol: 2;
+  mc_pubkey: string;
+  constellation_id: number;
+  name: string;
+  owner_id: number | null;
+  default_location_latitude: number | null;
+  default_location_longitude: number | null;
+}
+
+/** @deprecated Use CreateMeshtasticManagedNode or CreateMeshCoreManagedNode */
+export type CreateManagedNode = CreateMeshtasticManagedNode;
 
 /** Enriched route node with position for map display (from API route_nodes/route_back_nodes) */
 export interface TracerouteRouteNode {
@@ -588,7 +612,9 @@ export interface NodeApiKey {
   owner: number;
   last_used: string | null;
   is_active: boolean;
+  /** Legacy Meshtastic numeric ids only (omits MeshCore feeders). */
   nodes: number[];
+  linked_managed_nodes?: LinkedManagedNodeRef[];
 }
 
 export interface CreateNodeApiKey {

--- a/src/lib/my-nodes-grouping.test.ts
+++ b/src/lib/my-nodes-grouping.test.ts
@@ -271,13 +271,15 @@ describe('getPositionHint', () => {
 });
 
 describe('buildNodesForMap and merge', () => {
-  it('dedupes by meshtastic_node_id and merges managed position when observed has none', () => {
+  it('dedupes by node identity and merges managed position when observed has none', () => {
     const claimed = makeObserved({
       meshtastic_node_id: 42,
+      node_id_str: '!0000002a',
       latest_position: null,
     });
     const managed = makeManaged({
       meshtastic_node_id: 42,
+      node_id_str: '!0000002a',
       position: { latitude: 10, longitude: 20 },
     });
     const merged = buildNodesForMap([claimed], [managed]);
@@ -289,6 +291,7 @@ describe('buildNodesForMap and merge', () => {
   it('keeps claimed position when already valid', () => {
     const claimed = makeObserved({
       meshtastic_node_id: 42,
+      node_id_str: '!0000002a',
       latest_position: {
         latitude: 1,
         longitude: 2,
@@ -300,6 +303,7 @@ describe('buildNodesForMap and merge', () => {
     });
     const managed = makeManaged({
       meshtastic_node_id: 42,
+      node_id_str: '!0000002a',
       position: { latitude: 10, longitude: 20 },
     });
     const merged = buildNodesForMap([claimed], [managed]);

--- a/src/lib/my-nodes-grouping.ts
+++ b/src/lib/my-nodes-grouping.ts
@@ -234,7 +234,9 @@ export function managedNodeToObservedNode(m: ManagedNode): ObservedNode {
   const latest_position = positionFromManaged(m);
   return {
     internal_id: '',
-    meshtastic_node_id: m.meshtastic_node_id,
+    meshtastic_node_id: m.meshtastic_node_id ?? 0,
+    protocol: m.protocol,
+    mc_pubkey: m.mc_pubkey ?? null,
     node_id_str: m.node_id_str,
     mac_addr: null,
     long_name: m.long_name,
@@ -263,18 +265,24 @@ export function mergeManagedPositionIntoObserved(node: ObservedNode, m: ManagedN
  */
 export function buildNodesForMap(claimed: ObservedNode[], managed: ManagedNode[]): ObservedNode[] {
   const map = new Map<number, ObservedNode>();
+  const meshcoreOnly = new Map<string, ObservedNode>();
   for (const c of claimed) {
     map.set(c.meshtastic_node_id, c);
   }
   for (const m of managed) {
-    const existing = map.get(m.meshtastic_node_id);
+    const meshId = m.meshtastic_node_id;
+    if (meshId == null) {
+      meshcoreOnly.set(m.node_id_str, managedNodeToObservedNode(m));
+      continue;
+    }
+    const existing = map.get(meshId);
     if (existing) {
-      map.set(m.meshtastic_node_id, mergeManagedPositionIntoObserved(existing, m));
+      map.set(meshId, mergeManagedPositionIntoObserved(existing, m));
     } else {
-      map.set(m.meshtastic_node_id, managedNodeToObservedNode(m));
+      map.set(meshId, managedNodeToObservedNode(m));
     }
   }
-  return [...map.values()];
+  return [...map.values(), ...meshcoreOnly.values()];
 }
 
 /** Card row for a managed node: full observed payload when user also claimed it. */

--- a/src/lib/my-nodes-grouping.ts
+++ b/src/lib/my-nodes-grouping.ts
@@ -233,7 +233,7 @@ function hasValidObservedPosition(p: Position | null | undefined): boolean {
 export function managedNodeToObservedNode(m: ManagedNode): ObservedNode {
   const latest_position = positionFromManaged(m);
   return {
-    internal_id: '',
+    internal_id: m.internal_id ?? '',
     meshtastic_node_id: m.meshtastic_node_id ?? 0,
     protocol: m.protocol,
     mc_pubkey: m.mc_pubkey ?? null,
@@ -259,30 +259,33 @@ export function mergeManagedPositionIntoObserved(node: ObservedNode, m: ManagedN
   return { ...node, latest_position: pos };
 }
 
+function mapKeyForObserved(node: Pick<ObservedNode, 'node_id_str' | 'meshtastic_node_id'>): string {
+  return node.node_id_str || String(node.meshtastic_node_id);
+}
+
+function mapKeyForManaged(m: ManagedNode): string {
+  return m.node_id_str || m.internal_id || String(m.meshtastic_node_id ?? '');
+}
+
 /**
- * Union of claimed + managed for `NodesMap` / battery chart: one entry per `meshtastic_node_id`.
+ * Union of claimed + managed for `NodesMap` / battery chart: one entry per node identity.
  * When both exist, claimed data wins; managed fills in default position if needed.
  */
 export function buildNodesForMap(claimed: ObservedNode[], managed: ManagedNode[]): ObservedNode[] {
-  const map = new Map<number, ObservedNode>();
-  const meshcoreOnly = new Map<string, ObservedNode>();
+  const map = new Map<string, ObservedNode>();
   for (const c of claimed) {
-    map.set(c.meshtastic_node_id, c);
+    map.set(mapKeyForObserved(c), c);
   }
   for (const m of managed) {
-    const meshId = m.meshtastic_node_id;
-    if (meshId == null) {
-      meshcoreOnly.set(m.node_id_str, managedNodeToObservedNode(m));
-      continue;
-    }
-    const existing = map.get(meshId);
+    const key = mapKeyForManaged(m);
+    const existing = map.get(key);
     if (existing) {
-      map.set(meshId, mergeManagedPositionIntoObserved(existing, m));
+      map.set(key, mergeManagedPositionIntoObserved(existing, m));
     } else {
-      map.set(meshId, managedNodeToObservedNode(m));
+      map.set(key, managedNodeToObservedNode(m));
     }
   }
-  return [...map.values(), ...meshcoreOnly.values()];
+  return [...map.values()];
 }
 
 /** Card row for a managed node: full observed payload when user also claimed it. */

--- a/src/pages/nodes/InfrastructureExport.tsx
+++ b/src/pages/nodes/InfrastructureExport.tsx
@@ -62,7 +62,15 @@ function InfrastructureExportContent() {
     includeStatus: true,
   });
 
-  const managedByMeshId = useMemo(() => new Map(managedNodes.map((m) => [m.meshtastic_node_id, m])), [managedNodes]);
+  const managedByMeshId = useMemo(
+    () =>
+      new Map(
+        managedNodes
+          .filter((m): m is typeof m & { meshtastic_node_id: number } => m.meshtastic_node_id != null)
+          .map((m) => [m.meshtastic_node_id, m])
+      ),
+    [managedNodes]
+  );
 
   const exportRows = useMemo(() => buildInfrastructureExportRows(nodes, managedByMeshId), [nodes, managedByMeshId]);
 

--- a/src/pages/nodes/MyNodes.tsx
+++ b/src/pages/nodes/MyNodes.tsx
@@ -23,6 +23,8 @@ import {
   groupClaimedNodes,
   observedNodeForManagedRow,
 } from '@/lib/my-nodes-grouping';
+import { apiKeyLinksManagedNode, isObservedNodeManaged, managedNodeStableKey } from '@/lib/managed-node-enrollment';
+import { meshProtocolFromObservedNode } from '@/lib/mesh-protocol';
 import {
   Dialog,
   DialogContent,
@@ -50,7 +52,7 @@ function MyNodesContent() {
   const [showInstructionsNode, setShowInstructionsNode] = useState<ObservedNode | null>(null);
   const [instructionsModalOpen, setInstructionsModalOpen] = useState(false);
   const [unclaimTarget, setUnclaimTarget] = useState<ObservedNode | null>(null);
-  const [unmanageTarget, setUnmanageTarget] = useState<{ nodeId: number; label: string } | null>(null);
+  const [unmanageTarget, setUnmanageTarget] = useState<{ internalId: string; label: string } | null>(null);
   const cancelClaimMutation = useCancelNodeClaim();
   const deleteManagedMutation = useDeleteManagedNode();
   const { data: apiKeys } = useQuery({
@@ -67,19 +69,9 @@ function MyNodesContent() {
     return m;
   }, [watchesQuery.data]);
 
-  const managedNodeIds = useMemo(() => new Set(myManagedNodes.map((n) => n.meshtastic_node_id)), [myManagedNodes]);
-
-  const claimedByNodeId = useMemo(() => {
-    const m = new Map<number, ObservedNode>();
-    for (const c of myClaimedNodes) {
-      m.set(c.meshtastic_node_id, c);
-    }
-    return m;
-  }, [myClaimedNodes]);
-
   const claimedOnlyNodes = useMemo(
-    () => myClaimedNodes.filter((n) => !managedNodeIds.has(n.meshtastic_node_id)),
-    [myClaimedNodes, managedNodeIds]
+    () => myClaimedNodes.filter((n) => !isObservedNodeManaged(n, myManagedNodes)),
+    [myClaimedNodes, myManagedNodes]
   );
 
   const connectivityBuckets = useMemo(() => groupClaimedNodes(claimedOnlyNodes), [claimedOnlyNodes]);
@@ -102,8 +94,10 @@ function MyNodesContent() {
 
   const renderInstructionsModal = () => {
     if (!showInstructionsNode) return null;
-    const nodeApiKeys = apiKeys?.filter((key) => key.nodes.includes(showInstructionsNode.meshtastic_node_id)) || [];
+    const managedRow = myManagedNodes.find((m) => isObservedNodeManaged(showInstructionsNode, [m]));
+    const nodeApiKeys = managedRow && apiKeys ? apiKeys.filter((key) => apiKeyLinksManagedNode(key, managedRow)) : [];
     const firstApiKey = nodeApiKeys[0]?.key;
+    const instructionProtocol = meshProtocolFromObservedNode(showInstructionsNode) === 2 ? 'meshcore' : 'meshtastic';
     return (
       <Dialog
         open={instructionsModalOpen}
@@ -127,6 +121,7 @@ function MyNodesContent() {
             </Alert>
             {firstApiKey && config ? (
               <BotSetupInstructions
+                protocol={instructionProtocol}
                 apiKey={firstApiKey}
                 apiBaseUrl={config.apis.meshBot.baseUrl}
                 nodeShortName={showInstructionsNode.short_name || showInstructionsNode.node_id_str}
@@ -256,7 +251,7 @@ function MyNodesContent() {
               disabled={deleteManagedMutation.isPending}
               onClick={() => {
                 if (!unmanageTarget) return;
-                deleteManagedMutation.mutate(unmanageTarget.nodeId, {
+                deleteManagedMutation.mutate(unmanageTarget.internalId, {
                   onSuccess: () => setUnmanageTarget(null),
                 });
               }}
@@ -281,12 +276,13 @@ function MyNodesContent() {
               <CardContent>
                 <div className="grid grid-cols-1 sm:grid-cols-2 xl:grid-cols-3 gap-4">
                   {myManagedNodes.map((managed) => {
-                    const node = observedNodeForManagedRow(managed, claimedByNodeId.get(managed.meshtastic_node_id));
+                    const claimedMatch = myClaimedNodes.find((c) => isObservedNodeManaged(c, [managed]));
+                    const node = observedNodeForManagedRow(managed, claimedMatch);
                     const watch = watchesByNodeIdStr.get(node.node_id_str);
                     const liveness = getManagedLiveness(managed);
                     return (
                       <MyNodeCard
-                        key={`managed-${managed.meshtastic_node_id}`}
+                        key={`managed-${managedNodeStableKey(managed)}`}
                         node={node}
                         isManaged
                         isClaimed={node.owner?.id !== undefined}
@@ -299,12 +295,13 @@ function MyNodesContent() {
                           setShowInstructionsNode(node);
                           setInstructionsModalOpen(true);
                         }}
-                        onRequestUnmanage={() =>
+                        onRequestUnmanage={() => {
+                          if (!managed.internal_id) return;
                           setUnmanageTarget({
-                            nodeId: managed.meshtastic_node_id,
+                            internalId: managed.internal_id,
                             label: node.short_name || node.node_id_str,
-                          })
-                        }
+                          });
+                        }}
                       />
                     );
                   })}

--- a/src/pages/traceroutes/FeederCoveragePage.tsx
+++ b/src/pages/traceroutes/FeederCoveragePage.tsx
@@ -143,7 +143,8 @@ export function FeederCoveragePage() {
   useEffect(() => {
     if (selectedFeederId != null) return;
     if (feederOptions.length === 0) return;
-    setSelectedFeederId(feederOptions[0].meshtastic_node_id);
+    const firstId = feederOptions[0].meshtastic_node_id;
+    if (firstId != null) setSelectedFeederId(firstId);
   }, [feederOptions, selectedFeederId]);
 
   // Mirror selection into the URL so it's deep-linkable.

--- a/src/pages/traceroutes/TracerouteHistory.tsx
+++ b/src/pages/traceroutes/TracerouteHistory.tsx
@@ -441,7 +441,7 @@ export function TracerouteHistory() {
                               onClick={() =>
                                 triggerMutation.mutate(
                                   {
-                                    managedNodeId: tr.source_node.meshtastic_node_id,
+                                    managedNodeId: tr.source_node.meshtastic_node_id!,
                                     targetNodeId: tr.target_node.meshtastic_node_id,
                                     targetStrategy:
                                       tr.target_strategy === 'intra_zone' ||

--- a/src/pages/traceroutes/TriggerTracerouteModal.tsx
+++ b/src/pages/traceroutes/TriggerTracerouteModal.tsx
@@ -89,9 +89,14 @@ export function TriggerTracerouteModal({
 
   const managedNodesForMap = useMemo(() => filterManagedNodesForMapDisplay(managedNodes), [managedNodes]);
 
+  const meshtasticManagedNodes = useMemo(
+    () => managedNodes.filter((n) => n.meshtastic_node_id != null && n.meshtastic_node_id > 0),
+    [managedNodes]
+  );
+
   const managedNodeIdSet = useMemo(
-    () => new Set(managedNodesForMap.map((m) => m.meshtastic_node_id)),
-    [managedNodesForMap]
+    () => new Set(meshtasticManagedNodes.map((m) => m.meshtastic_node_id as number)),
+    [meshtasticManagedNodes]
   );
 
   const [pickTargetLastHeardAfter, setPickTargetLastHeardAfter] = useState(() => pickTargetLastHeardCutoff());
@@ -191,8 +196,8 @@ export function TriggerTracerouteModal({
                 <SelectValue placeholder="Select source node..." />
               </SelectTrigger>
               <SelectContent>
-                {managedNodes.map((node) => (
-                  <SelectItem key={node.meshtastic_node_id} value={node.meshtastic_node_id.toString()}>
+                {meshtasticManagedNodes.map((node) => (
+                  <SelectItem key={node.meshtastic_node_id} value={String(node.meshtastic_node_id)}>
                     {node.short_name ?? node.node_id_str} ({node.node_id_str})
                   </SelectItem>
                 ))}

--- a/src/pages/user/ApiKeysPage.tsx
+++ b/src/pages/user/ApiKeysPage.tsx
@@ -11,6 +11,7 @@ import { useConstellationsSuspense } from '@/hooks/api/useConstellations';
 import { useMyManagedNodesSuspense } from '@/hooks/api/useNodes';
 import type { NodeApiKey } from '@/lib/models';
 import type { OwnedManagedNode } from '@/lib/models';
+import { apiKeyLinkedInternalIds, managedNodeStableKey } from '@/lib/managed-node-enrollment';
 
 function ApiKeysContent() {
   const api = useMeshtasticApi();
@@ -24,7 +25,7 @@ function ApiKeysContent() {
   const [apiKeyError, setApiKeyError] = useState<string | null>(null);
   const [assignKeyId, setAssignKeyId] = useState<string | null>(null);
   const [assignModalOpen, setAssignModalOpen] = useState(false);
-  const [selectedAssignNodes, setSelectedAssignNodes] = useState<number[]>([]);
+  const [selectedAssignInternalIds, setSelectedAssignInternalIds] = useState<string[]>([]);
   const [isAssigning, setIsAssigning] = useState(false);
   const [deleteKeyId, setDeleteKeyId] = useState<string | null>(null);
   const [isDeleting, setIsDeleting] = useState(false);
@@ -60,16 +61,16 @@ function ApiKeysContent() {
     }
   };
 
-  const openAssignModal = (keyId: string, currentNodes: number[]) => {
+  const openAssignModal = (keyId: string, currentInternalIds: string[]) => {
     setAssignKeyId(keyId);
-    setSelectedAssignNodes(currentNodes);
+    setSelectedAssignInternalIds(currentInternalIds);
     setAssignModalOpen(true);
   };
 
   const closeAssignModal = () => {
     setAssignModalOpen(false);
     setAssignKeyId(null);
-    setSelectedAssignNodes([]);
+    setSelectedAssignInternalIds([]);
   };
 
   const handleAssignNodes = async () => {
@@ -78,14 +79,15 @@ function ApiKeysContent() {
     if (!apiKey) return;
     setIsAssigning(true);
     try {
-      for (const nodeId of selectedAssignNodes) {
-        if (!apiKey.nodes.includes(nodeId)) {
-          await api.addNodeToApiKey(assignKeyId, nodeId);
+      const currentlyLinked = apiKeyLinkedInternalIds(apiKey, myManagedNodes);
+      for (const internalId of selectedAssignInternalIds) {
+        if (!currentlyLinked.includes(internalId)) {
+          await api.addNodeToApiKey(assignKeyId, { managedNodeInternalId: internalId });
         }
       }
-      for (const nodeId of apiKey.nodes) {
-        if (!selectedAssignNodes.includes(nodeId)) {
-          await api.removeNodeFromApiKey(assignKeyId, nodeId);
+      for (const internalId of currentlyLinked) {
+        if (!selectedAssignInternalIds.includes(internalId)) {
+          await api.removeNodeFromApiKey(assignKeyId, { managedNodeInternalId: internalId });
         }
       }
       await queryClient.invalidateQueries({ queryKey: ['api-keys'] });
@@ -281,25 +283,29 @@ function ApiKeysContent() {
             </p>
             <div className="max-h-48 overflow-y-auto border rounded p-2 mb-4">
               {nodesForAssignModal.length > 0 ? (
-                nodesForAssignModal.map((node) => (
-                  <div key={node.meshtastic_node_id} className="flex items-center gap-2 mb-1">
-                    <input
-                      type="checkbox"
-                      id={`assign-node-${node.meshtastic_node_id}`}
-                      checked={selectedAssignNodes.includes(node.meshtastic_node_id)}
-                      onChange={(e) => {
-                        if (e.target.checked) {
-                          setSelectedAssignNodes((prev) => [...prev, node.meshtastic_node_id]);
-                        } else {
-                          setSelectedAssignNodes((prev) => prev.filter((id) => id !== node.meshtastic_node_id));
-                        }
-                      }}
-                    />
-                    <label htmlFor={`assign-node-${node.meshtastic_node_id}`} className="text-sm cursor-pointer">
-                      {node.short_name || node.node_id_str}
-                    </label>
-                  </div>
-                ))
+                nodesForAssignModal.map((node) => {
+                  const stableKey = managedNodeStableKey(node);
+                  if (!node.internal_id) return null;
+                  return (
+                    <div key={stableKey} className="flex items-center gap-2 mb-1">
+                      <input
+                        type="checkbox"
+                        id={`assign-node-${stableKey}`}
+                        checked={selectedAssignInternalIds.includes(node.internal_id)}
+                        onChange={(e) => {
+                          if (e.target.checked) {
+                            setSelectedAssignInternalIds((prev) => [...prev, node.internal_id!]);
+                          } else {
+                            setSelectedAssignInternalIds((prev) => prev.filter((id) => id !== node.internal_id));
+                          }
+                        }}
+                      />
+                      <label htmlFor={`assign-node-${stableKey}`} className="text-sm cursor-pointer">
+                        {node.short_name || node.node_id_str}
+                      </label>
+                    </div>
+                  );
+                })
               ) : (
                 <span className="text-sm text-muted-foreground">
                   No managed nodes in this constellation. Add nodes from{' '}
@@ -343,7 +349,7 @@ function ApiKeyCard({
   myManagedNodes: OwnedManagedNode[];
   onToggle: (keyId: string, isActive: boolean) => Promise<void>;
   onDelete: (keyId: string) => Promise<void>;
-  onAssignNodes: (keyId: string, currentNodes: number[]) => void;
+  onAssignNodes: (keyId: string, currentInternalIds: string[]) => void;
   onCopy: (text: string) => void;
   isToggling: boolean;
   isDeleting: boolean;
@@ -353,13 +359,11 @@ function ApiKeyCard({
       ? apiKey.constellation
       : ((apiKey.constellation as { id: number })?.id ?? 0);
   const constellationName = getConstellationName(constellationId);
-  const assignedNodeNames = apiKey.nodes
-    .map(
-      (nid) =>
-        myManagedNodes.find((n) => n.meshtastic_node_id === nid)?.short_name ||
-        myManagedNodes.find((n) => n.meshtastic_node_id === nid)?.node_id_str ||
-        `!${nid.toString(16)}`
-    )
+  const assignedNodeNames = apiKeyLinkedInternalIds(apiKey, myManagedNodes)
+    .map((internalId) => {
+      const n = myManagedNodes.find((m) => m.internal_id === internalId);
+      return n?.short_name || n?.node_id_str || internalId;
+    })
     .filter(Boolean);
 
   return (
@@ -397,7 +401,11 @@ function ApiKeyCard({
           >
             {apiKey.is_active ? 'Deactivate' : 'Activate'}
           </Button>
-          <Button size="sm" variant="outline" onClick={() => onAssignNodes(apiKey.id, apiKey.nodes)}>
+          <Button
+            size="sm"
+            variant="outline"
+            onClick={() => onAssignNodes(apiKey.id, apiKeyLinkedInternalIds(apiKey, myManagedNodes))}
+          >
             Assign/Remove Nodes
           </Button>
           <Button

--- a/src/pages/user/NodeSettings.tsx
+++ b/src/pages/user/NodeSettings.tsx
@@ -33,6 +33,8 @@ import {
   type NodeApiKey,
 } from '@/lib/models';
 import { SetupManagedNode } from '@/components/nodes/SetupManagedNode';
+import { apiKeyLinksManagedNode, isObservedNodeManaged, managedNodeStableKey } from '@/lib/managed-node-enrollment';
+import { meshProtocolFromManagedNode } from '@/lib/mesh-protocol';
 import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query';
 import { useMeshtasticApi } from '@/hooks/api/useApi';
 import { cn } from '@/lib/utils';
@@ -49,6 +51,7 @@ function NodeSettingsContent() {
   const [setupInstructionsKey, setSetupInstructionsKey] = useState<{
     apiKey: string;
     nodeShortName: string;
+    protocol: 'meshtastic' | 'meshcore';
     botDefaults?: { ignorePortnums?: string | null; hopLimit?: number | null };
   } | null>(null);
   const [cancelClaimInternalId, setCancelClaimInternalId] = useState<string | null>(null);
@@ -84,8 +87,7 @@ function NodeSettingsContent() {
     navigator.clipboard.writeText(text);
   };
 
-  // Create a Set of managed node IDs for quick lookup
-  const managedNodeIds = new Set(myManagedNodes.map((n) => n.meshtastic_node_id));
+  const isNodeManaged = (observed: ObservedNode) => isObservedNodeManaged(observed, myManagedNodes);
 
   // Fetch API keys
   const { data: apiKeys, isLoading: isLoadingApiKeys } = useQuery({
@@ -138,7 +140,7 @@ function NodeSettingsContent() {
                         >
                           View Node
                         </Link>
-                        {!managedNodeIds.has(node.meshtastic_node_id) && (
+                        {!isNodeManaged(node) && (
                           <Button
                             onClick={() => handleRunAsManagedNode(node)}
                             size="sm"
@@ -269,11 +271,12 @@ function NodeSettingsContent() {
               {myManagedNodes.length > 0 ? (
                 <Accordion type="multiple" className="space-y-2">
                   {myManagedNodes.map((node) => {
-                    const nodeApiKeys = apiKeys?.filter((key) => key.nodes.includes(node.meshtastic_node_id)) || [];
+                    const nodeApiKeys = apiKeys?.filter((key) => apiKeyLinksManagedNode(key, node)) || [];
+                    const stableKey = managedNodeStableKey(node);
                     return (
                       <AccordionItem
-                        key={node.meshtastic_node_id}
-                        value={`node-${node.meshtastic_node_id}`}
+                        key={stableKey}
+                        value={`node-${stableKey}`}
                         className="border-2 border-slate-300 dark:border-slate-500 rounded-lg bg-slate-50/80 dark:bg-slate-950/40 shadow-sm"
                       >
                         <AccordionTrigger className="px-4 py-3 hover:no-underline">
@@ -333,6 +336,7 @@ function NodeSettingsContent() {
                   <DialogTitle>Bot Setup Instructions</DialogTitle>
                 </DialogHeader>
                 <BotSetupInstructions
+                  protocol={setupInstructionsKey.protocol}
                   apiKey={setupInstructionsKey.apiKey}
                   apiBaseUrl={config.apis.meshBot.baseUrl}
                   nodeShortName={setupInstructionsKey.nodeShortName}
@@ -399,7 +403,8 @@ function NodeSettingsContent() {
               disabled={deleteManagedMutation.isPending}
               onClick={() => {
                 if (!unmanageManagedTarget) return;
-                deleteManagedMutation.mutate(unmanageManagedTarget.meshtastic_node_id, {
+                if (!unmanageManagedTarget.internal_id) return;
+                deleteManagedMutation.mutate(unmanageManagedTarget.internal_id, {
                   onSuccess: () => setUnmanageManagedTarget(null),
                 });
               }}
@@ -705,6 +710,7 @@ function ManagedNodeSettings({
     params: {
       apiKey: string;
       nodeShortName: string;
+      protocol: 'meshtastic' | 'meshcore';
       botDefaults?: { ignorePortnums?: string | null; hopLimit?: number | null };
     } | null
   ) => void;
@@ -726,8 +732,11 @@ function ManagedNodeSettings({
   const isChannelMapDirty = !channelMappingsEqual(mappings, savedMappings);
 
   const saveChannels = useMutation({
-    mutationFn: () =>
-      api.patchManagedNode(node.meshtastic_node_id, {
+    mutationFn: () => {
+      if (!node.internal_id) {
+        throw new Error('Managed node is missing internal_id');
+      }
+      return api.patchManagedNode(node.internal_id, {
         meshtastic_channel_0: mappings.meshtastic_channel_0,
         meshtastic_channel_1: mappings.meshtastic_channel_1,
         meshtastic_channel_2: mappings.meshtastic_channel_2,
@@ -736,7 +745,8 @@ function ManagedNodeSettings({
         meshtastic_channel_5: mappings.meshtastic_channel_5,
         meshtastic_channel_6: mappings.meshtastic_channel_6,
         meshtastic_channel_7: mappings.meshtastic_channel_7,
-      }),
+      });
+    },
     onSuccess: () => {
       queryClient.invalidateQueries({ queryKey: ['managed-nodes', 'mine'] });
       setChannelMapOpen(false);
@@ -937,6 +947,7 @@ function ManagedNodeSettings({
                           onShowSetupInstructions({
                             apiKey: apiKey.key,
                             nodeShortName: node.short_name || node.node_id_str,
+                            protocol: meshProtocolFromManagedNode(node) === 2 ? 'meshcore' : 'meshtastic',
                             botDefaults: node.constellation
                               ? {
                                   ignorePortnums:


### PR DESCRIPTION
## Summary

- Protocol-aware `SetupManagedNode` wizard for MeshCore feeders (pubkey, location, API key, bot instructions).
- API client uses `internal_id` for managed-node CRUD and `managed_node_internal_id` on API keys.
- `BotSetupInstructions` MeshCore compose path and `STORAGE_API_VERSION=3` for both protocols.
- Node Settings / My Nodes / API Keys pages key managed nodes by `internal_id` and `linked_managed_nodes`.

Closes #293
Closes #296
Closes #295

Parent: #291

## Testing performed

- `npm run build` (tsc)
- `npm test` (319 tests, via pre-commit on each commit)
- Manual staging E2E still required (claim MC node → wizard → bot ingest)