### PR TITLE
feat(messages): MC heard map polylines from resolved_path

### DIFF
--- a/src/components/messages/heard-path-map-adapters.test.ts
+++ b/src/components/messages/heard-path-map-adapters.test.ts
@@ -290,6 +290,63 @@ describe('heard path adapters', () => {
     expect(legs[0].lineColor).not.toBe(legs[1].lineColor);
   });
 
+  it('meshCoreHeardToLegs draws positioned hop polylines when path_known', () => {
+    const message: TextMessage = {
+      id: '7',
+      packet_id: 7,
+      protocol: 'meshcore',
+      sender: { node_id_str: 'mc:abc', long_name: 'X', short_name: 'X' },
+      sender_position: { latitude: 55.0, longitude: -4.0 },
+      recipient_meshtastic_node_id: null,
+      channel: 1,
+      sent_at: new Date().toISOString(),
+      message_text: 'mc',
+      is_emoji: false,
+      reply_to_meshtastic_packet_id: null,
+      heard: [
+        {
+          observer: {
+            node_id_str: 'mc:feed',
+            internal_id: null,
+            long_name: 'Feeder',
+            short_name: 'F',
+            position: { latitude: 55.2, longitude: -4.2 },
+          },
+          rx_time: new Date().toISOString(),
+          rx_rssi: -90,
+          rx_snr: 2,
+          path_hashes: ['aa', 'bb'],
+          resolved_path: [
+            {
+              hash: 'aa',
+              status: 'resolved',
+              node_id_str: 'mc:hop1',
+              internal_id: '1',
+              long_name: 'Hop1',
+              ambiguous: false,
+              position: { latitude: 55.05, longitude: -4.05 },
+            },
+            {
+              hash: 'bb',
+              status: 'resolved',
+              node_id_str: 'mc:hop2',
+              internal_id: '2',
+              long_name: 'Hop2',
+              ambiguous: false,
+              position: { latitude: 55.1, longitude: -4.1 },
+            },
+          ],
+          path_known: true,
+        },
+      ],
+    };
+    const { legs } = meshCoreHeardToLegs(message);
+    expect(legs[0].pathKnown).toBe(true);
+    expect(legs[0].waypoints).toHaveLength(2);
+    expect(legs[0].waypoints[0].position).toEqual({ latitude: 55.05, longitude: -4.05 });
+    expect(legs[0].waypoints[0].short_name).toBe('Hop1');
+  });
+
   it('resolvedHopsFromObservation falls back to path_hashes', () => {
     const hops = resolvedHopsFromObservation({
       observer: {

--- a/src/components/messages/heard-path-map-adapters.ts
+++ b/src/components/messages/heard-path-map-adapters.ts
@@ -82,11 +82,12 @@ export function heardPathSenderDisplayLabel(
 }
 
 function hopToWaypoint(hop: ResolvedHop): TracerouteRouteNode {
+  const label = hop.long_name || hop.node_id_str || hop.hash;
   return {
     meshtastic_node_id: UNKNOWN_NODE_ID,
-    node_id_str: hop.hash,
-    short_name: hop.hash,
-    position: null,
+    node_id_str: hop.node_id_str || hop.hash,
+    short_name: label,
+    position: hop.position ?? null,
   };
 }
 
@@ -139,7 +140,7 @@ export function meshtasticHeardToLegs(message: TextMessage): {
   return { sender, legs };
 }
 
-/** Geo map legs for MC: positioned feeders only (hop polylines not drawn on map). */
+/** Geo map legs for MC: feeders with position; hop polylines when path_known and hop positions exist. */
 export function meshCoreHeardToLegs(message: TextMessage): {
   sender: { label: string; position: MapPosition } | null;
   legs: HeardPathLeg[];

--- a/src/lib/models.ts
+++ b/src/lib/models.ts
@@ -417,6 +417,7 @@ export interface ResolvedHop {
   internal_id: string | null;
   long_name: string | null;
   ambiguous: boolean;
+  position?: MapPosition | null;
 }
 
 export interface HeardObserver {


### PR DESCRIPTION
## Summary

- `ResolvedHop` includes optional `position`.
- `HeardPathGeoMap` draws MeshCore hop polylines when `path_known` and hop positions are present (pairs with meshflow-api Tier 2 heard resolution).

Related: [#304](https://github.com/pskillen/meshflow-ui/issues/304), [#311](https://github.com/pskillen/meshflow-ui/issues/311); API PR in meshflow-api `api-388/pskillen/mc-path-twin-and-resolution`.

## Testing performed

- `npm test -- src/components/messages/heard-path-map-adapters.test.ts` (8 passed)
- Pre-commit: full vitest suite (357 passed)