### PR TITLE
docs(messages): align channel label docs with #379 display_label

### DIFF
--- a/docs/messages/README.md
+++ b/docs/messages/README.md
@@ -31,4 +31,4 @@ Documentation for the Meshflow UI **text message history** experience (Meshtasti
 
 - OpenAPI: `GET /api/messages/text/` (`channel_id`, `constellation_id`, `protocol`, `sender_node_id`, pagination)
 - WebSocket: `/ws/messages/?token=…` — pushes `TextMessage` payloads
-- Constellations/channels: `Constellation.protocol`, `MessageChannel.protocol`, `mc_channel_idx`, `mc_channel_type` ([meshflow-api text-message-channels](https://github.com/pskillen/meshflow-api/blob/main/docs/features/meshcore/text-message-channels.md))
+- Constellations/channels: `Constellation.protocol`, `MessageChannel.protocol`, `display_label`, `mc_channel_type` ([meshflow-api text-message-channels](https://github.com/pskillen/meshflow-api/blob/main/docs/features/meshcore/text-message-channels.md))

--- a/docs/messages/architecture.md
+++ b/docs/messages/architecture.md
@@ -65,7 +65,7 @@ flowchart TB
 ### `message-channels.ts`
 
 - `filterChannelsForProtocol`: match `MessageChannel.protocol`; channels with **no** protocol field are treated as **Meshtastic-only** (legacy).
-- `formatMessageChannelLabel`: appends `(#mc_channel_idx)` when set.
+- `formatMessageChannelLabel`: uses API `display_label` when set; for HASHTAG channels formats as `#tag` (device slot index is not on `MessageChannel`).
 
 ### Data hooks
 
@@ -107,6 +107,6 @@ Query keys include `protocol`, `channelId`, `constellationId`, `nodeId`, `pageSi
 
 `TextMessage` in `src/lib/models.ts` matches API v2 shape (`heard`, `is_emoji`, `reply_to_meshtastic_packet_id`, `protocol`).
 
-`Constellation` in the UI **does not** currently declare `protocol`, though OpenAPI and Django expose `Constellation.protocol` (single protocol per constellation in the data model). Channel rows have `protocol`, `mc_channel_idx`, `mc_channel_type` (optional on `MessageChannel`).
+`Constellation` in the UI **does not** currently declare `protocol`, though OpenAPI and Django expose `Constellation.protocol` (single protocol per constellation in the data model). Channel rows have `protocol`, `mc_channel_type`, `mc_hashtag`, `display_label` (optional on `MessageChannel`). Per-feeder device slots live on `ManagedNode.mc_channels` mirror entries (`mc_channel_idx` on feeder link), not on the constellation channel row.
 
-MeshCore channel **admin/sync** UI lives on **Node settings** (`NodeSettings.tsx`), not on the messages page.
+MeshCore channel **assign / apply** UI lives on **Node settings** (`MeshCoreChannelEditor` in `NodeSettings.tsx`), not on the messages page.

--- a/docs/messages/current-features.md
+++ b/docs/messages/current-features.md
@@ -16,15 +16,15 @@ Reverse-engineered from the codebase as of the docs migration. Meshtastic (MT) a
 
 ### Channels
 
-| Protocol | Typical channels                                          | UI labelling                                                 |
-| -------- | --------------------------------------------------------- | ------------------------------------------------------------ |
-| **MT**   | Often 1 primary (+ occasional second)                     | Channel `name`                                               |
-| **MC**   | Many per constellation — **PUBLIC** and **HASHTAG** types | `name` + `(#mc_channel_idx)` via `formatMessageChannelLabel` |
+| Protocol | Typical channels                                          | UI labelling                                                                         |
+| -------- | --------------------------------------------------------- | ------------------------------------------------------------------------------------ |
+| **MT**   | Often 1 primary (+ occasional second)                     | Channel `name`                                                                       |
+| **MC**   | Many per constellation — **PUBLIC** and **HASHTAG** types | `display_label` or `#hashtag` via `formatMessageChannelLabel` (no device slot index) |
 
 - Channel list: filtered with `filterChannelsForProtocol` (by `MessageChannel.protocol`).
 - Legacy channels without `protocol` appear only on **Meshtastic** pages.
 - Only **one channel** is loaded/displayed at a time; switching channel refetches/rebinds `MessageList`.
-- `mc_channel_type` / `mc_hashtag` are **not** shown on the messages picker (only index in label). Hashtag display names may equal hashtag string on the radio.
+- `mc_channel_type` is not shown separately on the messages picker; hashtags appear as `#tag` when `display_label` / `mc_hashtag` are set.
 
 ### Multi-channel support summary
 

--- a/docs/messages/gaps-and-roadmap.md
+++ b/docs/messages/gaps-and-roadmap.md
@@ -30,11 +30,11 @@ Depends on [#277] so the auto-selected constellation is protocol-valid.
 
 ### [#281 — Better channels UI](https://github.com/pskillen/meshflow-ui/issues/281)
 
-| Area            | Today                                 | Target                                                                              |
-| --------------- | ------------------------------------- | ----------------------------------------------------------------------------------- |
-| Channel control | Single `<select>`, one active channel | Search/filter; grid or list; show `mc_channel_idx`, type (PUBLIC/HASHTAG), protocol |
-| Scale           | Poor for 10+ MC channels              | Desktop/tablet usable at 10+                                                        |
-| MC ops          | Not on messages page                  | Surface sync/apply status where API allows (link to node settings or inline status) |
+| Area            | Today                                 | Target                                                                                          |
+| --------------- | ------------------------------------- | ----------------------------------------------------------------------------------------------- |
+| Channel control | Single `<select>`, one active channel | Search/filter; grid or list; show `display_label` / `#hashtag`, type (PUBLIC/HASHTAG), protocol |
+| Scale           | Poor for 10+ MC channels              | Desktop/tablet usable at 10+                                                                    |
+| MC ops          | Not on messages page                  | Surface sync/apply status where API allows (link to node settings or inline status)             |
 
 Likely layout: **constellation tabs** (row 1) + **channel sidebar or chip list** (row 2) + **message pane** — works for MT (few channels) and MC (many).
 


### PR DESCRIPTION
Remove stale mc_channel_idx-on-MessageChannel references; document MeshCoreChannelEditor on Node Settings.

# Summary

<!--
Describe the change for the benefit of the reviewer, and for someone
who may be writing release notes

Make sure to mention any breaking changes or manual steps which need
to be performed when shipping to pre-prod or prod
-->

<!--
## Background
You can optionally add a Background section here if the change requires
more context
 -->

## Testing performed

<!--
you don't need to evidence testing, but any testing relating
to this change  shold be described

e.g.
* updated unit/integration tests
* manually verified in pre-prod
-->
