### PR TITLE
feat(meshcore): logical hop chain per feeder in message heard dialog

### DIFF
--- a/docs/meshcore/heard-path-dialog.md
+++ b/docs/meshcore/heard-path-dialog.md
@@ -1,0 +1,17 @@
+## Message heard dialog (MeshCore paths)
+
+Opened from **N heard** on a MeshCore text message in message history.
+
+### Layout
+
+1. **Geo map** — Leaflet markers for sender (when position known) and feeders with coordinates. No hop polylines on the map.
+2. **Paths by feeder** — One schematic row per observation: sender → hash hops → feeder. Hops use dashed monospace badges (`unknown` per API v1); they are **not** placed at geographic coordinates.
+3. **Feeder list** — Each observer with RSSI/SNR and a **Path (this feeder)** column showing that observation’s hop chain.
+
+Each feeder can report a **different** `path_hashes` / `resolved_path` for the same message.
+
+### Related
+
+- Tracking: [meshflow-ui#311](https://github.com/pskillen/meshflow-ui/issues/311)
+- Passive path diagnostic tables: [passive-path-preview.md](./passive-path-preview.md) (`/meshcore/path-tracing`)
+- Geographic hop placement on maps: deferred — see [meshflow-api packet-path-tracing outstanding](https://github.com/pskillen/meshflow-api/blob/main/docs/features/meshcore/packet-path-tracing/packet-path-tracing-outstanding.md)

--- a/docs/meshcore/passive-path-preview.md
+++ b/docs/meshcore/passive-path-preview.md
@@ -10,3 +10,5 @@ This page is a **diagnostic MVP** for MeshCore passive packet path tracing (API 
 Staff users can manually annotate a segment (link hash to an observed node) via `PATCH /api/meshcore/path-tracing/segments/{id}/`.
 
 This preview supports **M2 decision-making** (mode/size distribution, chain sanity). The full map, realtime buffer, and centrality UI are tracked separately as [meshflow-ui#309](https://github.com/pskillen/meshflow-ui/issues/309) (M7), building on API work in [meshflow-api#372](https://github.com/pskillen/meshflow-api/issues/372).
+
+For **per-message** passive paths in the heard dialog (logical hop chains per feeder), see [heard-path-dialog.md](./heard-path-dialog.md) ([#311](https://github.com/pskillen/meshflow-ui/issues/311)).

--- a/src/components/messages/HeardPathGeoMap.tsx
+++ b/src/components/messages/HeardPathGeoMap.tsx
@@ -1,0 +1,142 @@
+import type { MapPosition } from '@/lib/models';
+import { MAP_NODE_MARKER_CSS } from '@/lib/map-marker-styles';
+import { useMapTileUrl } from '@/hooks/useMapTileUrl';
+import { createNodeIcon } from '@/components/nodes/map-utils';
+import type { LatLng } from '@/lib/map-path-segments';
+import { HEARD_PATH_LEG_COLORS, HEARD_PATH_SENDER_COLOR } from './heard-path-constants';
+import L from 'leaflet';
+import { useEffect, useRef } from 'react';
+import 'leaflet/dist/leaflet.css';
+
+const DEFAULT_CENTER: LatLng = [55.8642, -4.2518];
+
+export type HeardPathGeoAnchor = {
+  label: string;
+  position: MapPosition;
+  color?: string;
+};
+
+export type HeardPathGeoMapProps = {
+  sender: HeardPathGeoAnchor | null;
+  feeders: HeardPathGeoAnchor[];
+  senderName?: string | null;
+};
+
+function toLatLng(pos: MapPosition): LatLng {
+  return [pos.latitude, pos.longitude];
+}
+
+export function HeardPathGeoMap({ sender, feeders, senderName }: HeardPathGeoMapProps) {
+  const mapRef = useRef<HTMLDivElement>(null);
+  const mapInstanceRef = useRef<L.Map | null>(null);
+  const tileLayerRef = useRef<L.TileLayer | null>(null);
+  const layersRef = useRef<L.Layer[]>([]);
+  const { url: tileUrl, attribution } = useMapTileUrl();
+
+  useEffect(() => {
+    if (mapRef.current && !mapInstanceRef.current) {
+      const map = L.map(mapRef.current).setView(DEFAULT_CENTER, 13);
+      const tileLayer = L.tileLayer(tileUrl, { attribution }).addTo(map);
+      tileLayerRef.current = tileLayer;
+      mapInstanceRef.current = map;
+
+      const style = document.createElement('style');
+      style.id = 'heard-path-geo-map-styles';
+      style.textContent = MAP_NODE_MARKER_CSS;
+      document.head.appendChild(style);
+
+      return () => {
+        map.remove();
+        mapInstanceRef.current = null;
+        tileLayerRef.current = null;
+        style.remove();
+      };
+    }
+  }, []);
+
+  useEffect(() => {
+    const map = mapInstanceRef.current;
+    const oldLayer = tileLayerRef.current;
+    if (map && oldLayer) {
+      map.removeLayer(oldLayer);
+      const newLayer = L.tileLayer(tileUrl, { attribution }).addTo(map);
+      tileLayerRef.current = newLayer;
+    }
+  }, [tileUrl, attribution]);
+
+  useEffect(() => {
+    const map = mapInstanceRef.current;
+    if (!map) return;
+
+    layersRef.current.forEach((layer) => layer.remove());
+    layersRef.current = [];
+
+    const bounds = L.latLngBounds([]);
+    let hasMarker = false;
+
+    if (sender) {
+      const pos = toLatLng(sender.position);
+      const marker = L.marker(pos, {
+        icon: createNodeIcon(sender.label, HEARD_PATH_SENDER_COLOR, false),
+      }).addTo(map);
+      layersRef.current.push(marker);
+      bounds.extend(pos);
+      hasMarker = true;
+    }
+
+    feeders.forEach((feeder, index) => {
+      const pos = toLatLng(feeder.position);
+      const color = feeder.color ?? HEARD_PATH_LEG_COLORS[index % HEARD_PATH_LEG_COLORS.length];
+      const marker = L.marker(pos, {
+        icon: createNodeIcon(feeder.label, color, false),
+      }).addTo(map);
+      layersRef.current.push(marker);
+      bounds.extend(pos);
+      hasMarker = true;
+    });
+
+    if (!hasMarker) return;
+
+    map.invalidateSize();
+    const t = setTimeout(() => {
+      if (mapInstanceRef.current !== map) return;
+      map.invalidateSize();
+      const singlePoint = bounds.getNorthEast().equals(bounds.getSouthWest());
+      if (singlePoint) {
+        map.setView(bounds.getCenter(), 13);
+      } else {
+        map.fitBounds(bounds, { padding: [40, 40], maxZoom: 15 });
+      }
+    }, 150);
+    return () => clearTimeout(t);
+  }, [sender, feeders]);
+
+  if (!sender && feeders.length === 0) {
+    return (
+      <div
+        className="flex min-h-[200px] items-center justify-center rounded-md border bg-muted/30 text-sm text-muted-foreground"
+        data-testid="heard-path-geo-map-empty"
+      >
+        No map — sender and feeder positions unknown
+      </div>
+    );
+  }
+
+  const showSenderWarning = !sender;
+  const warningLabel = senderName?.trim() || sender?.label;
+
+  return (
+    <div className="relative rounded-md border" style={{ height: '240px' }} data-testid="heard-path-geo-map">
+      <div ref={mapRef} style={{ height: '100%' }} className="map-container rounded-md" />
+      {showSenderWarning && feeders.length > 0 && (
+        <div
+          className="pointer-events-none absolute left-2 right-2 top-2 z-[1000] rounded-md border border-amber-500/60 bg-amber-50/95 px-3 py-2 text-xs text-amber-950 shadow-sm dark:border-amber-600/50 dark:bg-amber-950/90 dark:text-amber-50"
+          role="status"
+        >
+          Sender position unknown
+          {warningLabel ? ` (${warningLabel})` : ''} — feeders shown; hop paths are schematic below.
+        </div>
+      )}
+    </div>
+  );
+}

--- a/src/components/messages/HeardPathMap.tsx
+++ b/src/components/messages/HeardPathMap.tsx
@@ -7,9 +7,9 @@ import L from 'leaflet';
 import { useEffect, useRef } from 'react';
 import 'leaflet/dist/leaflet.css';
 
+import { HEARD_PATH_LEG_COLORS, HEARD_PATH_SENDER_COLOR } from './heard-path-constants';
+
 const DEFAULT_CENTER: LatLng = [55.8642, -4.2518];
-const SENDER_COLOR = '#16a34a';
-const LEG_COLORS = ['#2563eb', '#0891b2', '#7c3aed', '#db2777', '#ea580c'];
 
 export type MapPosition = { latitude: number; longitude: number };
 
@@ -86,7 +86,7 @@ export function HeardPathMap({ sender, legs, senderName }: HeardPathMapProps) {
 
     if (senderPos) {
       const senderMarker = L.marker(senderPos, {
-        icon: createNodeIcon(sender?.label ?? 'S', SENDER_COLOR, false),
+        icon: createNodeIcon(sender?.label ?? 'S', HEARD_PATH_SENDER_COLOR, false),
       }).addTo(map);
       layersRef.current.push(senderMarker);
       bounds.extend(senderPos);
@@ -94,7 +94,7 @@ export function HeardPathMap({ sender, legs, senderName }: HeardPathMapProps) {
 
     legs.forEach((leg, index) => {
       const receiverPos = toLatLng(leg.receiver.position);
-      const color = leg.lineColor ?? LEG_COLORS[index % LEG_COLORS.length];
+      const color = leg.lineColor ?? HEARD_PATH_LEG_COLORS[index % HEARD_PATH_LEG_COLORS.length];
       const receiverMarker = L.marker(receiverPos, {
         icon: createNodeIcon(leg.receiver.label, color, false),
       }).addTo(map);

--- a/src/components/messages/MeshCoreHeardPathFlow.test.tsx
+++ b/src/components/messages/MeshCoreHeardPathFlow.test.tsx
@@ -1,0 +1,90 @@
+import { describe, expect, it } from 'vitest';
+import { render, screen } from '@testing-library/react';
+import { MemoryRouter } from 'react-router-dom';
+import { MeshCoreHeardPathFlow } from './MeshCoreHeardPathFlow';
+import type { MeshCoreHeardLeg } from './heard-path-map-adapters';
+
+const baseLeg: MeshCoreHeardLeg = {
+  observation: {
+    observer: {
+      node_id_str: 'mc:feed',
+      internal_id: null,
+      long_name: 'Feeder',
+      short_name: 'F',
+      position: { latitude: 55.2, longitude: -4.2 },
+    },
+    rx_time: new Date().toISOString(),
+    rx_rssi: -90,
+    rx_snr: 2,
+    path_hashes: ['aa', 'bb'],
+    resolved_path: [
+      {
+        hash: 'aa',
+        status: 'unknown',
+        node_id_str: null,
+        internal_id: null,
+        long_name: null,
+        ambiguous: false,
+      },
+      {
+        hash: 'bb',
+        status: 'unknown',
+        node_id_str: null,
+        internal_id: null,
+        long_name: null,
+        ambiguous: false,
+      },
+    ],
+    path_known: false,
+  },
+  receiverLabel: 'F',
+  receiverPosition: { latitude: 55.2, longitude: -4.2 },
+  hops: [
+    {
+      hash: 'aa',
+      status: 'unknown',
+      node_id_str: null,
+      internal_id: null,
+      long_name: null,
+      ambiguous: false,
+    },
+    {
+      hash: 'bb',
+      status: 'unknown',
+      node_id_str: null,
+      internal_id: null,
+      long_name: null,
+      ambiguous: false,
+    },
+  ],
+  pathKnown: false,
+  lineColor: '#2563eb',
+};
+
+function renderFlow(leg: MeshCoreHeardLeg, senderKnown: boolean) {
+  return render(
+    <MemoryRouter>
+      <MeshCoreHeardPathFlow leg={leg} senderDisplayLabel="Sender" senderKnown={senderKnown} />
+    </MemoryRouter>
+  );
+}
+
+describe('MeshCoreHeardPathFlow', () => {
+  it('renders one hop badge per segment', () => {
+    renderFlow(baseLeg, true);
+    expect(screen.getByText('aa')).toBeInTheDocument();
+    expect(screen.getByText('bb')).toBeInTheDocument();
+    expect(screen.queryAllByRole('link')).toHaveLength(0);
+  });
+
+  it('shows empty path message when no hops', () => {
+    const leg = { ...baseLeg, hops: [] };
+    renderFlow(leg, true);
+    expect(screen.getByText(/No path recorded for this observation/i)).toBeInTheDocument();
+  });
+
+  it('shows sender unknown label when sender not known', () => {
+    renderFlow(baseLeg, false);
+    expect(screen.getByText(/Sender unknown/i)).toBeInTheDocument();
+  });
+});

--- a/src/components/messages/MeshCoreHeardPathFlow.tsx
+++ b/src/components/messages/MeshCoreHeardPathFlow.tsx
@@ -1,0 +1,49 @@
+import { Badge } from '@/components/ui/badge';
+import { PathHopChain } from './PathHopChain';
+import type { MeshCoreHeardLeg } from './heard-path-map-adapters';
+import { ArrowRight } from 'lucide-react';
+import { cn } from '@/lib/utils';
+
+export type MeshCoreHeardPathFlowProps = {
+  leg: MeshCoreHeardLeg;
+  senderDisplayLabel: string;
+  senderKnown: boolean;
+};
+
+export function MeshCoreHeardPathFlow({ leg, senderDisplayLabel, senderKnown }: MeshCoreHeardPathFlowProps) {
+  const startBadge = (
+    <Badge
+      variant={senderKnown ? 'secondary' : 'outline'}
+      className={cn(!senderKnown && 'border-dashed text-muted-foreground')}
+    >
+      {senderKnown ? senderDisplayLabel : `Sender unknown${senderDisplayLabel ? ` (${senderDisplayLabel})` : ''}`}
+    </Badge>
+  );
+
+  const endBadge = (
+    <Badge variant="secondary" className="max-w-full" style={{ borderColor: leg.lineColor }}>
+      {leg.receiverLabel}
+    </Badge>
+  );
+
+  if (leg.hops.length === 0) {
+    return (
+      <div className="flex flex-wrap items-center gap-1 text-sm" data-testid={`heard-path-flow-${leg.receiverLabel}`}>
+        {startBadge}
+        <ArrowRight className="h-4 w-4 shrink-0 text-muted-foreground" aria-hidden />
+        {endBadge}
+        <span className="w-full text-xs text-muted-foreground italic mt-1">No path recorded for this observation</span>
+      </div>
+    );
+  }
+
+  return (
+    <div className="flex flex-wrap items-center gap-1 text-sm" data-testid={`heard-path-flow-${leg.receiverLabel}`}>
+      {startBadge}
+      <ArrowRight className="h-4 w-4 shrink-0 text-muted-foreground" aria-hidden />
+      <PathHopChain hops={leg.hops} />
+      <ArrowRight className="h-4 w-4 shrink-0 text-muted-foreground" aria-hidden />
+      {endBadge}
+    </div>
+  );
+}

--- a/src/components/messages/MeshCoreHeardPathsPanel.tsx
+++ b/src/components/messages/MeshCoreHeardPathsPanel.tsx
@@ -1,0 +1,37 @@
+import { MeshCoreHeardPathFlow } from './MeshCoreHeardPathFlow';
+import type { MeshCoreHeardLeg } from './heard-path-map-adapters';
+
+export type MeshCoreHeardPathsPanelProps = {
+  legs: MeshCoreHeardLeg[];
+  senderDisplayLabel: string;
+  senderKnown: boolean;
+};
+
+export function MeshCoreHeardPathsPanel({ legs, senderDisplayLabel, senderKnown }: MeshCoreHeardPathsPanelProps) {
+  if (legs.length === 0) {
+    return (
+      <p className="text-sm text-muted-foreground rounded-md border bg-muted/30 px-3 py-4">
+        No feeder observations for this message.
+      </p>
+    );
+  }
+
+  return (
+    <div className="space-y-3" data-testid="meshcore-heard-paths-panel">
+      <p className="text-xs text-muted-foreground">
+        Paths are per feeder and may differ for the same message. Hop hashes are list-order evidence, not map
+        coordinates.
+      </p>
+      {legs.map((leg) => (
+        <div
+          key={`${leg.observation.observer.node_id_str}-${leg.observation.rx_time}`}
+          className="rounded-md border px-3 py-3 space-y-2"
+          style={{ borderLeftWidth: 4, borderLeftColor: leg.lineColor }}
+        >
+          <div className="text-xs font-medium text-muted-foreground">Heard by {leg.receiverLabel}</div>
+          <MeshCoreHeardPathFlow leg={leg} senderDisplayLabel={senderDisplayLabel} senderKnown={senderKnown} />
+        </div>
+      ))}
+    </div>
+  );
+}

--- a/src/components/messages/MessageItem.tsx
+++ b/src/components/messages/MessageItem.tsx
@@ -1,7 +1,16 @@
-import { TextMessage, type PacketObservation, type MeshCoreHeardObservation } from '@/lib/models';
+import { TextMessage, type PacketObservation } from '@/lib/models';
 import { messageProtocol } from '@/lib/message-protocol';
+import { HeardPathGeoMap } from '@/components/messages/HeardPathGeoMap';
 import { HeardPathMap } from '@/components/messages/HeardPathMap';
-import { isMeshCoreHeardObservation, messageToHeardPathLegs } from '@/components/messages/heard-path-map-adapters';
+import { MeshCoreHeardPathsPanel } from '@/components/messages/MeshCoreHeardPathsPanel';
+import { PathHopChain } from '@/components/messages/PathHopChain';
+import {
+  isMeshCoreHeardMessage,
+  isMeshCoreHeardObservation,
+  meshCoreHeardLegs,
+  messageToHeardPathLegs,
+  resolvedHopsFromObservation,
+} from '@/components/messages/heard-path-map-adapters';
 import { Avatar } from '@/components/ui/avatar';
 import { Badge } from '@/components/ui/badge';
 import { Button } from '@/components/ui/button';
@@ -14,6 +23,83 @@ import { ExternalLink } from 'lucide-react';
 import { messageSenderDisplay } from '@/lib/message-display-sender';
 import { nodeDetailPath } from '@/lib/node-detail-routes';
 
+function MeshCoreHeardDialogBody({ message }: { message: TextMessage }) {
+  const { sender, senderDisplayLabel, legs } = useMemo(() => meshCoreHeardLegs(message), [message]);
+  const senderKnown = sender != null;
+
+  const geoFeeders = useMemo(
+    () =>
+      legs
+        .filter((leg) => leg.receiverPosition != null)
+        .map((leg) => ({
+          label: leg.receiverLabel,
+          position: leg.receiverPosition!,
+          color: leg.lineColor,
+        })),
+    [legs]
+  );
+
+  const geoSender = sender ? { label: sender.label, position: sender.position } : null;
+
+  return (
+    <>
+      <HeardPathGeoMap
+        sender={geoSender}
+        feeders={geoFeeders}
+        senderName={message.mc_sender_label || message.sender?.short_name || message.sender?.long_name || null}
+      />
+      {message.mc_sender_candidates && message.mc_sender_candidates.length > 1 && (
+        <p className="text-xs text-muted-foreground -mt-2">
+          Multiple nodes match sender &quot;{message.mc_sender_label}&quot; — map uses feeder positions only.
+        </p>
+      )}
+      <MeshCoreHeardPathsPanel legs={legs} senderDisplayLabel={senderDisplayLabel} senderKnown={senderKnown} />
+      <div className="space-y-4 mt-4">
+        {legs.map((leg, index) => {
+          const mc = leg.observation;
+          const observerLink = nodeDetailPath({
+            internal_id: mc.observer.internal_id ?? undefined,
+            node_id_str: mc.observer.node_id_str,
+            protocol: 2,
+          });
+          const hops = resolvedHopsFromObservation(mc);
+          return (
+            <div
+              key={`${mc.observer.node_id_str}-${index}`}
+              className="grid gap-3 rounded-md border p-3 sm:grid-cols-2 sm:gap-4"
+              style={{ borderLeftWidth: 4, borderLeftColor: leg.lineColor }}
+            >
+              <div className="min-w-0">
+                <div className="font-semibold">
+                  {observerLink ? (
+                    <Link to={observerLink} className="hover:underline">
+                      {leg.receiverLabel}
+                    </Link>
+                  ) : (
+                    leg.receiverLabel
+                  )}
+                </div>
+                {mc.observer.long_name && <div className="text-sm text-muted-foreground">{mc.observer.long_name}</div>}
+                <div className="text-xs text-muted-foreground">
+                  {format(new Date(mc.rx_time), 'MMM d, yyyy h:mm a')}
+                </div>
+                <div className="mt-2 text-right text-xs sm:text-left">
+                  {mc.rx_rssi != null && <div>RSSI: {mc.rx_rssi.toFixed(1)}</div>}
+                  {mc.rx_snr != null && <div>SNR: {mc.rx_snr.toFixed(1)}</div>}
+                </div>
+              </div>
+              <div className="min-w-0 border-t pt-3 sm:border-t-0 sm:border-l sm:pl-4 sm:pt-0">
+                <div className="text-xs font-medium text-muted-foreground mb-1">Path (this feeder)</div>
+                <PathHopChain hops={hops} />
+              </div>
+            </div>
+          );
+        })}
+      </div>
+    </>
+  );
+}
+
 function HeardDialog({
   message,
   size = 'sm',
@@ -25,6 +111,7 @@ function HeardDialog({
 }) {
   const observations = message.heard;
   const count = observations?.length || 0;
+  const meshCore = isMeshCoreHeardMessage(message);
   const { sender, legs } = useMemo(() => messageToHeardPathLegs(message), [message]);
   const protocol = messageProtocol(message);
 
@@ -48,95 +135,56 @@ function HeardDialog({
         <DialogHeader>
           <DialogTitle>Message Heard By</DialogTitle>
         </DialogHeader>
-        <HeardPathMap
-          sender={sender}
-          legs={legs}
-          senderName={message.mc_sender_label || message.sender?.short_name || message.sender?.long_name || null}
-        />
-        {message.mc_sender_candidates && message.mc_sender_candidates.length > 1 && (
-          <p className="text-xs text-muted-foreground -mt-2">
-            Multiple nodes match sender &quot;{message.mc_sender_label}&quot; — map uses feeder positions only.
-          </p>
-        )}
-        <div className="space-y-4 mt-4">
-          {observations?.length ? (
-            observations.map((observation, index) => {
-              if (protocol === 'meshcore' || isMeshCoreHeardObservation(observation)) {
-                const mc = observation as MeshCoreHeardObservation;
-                const observerLabel = mc.observer.short_name || mc.observer.node_id_str;
-                const observerLink = nodeDetailPath({
-                  internal_id: mc.observer.internal_id ?? undefined,
-                  node_id_str: mc.observer.node_id_str,
-                  protocol: 2,
-                });
-                return (
-                  <div
-                    key={`${mc.observer.node_id_str}-${index}`}
-                    className="flex items-start space-x-4 p-2 border rounded-md"
-                  >
-                    <div className="flex-1">
-                      <div className="font-semibold">
-                        {observerLink ? (
-                          <Link to={observerLink} className="hover:underline">
-                            {observerLabel}
-                          </Link>
+        {meshCore ? (
+          <MeshCoreHeardDialogBody message={message} />
+        ) : (
+          <>
+            <HeardPathMap
+              sender={sender}
+              legs={legs}
+              senderName={message.mc_sender_label || message.sender?.short_name || message.sender?.long_name || null}
+            />
+            <div className="space-y-4 mt-4">
+              {observations?.length ? (
+                observations.map((observation) => {
+                  if (protocol === 'meshcore' || isMeshCoreHeardObservation(observation)) {
+                    return null;
+                  }
+                  const mt = observation as PacketObservation;
+                  return (
+                    <div
+                      key={mt.observer.meshtastic_node_id}
+                      className="flex items-start space-x-4 p-2 border rounded-md"
+                    >
+                      <div className="flex-1">
+                        <div className="font-semibold">{mt.observer.short_name || mt.observer.node_id_str}</div>
+                        {mt.observer.long_name && (
+                          <div className="text-sm text-muted-foreground">{mt.observer.long_name}</div>
+                        )}
+                        <div className="text-xs text-muted-foreground">
+                          {format(new Date(mt.rx_time), 'MMM d, yyyy h:mm a')}
+                        </div>
+                      </div>
+                      <div className="text-right">
+                        {mt.direct_from_sender ? (
+                          <div>
+                            <Badge variant="secondary">Direct</Badge>
+                            {mt.rx_rssi != null && <div className="text-xs mt-1">RSSI: {mt.rx_rssi.toFixed(1)}</div>}
+                            {mt.rx_snr != null && <div className="text-xs">SNR: {mt.rx_snr.toFixed(1)}</div>}
+                          </div>
                         ) : (
-                          observerLabel
+                          <Badge variant="outline">Hop: {mt.hop_count}</Badge>
                         )}
                       </div>
-                      {mc.observer.long_name && (
-                        <div className="text-sm text-muted-foreground">{mc.observer.long_name}</div>
-                      )}
-                      <div className="text-xs text-muted-foreground">
-                        {format(new Date(mc.rx_time), 'MMM d, yyyy h:mm a')}
-                      </div>
-                      {mc.resolved_path && mc.resolved_path.length > 0 && (
-                        <div className="mt-2 flex flex-wrap gap-1">
-                          {mc.resolved_path.map((hop) => (
-                            <Badge key={hop.hash} variant="outline" className="font-mono text-xs">
-                              {hop.hash}
-                            </Badge>
-                          ))}
-                        </div>
-                      )}
                     </div>
-                    <div className="text-right text-xs">
-                      {mc.rx_rssi != null && <div>RSSI: {mc.rx_rssi.toFixed(1)}</div>}
-                      {mc.rx_snr != null && <div>SNR: {mc.rx_snr.toFixed(1)}</div>}
-                    </div>
-                  </div>
-                );
-              }
-              const mt = observation as PacketObservation;
-              return (
-                <div key={mt.observer.meshtastic_node_id} className="flex items-start space-x-4 p-2 border rounded-md">
-                  <div className="flex-1">
-                    <div className="font-semibold">{mt.observer.short_name || mt.observer.node_id_str}</div>
-                    {mt.observer.long_name && (
-                      <div className="text-sm text-muted-foreground">{mt.observer.long_name}</div>
-                    )}
-                    <div className="text-xs text-muted-foreground">
-                      {format(new Date(mt.rx_time), 'MMM d, yyyy h:mm a')}
-                    </div>
-                  </div>
-                  <div className="text-right">
-                    {mt.direct_from_sender ? (
-                      <div>
-                        <Badge variant="secondary">Direct</Badge>
-                        {mt.rx_rssi != null && <div className="text-xs mt-1">RSSI: {mt.rx_rssi.toFixed(1)}</div>}
-                        {mt.rx_snr != null && <div className="text-xs">SNR: {mt.rx_snr.toFixed(1)}</div>}
-                      </div>
-                    ) : (
-                      <Badge variant="outline">Hop: {mt.hop_count}</Badge>
-                    )}
-                  </div>
-                </div>
-              );
-            })
-          ) : (
-            <div className="text-center text-muted-foreground">No observation data available</div>
-          )}
-        </div>
+                  );
+                })
+              ) : (
+                <div className="text-center text-muted-foreground">No observation data available</div>
+              )}
+            </div>
+          </>
+        )}
       </DialogContent>
     </Dialog>
   );

--- a/src/components/messages/PathHopBadge.tsx
+++ b/src/components/messages/PathHopBadge.tsx
@@ -1,0 +1,68 @@
+import { Link } from 'react-router-dom';
+import { Badge } from '@/components/ui/badge';
+import { Tooltip, TooltipContent, TooltipProvider, TooltipTrigger } from '@/components/ui/tooltip';
+import type { ResolvedHop } from '@/lib/models';
+import { nodeDetailPath } from '@/lib/node-detail-routes';
+import { cn } from '@/lib/utils';
+
+function hopIsLinkable(hop: ResolvedHop): boolean {
+  return hop.status === 'resolved' && Boolean(hop.node_id_str?.trim());
+}
+
+function hopLabel(hop: ResolvedHop): string {
+  return hop.long_name?.trim() || hop.hash;
+}
+
+export function PathHopBadge({ hop }: { hop: ResolvedHop }) {
+  const unknown = hop.status === 'unknown' || !hopIsLinkable(hop);
+  const badge = (
+    <Badge
+      variant={unknown ? 'outline' : 'secondary'}
+      className={cn(
+        'max-w-full font-mono text-xs',
+        unknown && 'border-dashed text-muted-foreground',
+        hopIsLinkable(hop) && 'cursor-pointer'
+      )}
+    >
+      {hopLabel(hop)}
+    </Badge>
+  );
+
+  const wrapped =
+    hop.ambiguous && unknown ? (
+      <TooltipProvider>
+        <Tooltip>
+          <TooltipTrigger asChild>
+            <span className="inline-flex">{badge}</span>
+          </TooltipTrigger>
+          <TooltipContent>Multiple matches possible</TooltipContent>
+        </Tooltip>
+      </TooltipProvider>
+    ) : (
+      badge
+    );
+
+  if (!hopIsLinkable(hop)) {
+    return wrapped;
+  }
+
+  const path = nodeDetailPath({
+    node_id_str: hop.node_id_str!,
+    internal_id: hop.internal_id ?? undefined,
+    protocol: 2,
+  });
+
+  if (!path) {
+    return wrapped;
+  }
+
+  return (
+    <Link
+      to={path}
+      className="inline-flex max-w-full rounded-md focus:outline-none focus:ring-2 focus:ring-ring focus:ring-offset-2"
+      onClick={(e) => e.stopPropagation()}
+    >
+      {wrapped}
+    </Link>
+  );
+}

--- a/src/components/messages/PathHopChain.tsx
+++ b/src/components/messages/PathHopChain.tsx
@@ -1,0 +1,24 @@
+import type { ResolvedHop } from '@/lib/models';
+import { PathHopBadge } from './PathHopBadge';
+import { ArrowRight } from 'lucide-react';
+
+export function PathHopChain({ hops, emptyLabel }: { hops: ResolvedHop[]; emptyLabel?: string }) {
+  if (hops.length === 0) {
+    return (
+      <span className="text-xs text-muted-foreground italic">
+        {emptyLabel ?? 'No path recorded for this observation'}
+      </span>
+    );
+  }
+
+  return (
+    <div className="flex flex-wrap items-center gap-1" data-testid="path-hop-chain">
+      {hops.map((hop, index) => (
+        <span key={`${hop.hash}-${index}`} className="flex items-center gap-1">
+          {index > 0 && <ArrowRight className="h-3 w-3 shrink-0 text-muted-foreground" aria-hidden />}
+          <PathHopBadge hop={hop} />
+        </span>
+      ))}
+    </div>
+  );
+}

--- a/src/components/messages/heard-path-constants.ts
+++ b/src/components/messages/heard-path-constants.ts
@@ -1,0 +1,3 @@
+export const HEARD_PATH_SENDER_COLOR = '#16a34a';
+
+export const HEARD_PATH_LEG_COLORS = ['#2563eb', '#0891b2', '#7c3aed', '#db2777', '#ea580c'];

--- a/src/components/messages/heard-path-map-adapters.test.ts
+++ b/src/components/messages/heard-path-map-adapters.test.ts
@@ -1,5 +1,10 @@
 import { describe, expect, it } from 'vitest';
-import { meshtasticHeardToLegs, meshCoreHeardToLegs } from './heard-path-map-adapters';
+import {
+  meshCoreHeardLegs,
+  meshCoreHeardToLegs,
+  meshtasticHeardToLegs,
+  resolvedHopsFromObservation,
+} from './heard-path-map-adapters';
 import type { TextMessage } from '@/lib/models';
 
 describe('heard path adapters', () => {
@@ -167,5 +172,141 @@ describe('heard path adapters', () => {
     expect(legs[0].waypoints[0].node_id_str).toBe('aa');
     expect(legs[0].waypoints[0].position).toBeNull();
     expect(legs[0].pathKnown).toBe(false);
+  });
+
+  it('meshCoreHeardLegs includes feeder without observer position', () => {
+    const message: TextMessage = {
+      id: '5',
+      packet_id: 5,
+      protocol: 'meshcore',
+      sender: { node_id_str: 'mc:abc', long_name: 'X', short_name: 'X' },
+      sender_position: { latitude: 55.0, longitude: -4.0 },
+      recipient_meshtastic_node_id: null,
+      channel: 1,
+      sent_at: new Date().toISOString(),
+      message_text: 'mc',
+      is_emoji: false,
+      reply_to_meshtastic_packet_id: null,
+      heard: [
+        {
+          observer: {
+            node_id_str: 'mc:feed',
+            internal_id: null,
+            long_name: 'Feeder',
+            short_name: 'F',
+            position: null,
+          },
+          rx_time: new Date().toISOString(),
+          rx_rssi: -90,
+          rx_snr: 2,
+          path_hashes: ['aa'],
+          path_known: false,
+        },
+      ],
+    };
+    const { legs } = meshCoreHeardLegs(message);
+    expect(legs).toHaveLength(1);
+    expect(legs[0].receiverPosition).toBeNull();
+    expect(legs[0].hops).toHaveLength(1);
+    expect(legs[0].hops[0].hash).toBe('aa');
+  });
+
+  it('meshCoreHeardLegs returns distinct paths per feeder', () => {
+    const message: TextMessage = {
+      id: '6',
+      packet_id: 6,
+      protocol: 'meshcore',
+      sender: { node_id_str: 'mc:abc', long_name: 'X', short_name: 'X' },
+      sender_position: { latitude: 55.0, longitude: -4.0 },
+      recipient_meshtastic_node_id: null,
+      channel: 1,
+      sent_at: new Date().toISOString(),
+      message_text: 'mc',
+      is_emoji: false,
+      reply_to_meshtastic_packet_id: null,
+      heard: [
+        {
+          observer: {
+            node_id_str: 'mc:f1',
+            internal_id: null,
+            long_name: 'F1',
+            short_name: 'F1',
+            position: { latitude: 55.1, longitude: -4.1 },
+          },
+          rx_time: new Date().toISOString(),
+          rx_rssi: -90,
+          rx_snr: 2,
+          path_hashes: ['aa'],
+          resolved_path: [
+            {
+              hash: 'aa',
+              status: 'unknown',
+              node_id_str: null,
+              internal_id: null,
+              long_name: null,
+              ambiguous: false,
+            },
+          ],
+          path_known: false,
+        },
+        {
+          observer: {
+            node_id_str: 'mc:f2',
+            internal_id: null,
+            long_name: 'F2',
+            short_name: 'F2',
+            position: { latitude: 55.2, longitude: -4.2 },
+          },
+          rx_time: new Date().toISOString(),
+          rx_rssi: -88,
+          rx_snr: 3,
+          path_hashes: ['aa', 'cc'],
+          resolved_path: [
+            {
+              hash: 'aa',
+              status: 'unknown',
+              node_id_str: null,
+              internal_id: null,
+              long_name: null,
+              ambiguous: false,
+            },
+            {
+              hash: 'cc',
+              status: 'unknown',
+              node_id_str: null,
+              internal_id: null,
+              long_name: null,
+              ambiguous: false,
+            },
+          ],
+          path_known: false,
+        },
+      ],
+    };
+    const { legs } = meshCoreHeardLegs(message);
+    expect(legs).toHaveLength(2);
+    expect(legs[0].hops).toHaveLength(1);
+    expect(legs[1].hops).toHaveLength(2);
+    expect(legs[0].lineColor).not.toBe(legs[1].lineColor);
+  });
+
+  it('resolvedHopsFromObservation falls back to path_hashes', () => {
+    const hops = resolvedHopsFromObservation({
+      observer: {
+        node_id_str: 'mc:f',
+        internal_id: null,
+        long_name: null,
+        short_name: 'F',
+        position: null,
+      },
+      rx_time: new Date().toISOString(),
+      rx_rssi: null,
+      rx_snr: null,
+      path_hashes: ['de', 'ad'],
+      path_known: false,
+    });
+    expect(hops).toHaveLength(2);
+    expect(hops[0].status).toBe('unknown');
+    expect(hops[1].hash).toBe('ad');
   });
 });

--- a/src/components/messages/heard-path-map-adapters.ts
+++ b/src/components/messages/heard-path-map-adapters.ts
@@ -7,6 +7,7 @@ import type {
   TextMessage,
 } from '@/lib/models';
 import type { TracerouteRouteNode } from '@/lib/models';
+import { HEARD_PATH_LEG_COLORS } from './heard-path-constants';
 import type { HeardPathLeg } from './HeardPathMap';
 
 const UNKNOWN_NODE_ID = 0xffffffff;
@@ -15,6 +16,29 @@ export function isMeshCoreHeardObservation(
   obs: PacketObservation | MeshCoreHeardObservation
 ): obs is MeshCoreHeardObservation {
   return 'path_hashes' in obs;
+}
+
+export type MeshCoreHeardLeg = {
+  observation: MeshCoreHeardObservation;
+  receiverLabel: string;
+  receiverPosition: MapPosition | null;
+  hops: ResolvedHop[];
+  pathKnown: boolean;
+  lineColor: string;
+};
+
+export function resolvedHopsFromObservation(obs: MeshCoreHeardObservation): ResolvedHop[] {
+  if (obs.resolved_path?.length) {
+    return obs.resolved_path;
+  }
+  return (obs.path_hashes ?? []).map((hash) => ({
+    hash,
+    status: 'unknown' as const,
+    node_id_str: null,
+    internal_id: null,
+    long_name: null,
+    ambiguous: false,
+  }));
 }
 
 function senderFromMcCandidates(candidates: McSenderCandidate[] | undefined): {
@@ -33,7 +57,7 @@ function senderFromMcCandidates(candidates: McSenderCandidate[] | undefined): {
   };
 }
 
-function mapSender(message: TextMessage): { label: string; position: MapPosition } | null {
+export function mapHeardPathSender(message: TextMessage): { label: string; position: MapPosition } | null {
   if (message.sender && message.sender_position) {
     return {
       label: message.sender.short_name || message.sender.node_id_str,
@@ -49,6 +73,14 @@ function mapSender(message: TextMessage): { label: string; position: MapPosition
   return senderFromMcCandidates(message.mc_sender_candidates);
 }
 
+export function heardPathSenderDisplayLabel(
+  message: TextMessage,
+  sender: { label: string; position: MapPosition } | null
+): string {
+  if (sender?.label) return sender.label;
+  return message.mc_sender_label?.trim() || message.sender?.short_name || message.sender?.node_id_str || 'Sender';
+}
+
 function hopToWaypoint(hop: ResolvedHop): TracerouteRouteNode {
   return {
     meshtastic_node_id: UNKNOWN_NODE_ID,
@@ -58,14 +90,40 @@ function hopToWaypoint(hop: ResolvedHop): TracerouteRouteNode {
   };
 }
 
+export function meshCoreHeardLegs(message: TextMessage): {
+  sender: { label: string; position: MapPosition } | null;
+  senderDisplayLabel: string;
+  legs: MeshCoreHeardLeg[];
+} {
+  const sender = mapHeardPathSender(message);
+  const senderDisplayLabel = heardPathSenderDisplayLabel(message, sender);
+  const legs: MeshCoreHeardLeg[] = [];
+  let colorIndex = 0;
+
+  for (const obs of message.heard ?? []) {
+    if (!isMeshCoreHeardObservation(obs)) continue;
+    legs.push({
+      observation: obs,
+      receiverLabel: obs.observer.short_name || obs.observer.node_id_str,
+      receiverPosition: obs.observer.position,
+      hops: resolvedHopsFromObservation(obs),
+      pathKnown: obs.path_known ?? false,
+      lineColor: HEARD_PATH_LEG_COLORS[colorIndex % HEARD_PATH_LEG_COLORS.length],
+    });
+    colorIndex += 1;
+  }
+
+  return { sender, senderDisplayLabel, legs };
+}
+
 export function meshtasticHeardToLegs(message: TextMessage): {
   sender: { label: string; position: MapPosition } | null;
   legs: HeardPathLeg[];
 } {
-  const sender = mapSender(message);
+  const sender = mapHeardPathSender(message);
 
   const legs: HeardPathLeg[] = [];
-  for (const obs of message.heard) {
+  for (const obs of message.heard ?? []) {
     if (isMeshCoreHeardObservation(obs)) continue;
     const position = obs.observer_position;
     if (!position) continue;
@@ -81,28 +139,23 @@ export function meshtasticHeardToLegs(message: TextMessage): {
   return { sender, legs };
 }
 
+/** Geo map legs for MC: positioned feeders only (hop polylines not drawn on map). */
 export function meshCoreHeardToLegs(message: TextMessage): {
   sender: { label: string; position: MapPosition } | null;
   legs: HeardPathLeg[];
 } {
-  const sender = mapSender(message);
-
-  const legs: HeardPathLeg[] = [];
-  for (const obs of message.heard) {
-    if (!isMeshCoreHeardObservation(obs)) continue;
-    const position = obs.observer.position;
-    if (!position) continue;
-    const waypoints = (obs.resolved_path ?? []).map(hopToWaypoint);
-    legs.push({
-      receiver: {
-        label: obs.observer.short_name || obs.observer.node_id_str,
-        position,
-      },
-      waypoints,
-      pathKnown: obs.path_known ?? false,
+  const { sender, legs } = meshCoreHeardLegs(message);
+  const mapLegs: HeardPathLeg[] = [];
+  for (const leg of legs) {
+    if (!leg.receiverPosition) continue;
+    mapLegs.push({
+      receiver: { label: leg.receiverLabel, position: leg.receiverPosition },
+      waypoints: leg.hops.map(hopToWaypoint),
+      pathKnown: leg.pathKnown,
+      lineColor: leg.lineColor,
     });
   }
-  return { sender, legs };
+  return { sender, legs: mapLegs };
 }
 
 export function messageToHeardPathLegs(message: TextMessage): {
@@ -114,4 +167,10 @@ export function messageToHeardPathLegs(message: TextMessage): {
     return meshCoreHeardToLegs(message);
   }
   return meshtasticHeardToLegs(message);
+}
+
+export function isMeshCoreHeardMessage(message: TextMessage): boolean {
+  const proto = message.protocol?.toString().toLowerCase();
+  if (proto === 'meshcore' || proto === '2') return true;
+  return (message.heard ?? []).some(isMeshCoreHeardObservation);
 }


### PR DESCRIPTION
## Summary

Implements [meshflow-ui#311](https://github.com/pskillen/meshflow-ui/issues/311) (parent [meshflow-api#267](https://github.com/pskillen/meshflow-api/issues/267)): MeshCore message **heard** dialog now shows passive path evidence per feeder.

- **Geo map** (`HeardPathGeoMap`): sender + feeder markers only — no hop polylines on the map
- **Logical paths** (`MeshCoreHeardPathsPanel`): one schematic hop chain per observation (sender → hash hops → feeder)
- **Feeder list**: two-column layout with path hop badges beside each observer (distinct path per feeder)
- Meshtastic messages unchanged (`HeardPathMap` as before)

Uses existing message API `heard[]` `path_hashes` / `resolved_path` ([#360](https://github.com/pskillen/meshflow-api/issues/360)); no API deploy required.

Closes #311

## Testing performed

- `npm run lint` (warnings only)
- `npm test` / Vitest: `heard-path-map-adapters.test.ts`, `MeshCoreHeardPathFlow.test.tsx`
- Manual: open MeshCore message → **N heard** → verify per-feeder schematic paths and path column in list