### PR TITLE
feat(meshcore): passive path diagnostic page (preview) for M1

### DIFF
--- a/docs/meshcore/passive-path-preview.md
+++ b/docs/meshcore/passive-path-preview.md
@@ -1,0 +1,12 @@
+## Passive path tracing (preview)
+
+Route: `/meshcore/path-tracing`
+
+This page is a **diagnostic MVP** for MeshCore passive packet path tracing (API milestone M1). It lists:
+
+- **Segments** — hash segments from ingest rollups, with `hash_size`, `hash_mode`, and resolution `status`. Unknown hashes use dashed styling consistent with heard-path maps.
+- **Edges** — hourly hash→hash buckets derived from list-order `path_hashes` chains. The direction column shows the API value `list_order` (packet list order, not RF forwarding direction).
+
+Staff users can manually annotate a segment (link hash to an observed node) via `PATCH /api/meshcore/path-tracing/segments/{id}/`.
+
+This preview supports **M2 decision-making** (mode/size distribution, chain sanity). The full map, realtime buffer, and centrality UI are tracked separately as [meshflow-ui#309](https://github.com/pskillen/meshflow-ui/issues/309) (M7), building on API work in [meshflow-api#372](https://github.com/pskillen/meshflow-api/issues/372).

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -32,6 +32,7 @@ import DxMonitoringPage from '@/pages/nodes/DxMonitoringPage';
 import { MeshCoreNodesList } from '@/pages/meshcore/MeshCoreNodesList';
 import { MeshCoreMessages } from '@/pages/meshcore/MeshCoreMessages';
 import { MeshCoreDashboard } from '@/pages/meshcore/MeshCoreDashboard';
+import { MeshCorePassivePath } from '@/pages/meshcore/MeshCorePassivePath';
 import { MeshtasticDashboard } from '@/pages/meshtastic/MeshtasticDashboard';
 
 const ManagedNodesStatus = lazy(() => import('@/pages/nodes/ManagedNodesStatus'));
@@ -62,6 +63,7 @@ function App() {
                   <Route path="/messages" element={<MessageHistory />} />
                   <Route path="/meshtastic/dashboard" element={<MeshtasticDashboard />} />
                   <Route path="/meshcore/dashboard" element={<MeshCoreDashboard />} />
+                  <Route path="/meshcore/path-tracing" element={<MeshCorePassivePath />} />
                   <Route path="/meshcore/nodes" element={<MeshCoreNodesList />} />
                   <Route path="/meshcore/messages" element={<MeshCoreMessages />} />
                   <Route path="/meshcore/map" element={<Navigate to="/meshcore/nodes" replace />} />

--- a/src/components/nav-main.tsx
+++ b/src/components/nav-main.tsx
@@ -142,6 +142,11 @@ function buildNavSections(showDxMonitoring: boolean): NavSection[] {
       label: 'MeshCore',
       items: [
         { title: 'Dashboard', url: '/meshcore/dashboard', icon: BarChartIcon },
+        {
+          title: 'Passive path (preview)',
+          url: '/meshcore/path-tracing',
+          icon: RouteIcon,
+        },
         { title: 'Messages', url: '/meshcore/messages', icon: MessageSquareIcon },
         {
           title: 'Nodes',

--- a/src/hooks/api/usePathTracing.ts
+++ b/src/hooks/api/usePathTracing.ts
@@ -1,0 +1,40 @@
+import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query';
+import type { MeshCorePathSegmentAnnotateBody } from '@/lib/models';
+import type { PathTracingQueryParams } from '@/lib/types';
+import { useMeshflowApi } from './useApi';
+
+export function pathTracingEdgesKey(params?: PathTracingQueryParams) {
+  return ['pathTracing', 'edges', params] as const;
+}
+
+export function pathTracingSegmentsKey(params?: PathTracingQueryParams) {
+  return ['pathTracing', 'segments', params] as const;
+}
+
+export function usePathTracingEdges(params?: PathTracingQueryParams) {
+  const api = useMeshflowApi();
+  return useQuery({
+    queryKey: pathTracingEdgesKey(params),
+    queryFn: () => api.getPathTracingEdges(params),
+  });
+}
+
+export function usePathTracingSegments(params?: PathTracingQueryParams) {
+  const api = useMeshflowApi();
+  return useQuery({
+    queryKey: pathTracingSegmentsKey(params),
+    queryFn: () => api.getPathTracingSegments(params),
+  });
+}
+
+export function useAnnotatePathSegment() {
+  const api = useMeshflowApi();
+  const queryClient = useQueryClient();
+  return useMutation({
+    mutationFn: ({ segmentId, body }: { segmentId: string; body: MeshCorePathSegmentAnnotateBody }) =>
+      api.annotatePathSegment(segmentId, body),
+    onSuccess: () => {
+      queryClient.invalidateQueries({ queryKey: ['pathTracing'] });
+    },
+  });
+}

--- a/src/lib/api/meshflow-api.ts
+++ b/src/lib/api/meshflow-api.ts
@@ -34,6 +34,9 @@ import {
   DxNotificationSettings,
   DxNotificationSettingsWrite,
   MeshCorePacketListItem,
+  MeshCorePathEdgeBucket,
+  MeshCorePathSegment,
+  MeshCorePathSegmentAnnotateBody,
 } from '../models';
 import {
   ApiConfig,
@@ -42,6 +45,7 @@ import {
   PaginationParams,
   StatsSnapshotsParams,
   DxEventsQueryParams,
+  PathTracingQueryParams,
 } from '@/lib/types';
 import { parseNodeWatchFromAPI, parseObservedNodeFromAPI } from './api-utils';
 import type { RfProfile, RfProfileUpdateBody, RfPropagationPollResult, RfPropagationRenderRow } from '@/lib/models';
@@ -511,6 +515,38 @@ export class MeshflowApi extends BaseApi {
     if (params?.payload_type != null) searchParams.append('payload_type', String(params.payload_type));
     if (params?.from_pubkey_prefix) searchParams.append('from_pubkey_prefix', params.from_pubkey_prefix);
     return this.get('/meshcore/packets/', searchParams);
+  }
+
+  private appendPathTracingParams(searchParams: URLSearchParams, params?: PathTracingQueryParams) {
+    if (params?.page) searchParams.append('page', params.page.toString());
+    if (params?.page_size) searchParams.append('page_size', params.page_size.toString());
+    if (params?.bucket_start_after) searchParams.append('bucket_start_after', params.bucket_start_after);
+    if (params?.bucket_start_before) searchParams.append('bucket_start_before', params.bucket_start_before);
+    if (params?.observer) searchParams.append('observer', params.observer);
+    if (params?.constellation != null) searchParams.append('constellation', String(params.constellation));
+    if (params?.from_hash) searchParams.append('from_hash', params.from_hash);
+    if (params?.to_hash) searchParams.append('to_hash', params.to_hash);
+    if (params?.resolved != null) searchParams.append('resolved', params.resolved ? 'true' : 'false');
+    if (params?.status) searchParams.append('status', params.status);
+    if (params?.hash_mode != null) searchParams.append('hash_mode', String(params.hash_mode));
+    if (params?.hash_size != null) searchParams.append('hash_size', String(params.hash_size));
+    if (params?.segment_hash) searchParams.append('segment_hash', params.segment_hash);
+  }
+
+  async getPathTracingEdges(params?: PathTracingQueryParams): Promise<PaginatedResponse<MeshCorePathEdgeBucket>> {
+    const searchParams = new URLSearchParams();
+    this.appendPathTracingParams(searchParams, params);
+    return this.get('/meshcore/path-tracing/edges/', searchParams);
+  }
+
+  async getPathTracingSegments(params?: PathTracingQueryParams): Promise<PaginatedResponse<MeshCorePathSegment>> {
+    const searchParams = new URLSearchParams();
+    this.appendPathTracingParams(searchParams, params);
+    return this.get('/meshcore/path-tracing/segments/', searchParams);
+  }
+
+  async annotatePathSegment(segmentId: string, body: MeshCorePathSegmentAnnotateBody): Promise<MeshCorePathSegment> {
+    return this.patch(`/meshcore/path-tracing/segments/${segmentId}/`, body);
   }
 
   async getManagedNodes(

--- a/src/lib/models.ts
+++ b/src/lib/models.ts
@@ -154,6 +154,55 @@ export interface GeoClassification {
   };
 }
 
+export interface MeshCorePathObservedNodeMinimal {
+  internal_id: string;
+  node_id_str: string | null;
+  long_name: string | null;
+}
+
+export interface MeshCorePathEdgeBucket {
+  id: string;
+  bucket_start: string;
+  bucket_size: string;
+  from_kind: string;
+  to_kind: string;
+  from_hash: string;
+  to_hash: string;
+  observer: string | null;
+  observer_name: string | null;
+  constellation: number | null;
+  constellation_name: string | null;
+  packet_count: number;
+  observation_count: number;
+  first_seen_at: string | null;
+  last_seen_at: string | null;
+  avg_snr: number | null;
+  min_snr: number | null;
+  max_snr: number | null;
+  direction: string;
+  resolved: boolean;
+}
+
+export interface MeshCorePathSegment {
+  id: string;
+  segment_hash: string;
+  hash_size: number | null;
+  hash_mode: number | null;
+  status: string;
+  source: string;
+  resolver_version: number;
+  confidence: number | null;
+  observed_node: MeshCorePathObservedNodeMinimal | null;
+  first_seen_at: string;
+  last_seen_at: string;
+}
+
+export interface MeshCorePathSegmentAnnotateBody {
+  observed_node_id?: string | null;
+  node_id_str?: string | null;
+  status?: string;
+}
+
 export interface MeshCorePacketListItem {
   id: string;
   payload_type: number;

--- a/src/lib/types.ts
+++ b/src/lib/types.ts
@@ -44,6 +44,21 @@ export interface DxEventsQueryParams extends PaginationParams {
   first_observed_before?: string;
 }
 
+/** Query params for MeshCore passive path tracing list endpoints. */
+export interface PathTracingQueryParams extends PaginationParams {
+  bucket_start_after?: string;
+  bucket_start_before?: string;
+  observer?: string;
+  constellation?: number;
+  from_hash?: string;
+  to_hash?: string;
+  resolved?: boolean;
+  status?: string;
+  hash_mode?: number;
+  hash_size?: number;
+  segment_hash?: string;
+}
+
 export interface ApiAuthConfig {
   type: 'none' | 'token' | 'basic' | 'oauth' | 'apiKey';
   token?: string;

--- a/src/pages/meshcore/MeshCorePassivePath.test.tsx
+++ b/src/pages/meshcore/MeshCorePassivePath.test.tsx
@@ -1,0 +1,152 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { render, screen, waitFor } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { MemoryRouter } from 'react-router-dom';
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import type { MeshCorePathEdgeBucket, MeshCorePathSegment } from '@/lib/models';
+import {
+  useAnnotatePathSegment,
+  usePathTracingEdges,
+  usePathTracingSegments,
+} from '@/hooks/api/usePathTracing';
+import { MeshCorePassivePath } from './MeshCorePassivePath';
+
+const getCurrentUser = vi.fn();
+
+vi.mock('@/lib/auth/authService', () => ({
+  authService: {
+    getCurrentUser: () => getCurrentUser(),
+  },
+}));
+
+vi.mock('@/hooks/api/usePathTracing', () => ({
+  usePathTracingSegments: vi.fn(),
+  usePathTracingEdges: vi.fn(),
+  useAnnotatePathSegment: vi.fn(),
+}));
+
+const usePathTracingSegmentsMock = vi.mocked(usePathTracingSegments);
+const usePathTracingEdgesMock = vi.mocked(usePathTracingEdges);
+const useAnnotatePathSegmentMock = vi.mocked(useAnnotatePathSegment);
+
+const emptyPage = { count: 0, next: null, previous: null, results: [] as MeshCorePathSegment[] };
+const emptyEdges = { count: 0, next: null, previous: null, results: [] as MeshCorePathEdgeBucket[] };
+
+const sampleSegment: MeshCorePathSegment = {
+  id: 'seg-1',
+  segment_hash: 'aabb',
+  hash_size: 2,
+  hash_mode: 0,
+  status: 'unknown',
+  source: 'rollup',
+  resolver_version: 0,
+  confidence: null,
+  observed_node: null,
+  first_seen_at: '2026-06-01T10:00:00Z',
+  last_seen_at: '2026-06-01T12:00:00Z',
+};
+
+const sampleEdge: MeshCorePathEdgeBucket = {
+  id: 'edge-1',
+  bucket_start: '2026-06-01T09:00:00Z',
+  bucket_size: '1h',
+  from_kind: 'hash',
+  to_kind: 'hash',
+  from_hash: 'aa',
+  to_hash: 'bb',
+  observer: 'obs-uuid',
+  observer_name: 'Feeder A',
+  constellation: null,
+  constellation_name: null,
+  packet_count: 3,
+  observation_count: 5,
+  first_seen_at: '2026-06-01T09:05:00Z',
+  last_seen_at: '2026-06-01T09:55:00Z',
+  avg_snr: 4.5,
+  min_snr: 2,
+  max_snr: 7,
+  direction: 'list_order',
+  resolved: false,
+};
+
+function renderPage() {
+  const client = new QueryClient({ defaultOptions: { queries: { retry: false } } });
+  return render(
+    <QueryClientProvider client={client}>
+      <MemoryRouter>
+        <MeshCorePassivePath />
+      </MemoryRouter>
+    </QueryClientProvider>
+  );
+}
+
+describe('MeshCorePassivePath', () => {
+  const mutateAsync = vi.fn();
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    getCurrentUser.mockReturnValue({ id: 1, username: 'staff', is_staff: true });
+    usePathTracingSegmentsMock.mockReturnValue({
+      isLoading: false,
+      isSuccess: true,
+      isError: false,
+      error: null,
+      data: { ...emptyPage, count: 1, results: [sampleSegment] },
+    } as ReturnType<typeof usePathTracingSegments>);
+    usePathTracingEdgesMock.mockReturnValue({
+      isLoading: false,
+      isSuccess: true,
+      isError: false,
+      error: null,
+      data: { ...emptyEdges, count: 1, results: [sampleEdge] },
+    } as ReturnType<typeof usePathTracingEdges>);
+    useAnnotatePathSegmentMock.mockReturnValue({
+      mutateAsync,
+      isPending: false,
+    } as unknown as ReturnType<typeof useAnnotatePathSegment>);
+  });
+
+  it('renders preview title and segment/edge rows', () => {
+    renderPage();
+    expect(screen.getByText(/Passive path tracing \(preview\)/i)).toBeInTheDocument();
+    expect(screen.getByText('aabb')).toBeInTheDocument();
+    expect(screen.getByText('list_order')).toBeInTheDocument();
+    expect(screen.getByText(/aa → bb/)).toBeInTheDocument();
+  });
+
+  it('passes segment filters into the segments query hook', async () => {
+    const user = userEvent.setup();
+    renderPage();
+    await user.type(screen.getByTestId('segment-filter-hash-mode'), '1');
+    await waitFor(() => {
+      const lastCall = usePathTracingSegmentsMock.mock.calls.at(-1)?.[0];
+      expect(lastCall?.hash_mode).toBe(1);
+    });
+  });
+
+  it('shows staff annotate panel for staff', () => {
+    renderPage();
+    expect(screen.getByTestId('staff-annotate-panel')).toBeInTheDocument();
+  });
+
+  it('hides staff annotate panel for non-staff', () => {
+    getCurrentUser.mockReturnValue({ id: 2, username: 'user', is_staff: false });
+    renderPage();
+    expect(screen.queryByTestId('staff-annotate-panel')).not.toBeInTheDocument();
+  });
+
+  it('submits staff annotation via mutation', async () => {
+    const user = userEvent.setup();
+    mutateAsync.mockResolvedValue(sampleSegment);
+    renderPage();
+    await user.type(screen.getByTestId('annotate-segment-id'), 'seg-1');
+    await user.type(screen.getByTestId('annotate-node-id-str'), 'mc:abc');
+    await user.click(screen.getByTestId('annotate-submit'));
+    await waitFor(() => {
+      expect(mutateAsync).toHaveBeenCalledWith({
+        segmentId: 'seg-1',
+        body: { node_id_str: 'mc:abc', status: 'resolved' },
+      });
+    });
+  });
+});

--- a/src/pages/meshcore/MeshCorePassivePath.tsx
+++ b/src/pages/meshcore/MeshCorePassivePath.tsx
@@ -1,0 +1,419 @@
+import { useMemo, useState } from 'react';
+import { format } from 'date-fns';
+import { enGB } from 'date-fns/locale';
+import { toast } from 'sonner';
+import { authService } from '@/lib/auth/authService';
+import type { MeshCorePathEdgeBucket, MeshCorePathSegment } from '@/lib/models';
+import type { PathTracingQueryParams } from '@/lib/types';
+import { useAnnotatePathSegment, usePathTracingEdges, usePathTracingSegments } from '@/hooks/api/usePathTracing';
+import { Badge } from '@/components/ui/badge';
+import { Button } from '@/components/ui/button';
+import { Card, CardContent, CardDescription, CardHeader, CardTitle } from '@/components/ui/card';
+import { Input } from '@/components/ui/input';
+import { Label } from '@/components/ui/label';
+import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from '@/components/ui/select';
+import { Table, TableBody, TableCell, TableHead, TableHeader, TableRow } from '@/components/ui/table';
+import { cn } from '@/lib/utils';
+
+const SEGMENT_STATUSES = ['unknown', 'resolved', 'ambiguous', 'stale'] as const;
+const PAGE_SIZE = 100;
+
+function formatWhen(iso: string | null | undefined): string {
+  if (!iso) return '—';
+  const d = new Date(iso);
+  if (Number.isNaN(d.getTime())) return '—';
+  return format(d, 'PPp', { locale: enGB });
+}
+
+function segmentNodeLabel(seg: MeshCorePathSegment): string {
+  const node = seg.observed_node;
+  if (!node) return '—';
+  if (node.long_name?.trim()) {
+    return node.node_id_str ? `${node.long_name} (${node.node_id_str})` : node.long_name;
+  }
+  return node.node_id_str ?? node.internal_id;
+}
+
+function snrSummary(edge: MeshCorePathEdgeBucket): string {
+  if (edge.avg_snr == null) return '—';
+  const parts = [`avg ${edge.avg_snr.toFixed(1)}`];
+  if (edge.min_snr != null && edge.max_snr != null) {
+    parts.push(`[${edge.min_snr.toFixed(1)}, ${edge.max_snr.toFixed(1)}]`);
+  }
+  return parts.join(' ');
+}
+
+function SegmentStatusBadge({ status }: { status: string }) {
+  const isUnknown = status === 'unknown';
+  return (
+    <Badge
+      variant={isUnknown ? 'outline' : 'secondary'}
+      className={cn(isUnknown && 'border-dashed font-mono text-muted-foreground')}
+    >
+      {status}
+    </Badge>
+  );
+}
+
+function SegmentHashCell({ hash, status }: { hash: string; status: string }) {
+  const isUnknown = status === 'unknown';
+  return (
+    <span
+      className={cn(
+        'font-mono text-xs break-all',
+        isUnknown && 'border border-dashed border-muted-foreground/60 rounded px-1 py-0.5 text-muted-foreground'
+      )}
+    >
+      {hash}
+    </span>
+  );
+}
+
+export function MeshCorePassivePath() {
+  const isStaff = Boolean(authService.getCurrentUser()?.is_staff);
+
+  const [segmentStatus, setSegmentStatus] = useState<string>('');
+  const [segmentHashMode, setSegmentHashMode] = useState('');
+  const [segmentHashSize, setSegmentHashSize] = useState('');
+  const [segmentHash, setSegmentHash] = useState('');
+
+  const [edgeBucketAfter, setEdgeBucketAfter] = useState('');
+  const [edgeBucketBefore, setEdgeBucketBefore] = useState('');
+  const [edgeObserver, setEdgeObserver] = useState('');
+  const [edgeFromHash, setEdgeFromHash] = useState('');
+  const [edgeToHash, setEdgeToHash] = useState('');
+
+  const [annotateSegmentId, setAnnotateSegmentId] = useState('');
+  const [annotateNodeIdStr, setAnnotateNodeIdStr] = useState('');
+  const [annotateStatus, setAnnotateStatus] = useState<string>('resolved');
+
+  const segmentParams = useMemo((): PathTracingQueryParams => {
+    const p: PathTracingQueryParams = { page: 1, page_size: PAGE_SIZE };
+    if (segmentStatus) p.status = segmentStatus;
+    if (segmentHashMode.trim()) p.hash_mode = Number(segmentHashMode);
+    if (segmentHashSize.trim()) p.hash_size = Number(segmentHashSize);
+    if (segmentHash.trim()) p.segment_hash = segmentHash.trim();
+    return p;
+  }, [segmentStatus, segmentHashMode, segmentHashSize, segmentHash]);
+
+  const edgeParams = useMemo((): PathTracingQueryParams => {
+    const p: PathTracingQueryParams = { page: 1, page_size: PAGE_SIZE };
+    if (edgeBucketAfter.trim()) p.bucket_start_after = edgeBucketAfter.trim();
+    if (edgeBucketBefore.trim()) p.bucket_start_before = edgeBucketBefore.trim();
+    if (edgeObserver.trim()) p.observer = edgeObserver.trim();
+    if (edgeFromHash.trim()) p.from_hash = edgeFromHash.trim();
+    if (edgeToHash.trim()) p.to_hash = edgeToHash.trim();
+    return p;
+  }, [edgeBucketAfter, edgeBucketBefore, edgeObserver, edgeFromHash, edgeToHash]);
+
+  const segmentsQuery = usePathTracingSegments(segmentParams);
+  const edgesQuery = usePathTracingEdges(edgeParams);
+  const annotateMutation = useAnnotatePathSegment();
+
+  const handleAnnotate = async () => {
+    const id = annotateSegmentId.trim();
+    if (!id) {
+      toast.error('Segment id is required');
+      return;
+    }
+    try {
+      await annotateMutation.mutateAsync({
+        segmentId: id,
+        body: {
+          node_id_str: annotateNodeIdStr.trim() || undefined,
+          status: annotateStatus || undefined,
+        },
+      });
+      toast.success('Segment annotated');
+      setAnnotateSegmentId('');
+      setAnnotateNodeIdStr('');
+    } catch {
+      toast.error('Annotation failed');
+    }
+  };
+
+  return (
+    <div className="flex flex-col gap-4 py-4 md:gap-6 md:py-6 px-4 lg:px-6" data-testid="meshcore-passive-path-page">
+      <div>
+        <h1 className="text-2xl font-semibold tracking-tight">Passive path tracing (preview)</h1>
+        <p className="text-sm text-muted-foreground mt-1 max-w-3xl">
+          Diagnostic tables for MeshCore hash-chain edges and segment resolution. Use this view to compare{' '}
+          <code className="text-xs">path_hash_mode</code> / <code className="text-xs">path_hash_size</code>{' '}
+          distributions before M2 decisions. Full map and realtime UI are planned separately (M7).
+        </p>
+      </div>
+
+      <Card data-testid="passive-path-segments">
+        <CardHeader>
+          <CardTitle>Path segments</CardTitle>
+          <CardDescription>
+            Segment hashes seen on ingest; unknown rows use dashed styling (same convention as heard-path maps).
+          </CardDescription>
+        </CardHeader>
+        <CardContent className="space-y-4">
+          <div className="grid gap-3 sm:grid-cols-2 lg:grid-cols-4">
+            <div className="space-y-1">
+              <Label htmlFor="seg-status">Status</Label>
+              <Select value={segmentStatus || 'all'} onValueChange={(v) => setSegmentStatus(v === 'all' ? '' : v)}>
+                <SelectTrigger id="seg-status" data-testid="segment-filter-status">
+                  <SelectValue placeholder="All" />
+                </SelectTrigger>
+                <SelectContent>
+                  <SelectItem value="all">All</SelectItem>
+                  {SEGMENT_STATUSES.map((s) => (
+                    <SelectItem key={s} value={s}>
+                      {s}
+                    </SelectItem>
+                  ))}
+                </SelectContent>
+              </Select>
+            </div>
+            <div className="space-y-1">
+              <Label htmlFor="seg-mode">Hash mode</Label>
+              <Input
+                id="seg-mode"
+                inputMode="numeric"
+                placeholder="Any"
+                value={segmentHashMode}
+                onChange={(e) => setSegmentHashMode(e.target.value)}
+                data-testid="segment-filter-hash-mode"
+              />
+            </div>
+            <div className="space-y-1">
+              <Label htmlFor="seg-size">Hash size</Label>
+              <Input
+                id="seg-size"
+                inputMode="numeric"
+                placeholder="Any"
+                value={segmentHashSize}
+                onChange={(e) => setSegmentHashSize(e.target.value)}
+                data-testid="segment-filter-hash-size"
+              />
+            </div>
+            <div className="space-y-1">
+              <Label htmlFor="seg-hash">Segment hash</Label>
+              <Input
+                id="seg-hash"
+                placeholder="Prefix or full hash"
+                value={segmentHash}
+                onChange={(e) => setSegmentHash(e.target.value)}
+                data-testid="segment-filter-hash"
+              />
+            </div>
+          </div>
+
+          {segmentsQuery.isLoading && <p className="text-sm text-muted-foreground">Loading segments…</p>}
+          {segmentsQuery.isError && <p className="text-sm text-destructive">Failed to load segments.</p>}
+          {segmentsQuery.isSuccess && (
+            <>
+              <p className="text-xs text-muted-foreground">
+                {segmentsQuery.data.count} segment(s) (showing up to {PAGE_SIZE})
+              </p>
+              <Table>
+                <TableHeader>
+                  <TableRow>
+                    <TableHead>Hash</TableHead>
+                    <TableHead>Size</TableHead>
+                    <TableHead>Mode</TableHead>
+                    <TableHead>Status</TableHead>
+                    <TableHead>Node</TableHead>
+                    <TableHead>Source</TableHead>
+                    <TableHead>First seen</TableHead>
+                    <TableHead>Last seen</TableHead>
+                  </TableRow>
+                </TableHeader>
+                <TableBody>
+                  {segmentsQuery.data.results.length === 0 ? (
+                    <TableRow>
+                      <TableCell colSpan={8} className="text-center text-muted-foreground">
+                        No segments
+                      </TableCell>
+                    </TableRow>
+                  ) : (
+                    segmentsQuery.data.results.map((seg) => (
+                      <TableRow key={seg.id} data-testid={`segment-row-${seg.id}`}>
+                        <TableCell>
+                          <SegmentHashCell hash={seg.segment_hash} status={seg.status} />
+                        </TableCell>
+                        <TableCell className="font-mono tabular-nums">{seg.hash_size ?? '—'}</TableCell>
+                        <TableCell className="font-mono tabular-nums">{seg.hash_mode ?? '—'}</TableCell>
+                        <TableCell>
+                          <SegmentStatusBadge status={seg.status} />
+                        </TableCell>
+                        <TableCell className="text-sm">{segmentNodeLabel(seg)}</TableCell>
+                        <TableCell className="text-xs">{seg.source}</TableCell>
+                        <TableCell className="text-xs whitespace-nowrap">{formatWhen(seg.first_seen_at)}</TableCell>
+                        <TableCell className="text-xs whitespace-nowrap">{formatWhen(seg.last_seen_at)}</TableCell>
+                      </TableRow>
+                    ))
+                  )}
+                </TableBody>
+              </Table>
+            </>
+          )}
+
+          {isStaff && (
+            <div className="rounded-md border p-4 space-y-3" data-testid="staff-annotate-panel">
+              <p className="text-sm font-medium">Staff: manual segment annotation</p>
+              <div className="grid gap-3 sm:grid-cols-3">
+                <div className="space-y-1">
+                  <Label htmlFor="annotate-seg-id">Segment id (UUID)</Label>
+                  <Input
+                    id="annotate-seg-id"
+                    value={annotateSegmentId}
+                    onChange={(e) => setAnnotateSegmentId(e.target.value)}
+                    data-testid="annotate-segment-id"
+                  />
+                </div>
+                <div className="space-y-1">
+                  <Label htmlFor="annotate-node">Node id (mc:…)</Label>
+                  <Input
+                    id="annotate-node"
+                    placeholder="mc:…"
+                    value={annotateNodeIdStr}
+                    onChange={(e) => setAnnotateNodeIdStr(e.target.value)}
+                    data-testid="annotate-node-id-str"
+                  />
+                </div>
+                <div className="space-y-1">
+                  <Label htmlFor="annotate-status">Status</Label>
+                  <Select value={annotateStatus} onValueChange={setAnnotateStatus}>
+                    <SelectTrigger id="annotate-status">
+                      <SelectValue />
+                    </SelectTrigger>
+                    <SelectContent>
+                      {SEGMENT_STATUSES.map((s) => (
+                        <SelectItem key={s} value={s}>
+                          {s}
+                        </SelectItem>
+                      ))}
+                    </SelectContent>
+                  </Select>
+                </div>
+              </div>
+              <Button
+                type="button"
+                onClick={() => void handleAnnotate()}
+                disabled={annotateMutation.isPending}
+                data-testid="annotate-submit"
+              >
+                {annotateMutation.isPending ? 'Saving…' : 'Annotate segment'}
+              </Button>
+            </div>
+          )}
+        </CardContent>
+      </Card>
+
+      <Card data-testid="passive-path-edges">
+        <CardHeader>
+          <CardTitle>Path edges (hourly buckets)</CardTitle>
+          <CardDescription>
+            Consecutive hash pairs from list-order <code className="text-xs">path_hashes</code>. Direction is list order
+            only, not RF forwarding direction.
+          </CardDescription>
+        </CardHeader>
+        <CardContent className="space-y-4">
+          <div className="grid gap-3 sm:grid-cols-2 lg:grid-cols-3">
+            <div className="space-y-1">
+              <Label htmlFor="edge-after">Bucket start after (ISO)</Label>
+              <Input
+                id="edge-after"
+                placeholder="2026-06-01T00:00:00Z"
+                value={edgeBucketAfter}
+                onChange={(e) => setEdgeBucketAfter(e.target.value)}
+                data-testid="edge-filter-bucket-after"
+              />
+            </div>
+            <div className="space-y-1">
+              <Label htmlFor="edge-before">Bucket start before (ISO)</Label>
+              <Input
+                id="edge-before"
+                placeholder="2026-06-02T00:00:00Z"
+                value={edgeBucketBefore}
+                onChange={(e) => setEdgeBucketBefore(e.target.value)}
+                data-testid="edge-filter-bucket-before"
+              />
+            </div>
+            <div className="space-y-1">
+              <Label htmlFor="edge-observer">Observer (managed node id)</Label>
+              <Input
+                id="edge-observer"
+                value={edgeObserver}
+                onChange={(e) => setEdgeObserver(e.target.value)}
+                data-testid="edge-filter-observer"
+              />
+            </div>
+            <div className="space-y-1">
+              <Label htmlFor="edge-from">From hash</Label>
+              <Input
+                id="edge-from"
+                value={edgeFromHash}
+                onChange={(e) => setEdgeFromHash(e.target.value)}
+                data-testid="edge-filter-from-hash"
+              />
+            </div>
+            <div className="space-y-1">
+              <Label htmlFor="edge-to">To hash</Label>
+              <Input
+                id="edge-to"
+                value={edgeToHash}
+                onChange={(e) => setEdgeToHash(e.target.value)}
+                data-testid="edge-filter-to-hash"
+              />
+            </div>
+          </div>
+
+          {edgesQuery.isLoading && <p className="text-sm text-muted-foreground">Loading edges…</p>}
+          {edgesQuery.isError && <p className="text-sm text-destructive">Failed to load edges.</p>}
+          {edgesQuery.isSuccess && (
+            <>
+              <p className="text-xs text-muted-foreground">
+                {edgesQuery.data.count} edge bucket(s) (showing up to {PAGE_SIZE})
+              </p>
+              <Table>
+                <TableHeader>
+                  <TableRow>
+                    <TableHead>Bucket</TableHead>
+                    <TableHead>From → To</TableHead>
+                    <TableHead>Direction</TableHead>
+                    <TableHead>Observer</TableHead>
+                    <TableHead>Packets</TableHead>
+                    <TableHead>Observations</TableHead>
+                    <TableHead>SNR</TableHead>
+                    <TableHead>Resolved</TableHead>
+                  </TableRow>
+                </TableHeader>
+                <TableBody>
+                  {edgesQuery.data.results.length === 0 ? (
+                    <TableRow>
+                      <TableCell colSpan={8} className="text-center text-muted-foreground">
+                        No edges
+                      </TableCell>
+                    </TableRow>
+                  ) : (
+                    edgesQuery.data.results.map((edge) => (
+                      <TableRow key={edge.id} data-testid={`edge-row-${edge.id}`}>
+                        <TableCell className="text-xs whitespace-nowrap">{formatWhen(edge.bucket_start)}</TableCell>
+                        <TableCell className="font-mono text-xs">
+                          {edge.from_hash} → {edge.to_hash}
+                        </TableCell>
+                        <TableCell className="font-mono text-xs">{edge.direction}</TableCell>
+                        <TableCell className="text-xs">{edge.observer_name ?? edge.observer ?? '—'}</TableCell>
+                        <TableCell className="tabular-nums">{edge.packet_count}</TableCell>
+                        <TableCell className="tabular-nums">{edge.observation_count}</TableCell>
+                        <TableCell className="text-xs">{snrSummary(edge)}</TableCell>
+                        <TableCell>{edge.resolved ? 'yes' : 'no'}</TableCell>
+                      </TableRow>
+                    ))
+                  )}
+                </TableBody>
+              </Table>
+            </>
+          )}
+        </CardContent>
+      </Card>
+    </div>
+  );
+}
+
+export default MeshCorePassivePath;


### PR DESCRIPTION
## Summary

**M1 diagnostic MVP** for [meshflow-api#372](https://github.com/pskillen/meshflow-api/issues/372) — data tables (segments + hourly edges), not the M7 map ([meshflow-ui#309](https://github.com/pskillen/meshflow-ui/issues/309)).

- API client + hooks for `/meshcore/path-tracing/edges/` and `.../segments/`
- Preview page at `/meshcore/path-tracing` with filters and staff segment annotation
- Docs: `docs/meshcore/passive-path-preview.md`

**Follow-up (separate issue/PR):** logical hop layout in the message heard dialog — [meshflow-ui#311](https://github.com/pskillen/meshflow-ui/issues/311) (not part of this M1 PR).

Requires [meshflow-api#378](https://github.com/pskillen/meshflow-api/pull/378).

## Testing performed

- `npm run lint` (warnings only)
- `npm test` / Vitest for `MeshCorePassivePath`