### PR TITLE
feat(messages): MC heard path map overlay and hop position icons

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -70,6 +70,22 @@ npm test             # Vitest
 - Pages under `src/pages/`; shared components under `src/components/`.
 - API config: `config.ts` + remote `config.json`; `MESHFLOW_API_URL` for backend base URL.
 
+### Component and screen documentation
+
+When you **create** a non-trivial component or page screen, or **meaningfully change** one you touch, add or update a sibling markdown file next to the main `.tsx` (same basename, e.g. `HeardPathMap.tsx` → `HeardPathMap.md`).
+
+Do **not** backfill docs for the whole codebase in one go; only document what you are working on so behaviour stays accurate.
+
+Each doc should explain, in plain language:
+
+- **Purpose** — what the UI is for and when to use it vs similar components (e.g. `HeardPathMap` vs `HeardPathGeoMap`).
+- **Props / inputs** — main types and what drives rendering.
+- **Behaviour** — what is drawn or shown, empty states, warnings, and non-obvious rules (maps, dialogs, protocol splits).
+- **Wiring** — where it is used in the app and which adapters/hooks feed it.
+- **Related** — links to paired components, feature docs under `docs/`, or API contracts when relevant.
+
+Examples: [`src/components/messages/HeardPathMap.md`](src/components/messages/HeardPathMap.md), [`src/components/messages/HeardPathGeoMap.md`](src/components/messages/HeardPathGeoMap.md).
+
 ## Configuration
 
 - Default config in `config.ts`

--- a/docs/meshcore/heard-path-dialog.md
+++ b/docs/meshcore/heard-path-dialog.md
@@ -4,7 +4,7 @@ Opened from **N heard** on a MeshCore text message in message history.
 
 ### Layout
 
-1. **Geo map** — [`HeardPathGeoMap`](../../src/components/messages/HeardPathGeoMap.tsx) ([docs](../../src/components/messages/HeardPathGeoMap.md)): Leaflet markers for sender (when position known) and feeders with coordinates. No hop polylines. Not the same as [`HeardPathMap`](../../src/components/messages/HeardPathMap.tsx) ([docs](../../src/components/messages/HeardPathMap.md)), which Meshtastic uses for sender→feeder path lines.
+1. **Geo map** — [`HeardPathGeoMap`](../../src/components/messages/HeardPathGeoMap.tsx) ([docs](../../src/components/messages/HeardPathGeoMap.md)): Leaflet markers for sender (when position known) and feeders with coordinates, plus optional **partial hop polylines** when API resolves hop positions. Ambiguous hops are list-only. Meshtastic uses [`HeardPathMap`](../../src/components/messages/HeardPathMap.tsx) ([docs](../../src/components/messages/HeardPathMap.md)) for full sender→feeder paths.
 2. **Paths by feeder** — One schematic row per observation: sender → hash hops → feeder. Hops use dashed monospace badges (`unknown` per API v1); they are **not** placed at geographic coordinates.
 3. **Feeder list** — Each observer with RSSI/SNR and a **Path (this feeder)** column showing that observation’s hop chain.
 

--- a/docs/meshcore/heard-path-dialog.md
+++ b/docs/meshcore/heard-path-dialog.md
@@ -5,7 +5,7 @@ Opened from **N heard** on a MeshCore text message in message history.
 ### Layout
 
 1. **Geo map** — [`HeardPathGeoMap`](../../src/components/messages/HeardPathGeoMap.tsx) ([docs](../../src/components/messages/HeardPathGeoMap.md)): Leaflet markers for sender (when position known) and feeders with coordinates, plus optional **partial hop polylines** when API resolves hop positions. Ambiguous hops are list-only. Meshtastic uses [`HeardPathMap`](../../src/components/messages/HeardPathMap.tsx) ([docs](../../src/components/messages/HeardPathMap.md)) for full sender→feeder paths.
-2. **Paths by feeder** — One schematic row per observation: sender → hash hops → feeder. Hops use dashed monospace badges (`unknown` per API v1); they are **not** placed at geographic coordinates.
+2. **Paths by feeder** — One schematic row per observation: sender → hash hops → feeder. A single `mc_sender_candidate` is shown as the sender (with node link) even when the node has no map position; `HopPositionIcon` reflects position only. Hops use dashed monospace badges when unresolved; they are **not** placed at geographic coordinates unless the API supplies hop positions.
 3. **Feeder list** — Each observer with RSSI/SNR and a **Path (this feeder)** column showing that observation’s hop chain.
 
 Each feeder can report a **different** `path_hashes` / `resolved_path` for the same message.

--- a/docs/meshcore/heard-path-dialog.md
+++ b/docs/meshcore/heard-path-dialog.md
@@ -4,7 +4,7 @@ Opened from **N heard** on a MeshCore text message in message history.
 
 ### Layout
 
-1. **Geo map** — Leaflet markers for sender (when position known) and feeders with coordinates. No hop polylines on the map.
+1. **Geo map** — [`HeardPathGeoMap`](../../src/components/messages/HeardPathGeoMap.tsx) ([docs](../../src/components/messages/HeardPathGeoMap.md)): Leaflet markers for sender (when position known) and feeders with coordinates. No hop polylines. Not the same as [`HeardPathMap`](../../src/components/messages/HeardPathMap.tsx) ([docs](../../src/components/messages/HeardPathMap.md)), which Meshtastic uses for sender→feeder path lines.
 2. **Paths by feeder** — One schematic row per observation: sender → hash hops → feeder. Hops use dashed monospace badges (`unknown` per API v1); they are **not** placed at geographic coordinates.
 3. **Feeder list** — Each observer with RSSI/SNR and a **Path (this feeder)** column showing that observation’s hop chain.
 

--- a/src/components/messages/HeardPathGeoMap.md
+++ b/src/components/messages/HeardPathGeoMap.md
@@ -1,0 +1,49 @@
+# HeardPathGeoMap
+
+Leaflet map for the **message heard** dialog that shows **only geographic anchors** (sender and feeders). It does **not** draw hop polylines, path segments, or hash labels on the map.
+
+Use this when hop evidence is hash-based or schematic and should not be interpreted as real-world RF geometry on the map—typical for **MeshCore** heard dialogs today.
+
+## When to use
+
+| Use `HeardPathGeoMap`                                                                       | Use `HeardPathMap` instead                                                                               |
+| ------------------------------------------------------------------------------------------- | -------------------------------------------------------------------------------------------------------- |
+| MeshCore heard dialog top map (markers for “who” heard the message and where they sit)      | Meshtastic heard dialog, or any case where you want sender → hop waypoints → feeder **lines** on the map |
+| You will show the full hop chain elsewhere (e.g. `MeshCoreHeardPathsPanel`, `PathHopChain`) | `path_known` and/or positioned intermediate hops should appear as polylines                              |
+
+These components are **not** drop-in replacements: props and rendering models differ (see below).
+
+## Props
+
+| Prop         | Type                         | Role                                                                                |
+| ------------ | ---------------------------- | ----------------------------------------------------------------------------------- |
+| `sender`     | `HeardPathGeoAnchor \| null` | Sender marker when `position` is known                                              |
+| `feeders`    | `HeardPathGeoAnchor[]`       | One marker per feeder/feeder with a known position                                  |
+| `senderName` | `string \| null`             | Label for the amber banner when sender position is missing (e.g. `mc_sender_label`) |
+
+`HeardPathGeoAnchor`: `{ label, position, color? }`. Feeder `color` defaults from `HEARD_PATH_LEG_COLORS` by index.
+
+## What it draws
+
+1. **Sender** (green, `HEARD_PATH_SENDER_COLOR`) — if `sender` is non-null.
+2. **Feeder markers** — one per entry in `feeders`, with per-leg colour when `color` is set.
+3. **No polylines** — no use of `buildSegments` or `path_hashes` / `resolved_path`.
+
+Map bounds fit all markers (padding, max zoom 15). Default centre before fit: Glasgow area (`55.8642, -4.2518`).
+
+## Empty and warning states
+
+- **Empty** (`!sender && feeders.length === 0`): placeholder text — “No map — sender and feeder positions unknown” (`data-testid="heard-path-geo-map-empty"`).
+- **Sender missing, feeders present**: amber overlay — sender position unknown; feeders shown; **hop paths are schematic below** (paths belong in `MeshCoreHeardPathsPanel` / list, not on this map).
+
+## Wiring in the app
+
+[`MessageItem.tsx`](./MessageItem.tsx) → `MeshCoreHeardDialogBody` builds `geoSender` and `geoFeeders` from `meshCoreHeardLegs(message)` (feeders with `receiverPosition` only) and renders `HeardPathGeoMap`.
+
+Data still comes from message `heard[]` / API; this component only consumes **positions**, not hop hashes.
+
+## Related
+
+- [`HeardPathMap.md`](./HeardPathMap.md) — path polylines and hop geometry
+- [`heard-path-map-adapters.ts`](./heard-path-map-adapters.ts) — `meshCoreHeardLegs`, Meshtastic vs MC adapters
+- [`docs/meshcore/heard-path-dialog.md`](../../../docs/meshcore/heard-path-dialog.md) — full dialog layout

--- a/src/components/messages/HeardPathGeoMap.md
+++ b/src/components/messages/HeardPathGeoMap.md
@@ -19,6 +19,7 @@ These components are **not** drop-in replacements: props and rendering models di
 | ------------ | ---------------------------- | ----------------------------------------------------------------------------------- |
 | `sender`     | `HeardPathGeoAnchor \| null` | Sender marker when `position` is known                                              |
 | `feeders`    | `HeardPathGeoAnchor[]`       | One marker per feeder/feeder with a known position                                  |
+| `pathLegs`   | `HeardPathLeg[]` (optional)  | Per-feeder polylines and intermediate hop markers when positions are known          |
 | `senderName` | `string \| null`             | Label for the amber banner when sender position is missing (e.g. `mc_sender_label`) |
 
 `HeardPathGeoAnchor`: `{ label, position, color? }`. Feeder `color` defaults from `HEARD_PATH_LEG_COLORS` by index.
@@ -27,7 +28,7 @@ These components are **not** drop-in replacements: props and rendering models di
 
 1. **Sender** (green, `HEARD_PATH_SENDER_COLOR`) — if `sender` is non-null.
 2. **Feeder markers** — one per entry in `feeders`, with per-leg colour when `color` is set.
-3. **No polylines** — no use of `buildSegments` or `path_hashes` / `resolved_path`.
+3. **Optional path overlay** — when `pathLegs` is set, draws partial polylines and positioned hop markers via [`heard-path-map-layers.ts`](./heard-path-map-layers.ts). Ambiguous hops are omitted from `pathLegs`. Without `pathLegs`, no path geometry is drawn.
 
 Map bounds fit all markers (padding, max zoom 15). Default centre before fit: Glasgow area (`55.8642, -4.2518`).
 

--- a/src/components/messages/HeardPathGeoMap.tsx
+++ b/src/components/messages/HeardPathGeoMap.tsx
@@ -3,6 +3,8 @@ import { MAP_NODE_MARKER_CSS } from '@/lib/map-marker-styles';
 import { useMapTileUrl } from '@/hooks/useMapTileUrl';
 import { createNodeIcon } from '@/components/nodes/map-utils';
 import type { LatLng } from '@/lib/map-path-segments';
+import type { HeardPathLeg } from './HeardPathMap';
+import { drawHeardPathPolylinesOnly, hasDrawablePathOnMap, toLatLng } from './heard-path-map-layers';
 import { HEARD_PATH_LEG_COLORS, HEARD_PATH_SENDER_COLOR } from './heard-path-constants';
 import L from 'leaflet';
 import { useEffect, useRef } from 'react';
@@ -19,19 +21,19 @@ export type HeardPathGeoAnchor = {
 export type HeardPathGeoMapProps = {
   sender: HeardPathGeoAnchor | null;
   feeders: HeardPathGeoAnchor[];
+  /** Optional per-feeder path geometry (MeshCore); anchor markers remain on this map. */
+  pathLegs?: HeardPathLeg[];
   senderName?: string | null;
 };
 
-function toLatLng(pos: MapPosition): LatLng {
-  return [pos.latitude, pos.longitude];
-}
-
-export function HeardPathGeoMap({ sender, feeders, senderName }: HeardPathGeoMapProps) {
+export function HeardPathGeoMap({ sender, feeders, pathLegs = [], senderName }: HeardPathGeoMapProps) {
   const mapRef = useRef<HTMLDivElement>(null);
   const mapInstanceRef = useRef<L.Map | null>(null);
   const tileLayerRef = useRef<L.TileLayer | null>(null);
   const layersRef = useRef<L.Layer[]>([]);
   const { url: tileUrl, attribution } = useMapTileUrl();
+
+  const senderPos = sender ? toLatLng(sender.position) : null;
 
   useEffect(() => {
     if (mapRef.current && !mapInstanceRef.current) {
@@ -95,6 +97,10 @@ export function HeardPathGeoMap({ sender, feeders, senderName }: HeardPathGeoMap
       hasMarker = true;
     });
 
+    if (pathLegs.length > 0) {
+      drawHeardPathPolylinesOnly(map, layersRef.current, bounds, senderPos, pathLegs);
+    }
+
     if (!hasMarker) return;
 
     map.invalidateSize();
@@ -109,7 +115,7 @@ export function HeardPathGeoMap({ sender, feeders, senderName }: HeardPathGeoMap
       }
     }, 150);
     return () => clearTimeout(t);
-  }, [sender, feeders]);
+  }, [sender, feeders, pathLegs, senderPos]);
 
   if (!sender && feeders.length === 0) {
     return (
@@ -123,6 +129,7 @@ export function HeardPathGeoMap({ sender, feeders, senderName }: HeardPathGeoMap
   }
 
   const showSenderWarning = !sender;
+  const hasPartialPaths = !sender && hasDrawablePathOnMap(null, pathLegs);
   const warningLabel = senderName?.trim() || sender?.label;
 
   return (
@@ -134,7 +141,10 @@ export function HeardPathGeoMap({ sender, feeders, senderName }: HeardPathGeoMap
           role="status"
         >
           Sender position unknown
-          {warningLabel ? ` (${warningLabel})` : ''} — feeders shown; hop paths are schematic below.
+          {warningLabel ? ` (${warningLabel})` : ''} —
+          {hasPartialPaths
+            ? ' paths use known hop and feeder positions only; full chain below.'
+            : ' feeders shown; hop paths are schematic below.'}
         </div>
       )}
     </div>

--- a/src/components/messages/HeardPathMap.md
+++ b/src/components/messages/HeardPathMap.md
@@ -1,0 +1,65 @@
+# HeardPathMap
+
+Leaflet map for the **message heard** dialog that shows **sender, feeders (receivers), and path geometry**: solid polylines where hop positions are known, dashed lines with hash tooltips where they are not.
+
+Use this when each observation leg can be drawn as a geographic path from sender through waypoints to the hearing feeder—primarily **Meshtastic** heard UI today.
+
+## When to use
+
+| Use `HeardPathMap`                                                                             | Use `HeardPathGeoMap` instead                                                |
+| ---------------------------------------------------------------------------------------------- | ---------------------------------------------------------------------------- |
+| Meshtastic `HeardDialog` branch in [`MessageItem.tsx`](./MessageItem.tsx)                      | MeshCore heard dialog top map (markers only; hops shown schematically below) |
+| Legs include `waypoints` + `pathKnown` from `messageToHeardPathLegs` / `meshtasticHeardToLegs` | You only need sender + feeder pins with no on-map hop geometry               |
+
+These components are **not** drop-in replacements: `HeardPathMap` expects per-leg `HeardPathLeg` objects with waypoints; `HeardPathGeoMap` expects a flat `feeders[]` list.
+
+## Props
+
+| Prop         | Type                          | Role                                                              |
+| ------------ | ----------------------------- | ----------------------------------------------------------------- |
+| `sender`     | `{ label, position } \| null` | Path start marker (green)                                         |
+| `legs`       | `HeardPathLeg[]`              | One entry per feeder observation that has a **receiver position** |
+| `senderName` | `string \| null`              | Banner label when sender position is missing                      |
+
+### `HeardPathLeg`
+
+| Field       | Role                                                                      |
+| ----------- | ------------------------------------------------------------------------- |
+| `receiver`  | Feeder marker (`label`, `position`)                                       |
+| `waypoints` | Intermediate hops as `TracerouteRouteNode[]` (`position` optional)        |
+| `pathKnown` | From API `path_known`: all hops resolved with positions                   |
+| `lineColor` | Polyline and feeder marker colour (defaults from `HEARD_PATH_LEG_COLORS`) |
+
+Legs without a receiver position are omitted upstream (`meshtasticHeardToLegs` / `meshCoreHeardToLegs`).
+
+## What it draws
+
+For each leg (feeder colour by index):
+
+1. **Receiver marker** at `receiver.position`.
+2. **Path lines** only if **sender position is known** (`senderPos`). If sender is missing, feeder markers still render but **no polylines** (banner: path lines omitted).
+3. **Segment mode** (when `senderPos` exists):
+   - **`pathKnown` and at least one waypoint with `position`**: [`buildSegments`](../../../lib/map-path-segments.ts) — solid runs through known coordinates; dashed segments between known points with permanent tooltips showing `node_id_str` (hash) for unknown hops in that span.
+   - **Otherwise**: single **dashed** line sender → feeder; tooltips list all waypoint `node_id_str` values at the segment midpoint.
+
+Sender marker uses `HEARD_PATH_SENDER_COLOR`. Map height **280px** (vs 240px on geo map).
+
+## Empty and warning states
+
+- **`legs.length === 0`**: placeholder — either “No feeder positions available for map” (sender known) or “No map — sender and feeder positions unknown”.
+- **Sender missing, legs present**: amber overlay — sender position unknown; feeders shown; **path lines omitted**.
+
+## Data adapters
+
+| Adapter                 | Protocol   | Output                                                                                                                                          |
+| ----------------------- | ---------- | ----------------------------------------------------------------------------------------------------------------------------------------------- |
+| `meshtasticHeardToLegs` | Meshtastic | Sender from `sender_position`; legs from `heard[]` with `observer_position`; empty `waypoints`                                                  |
+| `meshCoreHeardToLegs`   | MeshCore   | Waypoints from `resolved_path` / `path_hashes`; used by tests and available for future MC map work—not wired in `MeshCoreHeardDialogBody` today |
+
+Entry point: `messageToHeardPathLegs(message)` in [`heard-path-map-adapters.ts`](./heard-path-map-adapters.ts).
+
+## Related
+
+- [`HeardPathGeoMap.md`](./HeardPathGeoMap.md) — anchor-only map for MeshCore
+- [`MeshCoreHeardPathsPanel.tsx`](./MeshCoreHeardPathsPanel.tsx) — schematic per-feeder hop chains (MC)
+- [`docs/meshcore/heard-path-dialog.md`](../../../docs/meshcore/heard-path-dialog.md) — full dialog layout

--- a/src/components/messages/HeardPathMap.tsx
+++ b/src/components/messages/HeardPathMap.tsx
@@ -1,13 +1,11 @@
-import { buildSegments, midpoint, type LatLng } from '@/lib/map-path-segments';
+import type { LatLng } from '@/lib/map-path-segments';
 import { MAP_NODE_MARKER_CSS } from '@/lib/map-marker-styles';
 import type { TracerouteRouteNode } from '@/lib/models';
 import { useMapTileUrl } from '@/hooks/useMapTileUrl';
-import { createNodeIcon } from '@/components/nodes/map-utils';
+import { drawHeardPathLayers, hasDrawablePathOnMap, toLatLng } from './heard-path-map-layers';
 import L from 'leaflet';
 import { useEffect, useRef } from 'react';
 import 'leaflet/dist/leaflet.css';
-
-import { HEARD_PATH_LEG_COLORS, HEARD_PATH_SENDER_COLOR } from './heard-path-constants';
 
 const DEFAULT_CENTER: LatLng = [55.8642, -4.2518];
 
@@ -26,14 +24,6 @@ export type HeardPathMapProps = {
   /** Display name when sender position is missing (e.g. parsed MC channel prefix). */
   senderName?: string | null;
 };
-
-function toLatLng(pos: MapPosition): LatLng {
-  return [pos.latitude, pos.longitude];
-}
-
-function hasPositionedWaypoints(waypoints: TracerouteRouteNode[]): boolean {
-  return waypoints.some((node) => node.position != null);
-}
 
 export function HeardPathMap({ sender, legs, senderName }: HeardPathMapProps) {
   const mapRef = useRef<HTMLDivElement>(null);
@@ -83,63 +73,12 @@ export function HeardPathMap({ sender, legs, senderName }: HeardPathMapProps) {
     layersRef.current = [];
 
     const bounds = L.latLngBounds([]);
-
-    if (senderPos) {
-      const senderMarker = L.marker(senderPos, {
-        icon: createNodeIcon(sender?.label ?? 'S', HEARD_PATH_SENDER_COLOR, false),
-      }).addTo(map);
-      layersRef.current.push(senderMarker);
-      bounds.extend(senderPos);
-    }
-
-    legs.forEach((leg, index) => {
-      const receiverPos = toLatLng(leg.receiver.position);
-      const color = leg.lineColor ?? HEARD_PATH_LEG_COLORS[index % HEARD_PATH_LEG_COLORS.length];
-      const receiverMarker = L.marker(receiverPos, {
-        icon: createNodeIcon(leg.receiver.label, color, false),
-      }).addTo(map);
-      layersRef.current.push(receiverMarker);
-      bounds.extend(receiverPos);
-
-      if (!senderPos) {
-        return;
-      }
-
-      const segments =
-        leg.pathKnown && hasPositionedWaypoints(leg.waypoints)
-          ? buildSegments(senderPos, leg.waypoints, receiverPos)
-          : [
-              {
-                latlngs: [senderPos, receiverPos] as LatLng[],
-                dashed: true,
-                unknownLabels: leg.waypoints.map((node) => ({ node_id_str: node.node_id_str })),
-              },
-            ];
-
-      segments.forEach((seg) => {
-        const poly = L.polyline(seg.latlngs, {
-          color,
-          weight: 4,
-          dashArray: seg.dashed ? '10, 10' : undefined,
-        }).addTo(map);
-        layersRef.current.push(poly);
-        seg.latlngs.forEach((p) => bounds.extend(p));
-
-        if (seg.dashed && seg.unknownLabels.length > 0 && seg.latlngs.length >= 2) {
-          const mid = midpoint(seg.latlngs[0], seg.latlngs[seg.latlngs.length - 1]);
-          seg.unknownLabels.forEach((label) => {
-            const tooltip = L.tooltip({
-              permanent: true,
-              direction: 'center',
-              className: 'traceroute-unknown-label',
-            })
-              .setContent(label.node_id_str)
-              .setLatLng(mid);
-            tooltip.addTo(map);
-            layersRef.current.push(tooltip);
-          });
-        }
-      });
+    drawHeardPathLayers({
+      map,
+      layers: layersRef.current,
+      bounds,
+      sender,
+      legs,
     });
 
     if (bounds.isValid()) {
@@ -168,6 +107,7 @@ export function HeardPathMap({ sender, legs, senderName }: HeardPathMapProps) {
   }
 
   const showSenderWarning = !senderPos;
+  const hasPartialPaths = !senderPos && hasDrawablePathOnMap(null, legs);
   const warningLabel = senderName?.trim() || sender?.label;
 
   return (
@@ -183,7 +123,8 @@ export function HeardPathMap({ sender, legs, senderName }: HeardPathMapProps) {
           role="status"
         >
           Sender position unknown
-          {warningLabel ? ` (${warningLabel})` : ''} — feeders shown; path lines omitted.
+          {warningLabel ? ` (${warningLabel})` : ''} —
+          {hasPartialPaths ? ' paths use known hop and feeder positions only.' : ' feeders shown; path lines omitted.'}
         </div>
       )}
     </div>

--- a/src/components/messages/HopPositionIcon.tsx
+++ b/src/components/messages/HopPositionIcon.tsx
@@ -1,0 +1,31 @@
+import type { ResolvedHop } from '@/lib/models';
+import { MapPin, MapPinOff } from 'lucide-react';
+import { cn } from '@/lib/utils';
+
+export type HopPositionIconProps = {
+  hop?: ResolvedHop | null;
+  positioned?: boolean;
+  className?: string;
+};
+
+export function HopPositionIcon({ hop, positioned, className }: HopPositionIconProps) {
+  const hasPosition = positioned ?? (hop?.status === 'resolved' && hop.position != null);
+  const ambiguous = hop?.status === 'ambiguous' || (hop?.candidates?.length ?? 0) > 1;
+
+  if (hasPosition) {
+    return (
+      <MapPin className={cn('h-3.5 w-3.5 shrink-0 text-emerald-600 dark:text-emerald-400', className)} aria-hidden />
+    );
+  }
+
+  return (
+    <MapPinOff
+      className={cn(
+        'h-3.5 w-3.5 shrink-0',
+        ambiguous ? 'text-amber-600 dark:text-amber-400' : 'text-muted-foreground',
+        className
+      )}
+      aria-hidden
+    />
+  );
+}

--- a/src/components/messages/MeshCoreHeardPathFlow.test.tsx
+++ b/src/components/messages/MeshCoreHeardPathFlow.test.tsx
@@ -61,10 +61,20 @@ const baseLeg: MeshCoreHeardLeg = {
   lineColor: '#2563eb',
 };
 
-function renderFlow(leg: MeshCoreHeardLeg, senderKnown: boolean) {
+function renderFlow(
+  leg: MeshCoreHeardLeg,
+  senderKnown: boolean,
+  opts?: { senderHasPosition?: boolean; senderDetailPath?: string | null }
+) {
   return render(
     <MemoryRouter>
-      <MeshCoreHeardPathFlow leg={leg} senderDisplayLabel="Sender" senderKnown={senderKnown} />
+      <MeshCoreHeardPathFlow
+        leg={leg}
+        senderDisplayLabel="☘️GI7"
+        senderKnown={senderKnown}
+        senderHasPosition={opts?.senderHasPosition ?? senderKnown}
+        senderDetailPath={opts?.senderDetailPath ?? null}
+      />
     </MemoryRouter>
   );
 }
@@ -84,7 +94,16 @@ describe('MeshCoreHeardPathFlow', () => {
   });
 
   it('shows sender unknown label when sender not known', () => {
-    renderFlow(baseLeg, false);
+    renderFlow(baseLeg, false, { senderHasPosition: false });
     expect(screen.getByText(/Sender unknown/i)).toBeInTheDocument();
+  });
+
+  it('links identified sender without position', () => {
+    renderFlow(baseLeg, true, {
+      senderHasPosition: false,
+      senderDetailPath: '/nodes/mc%3A9cce73b9b3ee',
+    });
+    expect(screen.getByRole('link', { name: '☘️GI7' })).toHaveAttribute('href', '/nodes/mc%3A9cce73b9b3ee');
+    expect(screen.queryByText(/Sender unknown/i)).not.toBeInTheDocument();
   });
 });

--- a/src/components/messages/MeshCoreHeardPathFlow.tsx
+++ b/src/components/messages/MeshCoreHeardPathFlow.tsx
@@ -4,23 +4,46 @@ import { PathHopChain } from './PathHopChain';
 import type { MeshCoreHeardLeg } from './heard-path-map-adapters';
 import { ArrowRight } from 'lucide-react';
 import { cn } from '@/lib/utils';
+import { Link } from 'react-router-dom';
 
 export type MeshCoreHeardPathFlowProps = {
   leg: MeshCoreHeardLeg;
   senderDisplayLabel: string;
   senderKnown: boolean;
+  senderHasPosition?: boolean;
+  senderDetailPath?: string | null;
 };
 
-export function MeshCoreHeardPathFlow({ leg, senderDisplayLabel, senderKnown }: MeshCoreHeardPathFlowProps) {
+export function MeshCoreHeardPathFlow({
+  leg,
+  senderDisplayLabel,
+  senderKnown,
+  senderHasPosition = false,
+  senderDetailPath = null,
+}: MeshCoreHeardPathFlowProps) {
+  const senderLabel = senderKnown
+    ? senderDisplayLabel
+    : `Sender unknown${senderDisplayLabel ? ` (${senderDisplayLabel})` : ''}`;
+
+  const senderBadge = (
+    <Badge
+      variant={senderKnown ? 'secondary' : 'outline'}
+      className={cn(!senderKnown && 'border-dashed text-muted-foreground')}
+    >
+      {senderLabel}
+    </Badge>
+  );
+
   const startBadge = (
     <span className="inline-flex items-center gap-1">
-      <HopPositionIcon positioned={senderKnown} />
-      <Badge
-        variant={senderKnown ? 'secondary' : 'outline'}
-        className={cn(!senderKnown && 'border-dashed text-muted-foreground')}
-      >
-        {senderKnown ? senderDisplayLabel : `Sender unknown${senderDisplayLabel ? ` (${senderDisplayLabel})` : ''}`}
-      </Badge>
+      <HopPositionIcon positioned={senderHasPosition} />
+      {senderKnown && senderDetailPath ? (
+        <Link to={senderDetailPath} className="inline-flex hover:underline">
+          {senderBadge}
+        </Link>
+      ) : (
+        senderBadge
+      )}
     </span>
   );
 

--- a/src/components/messages/MeshCoreHeardPathFlow.tsx
+++ b/src/components/messages/MeshCoreHeardPathFlow.tsx
@@ -1,4 +1,5 @@
 import { Badge } from '@/components/ui/badge';
+import { HopPositionIcon } from './HopPositionIcon';
 import { PathHopChain } from './PathHopChain';
 import type { MeshCoreHeardLeg } from './heard-path-map-adapters';
 import { ArrowRight } from 'lucide-react';
@@ -12,18 +13,24 @@ export type MeshCoreHeardPathFlowProps = {
 
 export function MeshCoreHeardPathFlow({ leg, senderDisplayLabel, senderKnown }: MeshCoreHeardPathFlowProps) {
   const startBadge = (
-    <Badge
-      variant={senderKnown ? 'secondary' : 'outline'}
-      className={cn(!senderKnown && 'border-dashed text-muted-foreground')}
-    >
-      {senderKnown ? senderDisplayLabel : `Sender unknown${senderDisplayLabel ? ` (${senderDisplayLabel})` : ''}`}
-    </Badge>
+    <span className="inline-flex items-center gap-1">
+      <HopPositionIcon positioned={senderKnown} />
+      <Badge
+        variant={senderKnown ? 'secondary' : 'outline'}
+        className={cn(!senderKnown && 'border-dashed text-muted-foreground')}
+      >
+        {senderKnown ? senderDisplayLabel : `Sender unknown${senderDisplayLabel ? ` (${senderDisplayLabel})` : ''}`}
+      </Badge>
+    </span>
   );
 
   const endBadge = (
-    <Badge variant="secondary" className="max-w-full" style={{ borderColor: leg.lineColor }}>
-      {leg.receiverLabel}
-    </Badge>
+    <span className="inline-flex items-center gap-1">
+      <HopPositionIcon positioned={leg.receiverPosition != null} />
+      <Badge variant="secondary" className="max-w-full" style={{ borderColor: leg.lineColor }}>
+        {leg.receiverLabel}
+      </Badge>
+    </span>
   );
 
   if (leg.hops.length === 0) {

--- a/src/components/messages/MeshCoreHeardPathsPanel.tsx
+++ b/src/components/messages/MeshCoreHeardPathsPanel.tsx
@@ -5,9 +5,15 @@ export type MeshCoreHeardPathsPanelProps = {
   legs: MeshCoreHeardLeg[];
   senderDisplayLabel: string;
   senderKnown: boolean;
+  hasAmbiguousHops?: boolean;
 };
 
-export function MeshCoreHeardPathsPanel({ legs, senderDisplayLabel, senderKnown }: MeshCoreHeardPathsPanelProps) {
+export function MeshCoreHeardPathsPanel({
+  legs,
+  senderDisplayLabel,
+  senderKnown,
+  hasAmbiguousHops = false,
+}: MeshCoreHeardPathsPanelProps) {
   if (legs.length === 0) {
     return (
       <p className="text-sm text-muted-foreground rounded-md border bg-muted/30 px-3 py-4">
@@ -18,6 +24,14 @@ export function MeshCoreHeardPathsPanel({ legs, senderDisplayLabel, senderKnown 
 
   return (
     <div className="space-y-3" data-testid="meshcore-heard-paths-panel">
+      {hasAmbiguousHops && (
+        <p
+          className="text-xs text-amber-800 dark:text-amber-200 rounded-md border border-amber-500/50 bg-amber-50/90 dark:bg-amber-950/50 px-3 py-2"
+          role="status"
+        >
+          Some path hops match multiple nodes. Those hops are listed below but omitted from the map.
+        </p>
+      )}
       <p className="text-xs text-muted-foreground">
         Paths are per feeder and may differ for the same message. Hop hashes are list-order evidence, not map
         coordinates.

--- a/src/components/messages/MeshCoreHeardPathsPanel.tsx
+++ b/src/components/messages/MeshCoreHeardPathsPanel.tsx
@@ -5,6 +5,8 @@ export type MeshCoreHeardPathsPanelProps = {
   legs: MeshCoreHeardLeg[];
   senderDisplayLabel: string;
   senderKnown: boolean;
+  senderHasPosition?: boolean;
+  senderDetailPath?: string | null;
   hasAmbiguousHops?: boolean;
 };
 
@@ -12,6 +14,8 @@ export function MeshCoreHeardPathsPanel({
   legs,
   senderDisplayLabel,
   senderKnown,
+  senderHasPosition = false,
+  senderDetailPath = null,
   hasAmbiguousHops = false,
 }: MeshCoreHeardPathsPanelProps) {
   if (legs.length === 0) {
@@ -43,7 +47,13 @@ export function MeshCoreHeardPathsPanel({
           style={{ borderLeftWidth: 4, borderLeftColor: leg.lineColor }}
         >
           <div className="text-xs font-medium text-muted-foreground">Heard by {leg.receiverLabel}</div>
-          <MeshCoreHeardPathFlow leg={leg} senderDisplayLabel={senderDisplayLabel} senderKnown={senderKnown} />
+          <MeshCoreHeardPathFlow
+            leg={leg}
+            senderDisplayLabel={senderDisplayLabel}
+            senderKnown={senderKnown}
+            senderHasPosition={senderHasPosition}
+            senderDetailPath={senderDetailPath}
+          />
         </div>
       ))}
     </div>

--- a/src/components/messages/MessageItem.tsx
+++ b/src/components/messages/MessageItem.tsx
@@ -7,6 +7,7 @@ import { PathHopChain } from '@/components/messages/PathHopChain';
 import {
   isMeshCoreHeardMessage,
   isMeshCoreHeardObservation,
+  heardPathSenderForGeoMap,
   meshCoreHeardLegs,
   meshCoreHeardToLegs,
   messageHasAmbiguousPathHops,
@@ -28,7 +29,8 @@ import { nodeDetailPath } from '@/lib/node-detail-routes';
 
 function MeshCoreHeardDialogBody({ message }: { message: TextMessage }) {
   const { sender, senderDisplayLabel, legs } = useMemo(() => meshCoreHeardLegs(message), [message]);
-  const senderKnown = sender != null;
+  const senderKnown = sender?.identified ?? false;
+  const senderHasPosition = sender?.position != null;
 
   const geoFeeders = useMemo(
     () =>
@@ -42,7 +44,7 @@ function MeshCoreHeardDialogBody({ message }: { message: TextMessage }) {
     [legs]
   );
 
-  const geoSender = sender ? { label: sender.label, position: sender.position } : null;
+  const geoSender = heardPathSenderForGeoMap(sender);
   const { legs: pathLegs } = useMemo(() => meshCoreHeardToLegs(message), [message]);
   const hasAmbiguousHops = useMemo(() => messageHasAmbiguousPathHops(message), [message]);
 
@@ -63,6 +65,8 @@ function MeshCoreHeardDialogBody({ message }: { message: TextMessage }) {
         legs={legs}
         senderDisplayLabel={senderDisplayLabel}
         senderKnown={senderKnown}
+        senderHasPosition={senderHasPosition}
+        senderDetailPath={sender?.detailPath ?? null}
         hasAmbiguousHops={hasAmbiguousHops}
       />
       <div className="space-y-4 mt-4">

--- a/src/components/messages/MessageItem.tsx
+++ b/src/components/messages/MessageItem.tsx
@@ -8,9 +8,12 @@ import {
   isMeshCoreHeardMessage,
   isMeshCoreHeardObservation,
   meshCoreHeardLegs,
+  meshCoreHeardToLegs,
+  messageHasAmbiguousPathHops,
   messageToHeardPathLegs,
   resolvedHopsFromObservation,
 } from '@/components/messages/heard-path-map-adapters';
+import { HopPositionIcon } from '@/components/messages/HopPositionIcon';
 import { Avatar } from '@/components/ui/avatar';
 import { Badge } from '@/components/ui/badge';
 import { Button } from '@/components/ui/button';
@@ -40,12 +43,15 @@ function MeshCoreHeardDialogBody({ message }: { message: TextMessage }) {
   );
 
   const geoSender = sender ? { label: sender.label, position: sender.position } : null;
+  const { legs: pathLegs } = useMemo(() => meshCoreHeardToLegs(message), [message]);
+  const hasAmbiguousHops = useMemo(() => messageHasAmbiguousPathHops(message), [message]);
 
   return (
     <>
       <HeardPathGeoMap
         sender={geoSender}
         feeders={geoFeeders}
+        pathLegs={pathLegs}
         senderName={message.mc_sender_label || message.sender?.short_name || message.sender?.long_name || null}
       />
       {message.mc_sender_candidates && message.mc_sender_candidates.length > 1 && (
@@ -53,7 +59,12 @@ function MeshCoreHeardDialogBody({ message }: { message: TextMessage }) {
           Multiple nodes match sender &quot;{message.mc_sender_label}&quot; — map uses feeder positions only.
         </p>
       )}
-      <MeshCoreHeardPathsPanel legs={legs} senderDisplayLabel={senderDisplayLabel} senderKnown={senderKnown} />
+      <MeshCoreHeardPathsPanel
+        legs={legs}
+        senderDisplayLabel={senderDisplayLabel}
+        senderKnown={senderKnown}
+        hasAmbiguousHops={hasAmbiguousHops}
+      />
       <div className="space-y-4 mt-4">
         {legs.map((leg, index) => {
           const mc = leg.observation;
@@ -70,7 +81,8 @@ function MeshCoreHeardDialogBody({ message }: { message: TextMessage }) {
               style={{ borderLeftWidth: 4, borderLeftColor: leg.lineColor }}
             >
               <div className="min-w-0">
-                <div className="font-semibold">
+                <div className="font-semibold flex items-center gap-1.5">
+                  <HopPositionIcon positioned={mc.observer.position != null} />
                   {observerLink ? (
                     <Link to={observerLink} className="hover:underline">
                       {leg.receiverLabel}

--- a/src/components/messages/PathHopBadge.tsx
+++ b/src/components/messages/PathHopBadge.tsx
@@ -4,13 +4,25 @@ import { Tooltip, TooltipContent, TooltipProvider, TooltipTrigger } from '@/comp
 import type { ResolvedHop } from '@/lib/models';
 import { nodeDetailPath } from '@/lib/node-detail-routes';
 import { cn } from '@/lib/utils';
+import { HopPositionIcon } from './HopPositionIcon';
 
 function hopIsLinkable(hop: ResolvedHop): boolean {
   return hop.status === 'resolved' && Boolean(hop.node_id_str?.trim());
 }
 
 function hopLabel(hop: ResolvedHop): string {
-  return hop.long_name?.trim() || hop.hash;
+  return hop.short_name?.trim() || hop.long_name?.trim() || hop.hash;
+}
+
+function hopTooltip(hop: ResolvedHop): string | null {
+  if (hop.candidates && hop.candidates.length > 0) {
+    const names = hop.candidates.map((c) => c.short_name || c.long_name || c.node_id_str).join(', ');
+    return `${hop.candidates.length} possible nodes: ${names}`;
+  }
+  if (hop.ambiguous) {
+    return 'Multiple matches possible';
+  }
+  return null;
 }
 
 export function PathHopBadge({ hop }: { hop: ResolvedHop }) {
@@ -28,22 +40,30 @@ export function PathHopBadge({ hop }: { hop: ResolvedHop }) {
     </Badge>
   );
 
-  const wrapped =
-    hop.ambiguous && unknown ? (
+  const tooltipText = hopTooltip(hop);
+  const wrappedBadge =
+    tooltipText != null ? (
       <TooltipProvider>
         <Tooltip>
           <TooltipTrigger asChild>
             <span className="inline-flex">{badge}</span>
           </TooltipTrigger>
-          <TooltipContent>Multiple matches possible</TooltipContent>
+          <TooltipContent>{tooltipText}</TooltipContent>
         </Tooltip>
       </TooltipProvider>
     ) : (
       badge
     );
 
+  const content = (
+    <span className="inline-flex items-center gap-1">
+      <HopPositionIcon hop={hop} />
+      {wrappedBadge}
+    </span>
+  );
+
   if (!hopIsLinkable(hop)) {
-    return wrapped;
+    return content;
   }
 
   const path = nodeDetailPath({
@@ -53,16 +73,16 @@ export function PathHopBadge({ hop }: { hop: ResolvedHop }) {
   });
 
   if (!path) {
-    return wrapped;
+    return content;
   }
 
   return (
     <Link
       to={path}
-      className="inline-flex max-w-full rounded-md focus:outline-none focus:ring-2 focus:ring-ring focus:ring-offset-2"
+      className="inline-flex max-w-full items-center gap-1 rounded-md focus:outline-none focus:ring-2 focus:ring-ring focus:ring-offset-2"
       onClick={(e) => e.stopPropagation()}
     >
-      {wrapped}
+      {content}
     </Link>
   );
 }

--- a/src/components/messages/heard-path-map-adapters.test.ts
+++ b/src/components/messages/heard-path-map-adapters.test.ts
@@ -347,6 +347,71 @@ describe('heard path adapters', () => {
     expect(legs[0].waypoints[0].short_name).toBe('Hop1');
   });
 
+  it('meshCoreHeardToLegs omits ambiguous hops from map waypoints', () => {
+    const message: TextMessage = {
+      id: '8',
+      packet_id: 8,
+      protocol: 'meshcore',
+      sender: { node_id_str: 'mc:abc', long_name: 'X', short_name: 'X' },
+      sender_position: { latitude: 55.0, longitude: -4.0 },
+      recipient_meshtastic_node_id: null,
+      channel: 1,
+      sent_at: new Date().toISOString(),
+      message_text: 'mc',
+      is_emoji: false,
+      reply_to_meshtastic_packet_id: null,
+      heard: [
+        {
+          observer: {
+            node_id_str: 'mc:feed',
+            internal_id: null,
+            long_name: 'Feeder',
+            short_name: 'F',
+            position: { latitude: 55.2, longitude: -4.2 },
+          },
+          rx_time: new Date().toISOString(),
+          rx_rssi: -90,
+          rx_snr: 2,
+          path_hashes: ['aa', 'bb'],
+          resolved_path: [
+            {
+              hash: 'aa',
+              status: 'resolved',
+              node_id_str: 'mc:hop',
+              internal_id: '1',
+              long_name: 'Hop',
+              short_name: 'H',
+              ambiguous: false,
+              position: { latitude: 55.1, longitude: -4.1 },
+            },
+            {
+              hash: 'bb',
+              status: 'ambiguous',
+              node_id_str: null,
+              internal_id: null,
+              long_name: null,
+              short_name: null,
+              ambiguous: true,
+              candidates: [
+                {
+                  internal_id: '2',
+                  node_id_str: 'mc:x',
+                  long_name: 'X1',
+                  short_name: 'X1',
+                  position: null,
+                },
+              ],
+            },
+          ],
+          path_known: false,
+        },
+      ],
+    };
+    const { legs } = meshCoreHeardToLegs(message);
+    expect(legs[0].waypoints).toHaveLength(1);
+    expect(legs[0].waypoints[0].node_id_str).toBe('mc:hop');
+  });
+
   it('resolvedHopsFromObservation falls back to path_hashes', () => {
     const hops = resolvedHopsFromObservation({
       observer: {

--- a/src/components/messages/heard-path-map-adapters.test.ts
+++ b/src/components/messages/heard-path-map-adapters.test.ts
@@ -3,6 +3,7 @@ import {
   meshCoreHeardLegs,
   meshCoreHeardToLegs,
   meshtasticHeardToLegs,
+  resolveHeardPathSender,
   resolvedHopsFromObservation,
 } from './heard-path-map-adapters';
 import type { TextMessage } from '@/lib/models';
@@ -46,6 +47,39 @@ describe('heard path adapters', () => {
     expect(legs[0].waypoints).toHaveLength(0);
   });
 
+  it('resolveHeardPathSender identifies single mc_sender_candidate without position', () => {
+    const message: TextMessage = {
+      id: 'gi7',
+      packet_id: 1,
+      protocol: 'meshcore',
+      sender: null,
+      mc_sender_label: '☘️GI7ULG☘️',
+      mc_sender_candidates: [
+        {
+          internal_id: '00000000-0000-4000-8000-000000000099',
+          node_id_str: 'mc:9cce73b9b3ee',
+          long_name: '☘️GI7ULG☘️',
+          short_name: '☘️GI7',
+          position: null,
+        },
+      ],
+      recipient_meshtastic_node_id: null,
+      channel: 1,
+      sent_at: new Date().toISOString(),
+      message_text: '☘️GI7ULG☘️: Test',
+      is_emoji: false,
+      reply_to_meshtastic_packet_id: null,
+      heard: [],
+    };
+    const sender = resolveHeardPathSender(message);
+    expect(sender?.identified).toBe(true);
+    expect(sender?.label).toBe('☘️GI7');
+    expect(sender?.position).toBeNull();
+    expect(sender?.detailPath).toBe('/nodes/mc%3A9cce73b9b3ee');
+    const { sender: geoSender } = meshCoreHeardToLegs(message);
+    expect(geoSender).toBeNull();
+  });
+
   it('meshCoreHeardToLegs uses single mc_sender_candidate with position as sender', () => {
     const message: TextMessage = {
       id: '3',
@@ -76,7 +110,7 @@ describe('heard path adapters', () => {
     expect(sender?.position.latitude).toBe(55.0);
   });
 
-  it('meshCoreHeardToLegs omits sender when multiple positioned candidates', () => {
+  it('meshCoreHeardToLegs omits geo sender when multiple mc_sender_candidates', () => {
     const pos = { latitude: 55.0, longitude: -4.0 };
     const message: TextMessage = {
       id: '4',

--- a/src/components/messages/heard-path-map-adapters.ts
+++ b/src/components/messages/heard-path-map-adapters.ts
@@ -81,8 +81,11 @@ export function heardPathSenderDisplayLabel(
   return message.mc_sender_label?.trim() || message.sender?.short_name || message.sender?.node_id_str || 'Sender';
 }
 
-function hopToWaypoint(hop: ResolvedHop): TracerouteRouteNode {
-  const label = hop.long_name || hop.node_id_str || hop.hash;
+function hopToWaypoint(hop: ResolvedHop): TracerouteRouteNode | null {
+  if (hop.status === 'ambiguous') {
+    return null;
+  }
+  const label = hop.short_name || hop.long_name || hop.node_id_str || hop.hash;
   return {
     meshtastic_node_id: UNKNOWN_NODE_ID,
     node_id_str: hop.node_id_str || hop.hash,
@@ -149,9 +152,10 @@ export function meshCoreHeardToLegs(message: TextMessage): {
   const mapLegs: HeardPathLeg[] = [];
   for (const leg of legs) {
     if (!leg.receiverPosition) continue;
+    const waypoints = leg.hops.map(hopToWaypoint).filter((node): node is TracerouteRouteNode => node != null);
     mapLegs.push({
       receiver: { label: leg.receiverLabel, position: leg.receiverPosition },
-      waypoints: leg.hops.map(hopToWaypoint),
+      waypoints,
       pathKnown: leg.pathKnown,
       lineColor: leg.lineColor,
     });
@@ -168,6 +172,17 @@ export function messageToHeardPathLegs(message: TextMessage): {
     return meshCoreHeardToLegs(message);
   }
   return meshtasticHeardToLegs(message);
+}
+
+export function messageHasAmbiguousPathHops(message: TextMessage): boolean {
+  for (const obs of message.heard ?? []) {
+    if (!isMeshCoreHeardObservation(obs)) continue;
+    const hops = resolvedHopsFromObservation(obs);
+    if (hops.some((hop) => hop.status === 'ambiguous' || (hop.candidates?.length ?? 0) > 1)) {
+      return true;
+    }
+  }
+  return false;
 }
 
 export function isMeshCoreHeardMessage(message: TextMessage): boolean {

--- a/src/components/messages/heard-path-map-adapters.ts
+++ b/src/components/messages/heard-path-map-adapters.ts
@@ -7,6 +7,7 @@ import type {
   TextMessage,
 } from '@/lib/models';
 import type { TracerouteRouteNode } from '@/lib/models';
+import { nodeDetailPath } from '@/lib/node-detail-routes';
 import { HEARD_PATH_LEG_COLORS } from './heard-path-constants';
 import type { HeardPathLeg } from './HeardPathMap';
 
@@ -41,42 +42,91 @@ export function resolvedHopsFromObservation(obs: MeshCoreHeardObservation): Reso
   }));
 }
 
-function senderFromMcCandidates(candidates: McSenderCandidate[] | undefined): {
+/** Sender for heard dialog: identity vs map position are separate. */
+export type HeardPathSender = {
   label: string;
-  position: MapPosition;
-} | null {
-  if (!candidates?.length) return null;
-  const positioned = candidates.filter((c) => c.position != null) as Array<
-    McSenderCandidate & { position: MapPosition }
-  >;
-  if (positioned.length !== 1) return null;
-  const node = positioned[0];
-  return {
-    label: node.short_name || node.long_name || node.node_id_str,
-    position: node.position,
-  };
+  position: MapPosition | null;
+  /** True when the sender node is identified (not ambiguous). */
+  identified: boolean;
+  detailPath: string | null;
+};
+
+function mcCandidateDetailPath(candidate: McSenderCandidate): string | null {
+  return nodeDetailPath({
+    internal_id: candidate.internal_id ?? undefined,
+    node_id_str: candidate.node_id_str,
+    protocol: 2,
+  });
+}
+
+function senderFromMcCandidates(
+  candidates: McSenderCandidate[] | undefined,
+  fallbackLabel?: string
+): HeardPathSender | null {
+  if (!candidates?.length) {
+    if (fallbackLabel) {
+      return { label: fallbackLabel, position: null, identified: false, detailPath: null };
+    }
+    return null;
+  }
+  if (candidates.length === 1) {
+    const node = candidates[0];
+    return {
+      label: node.short_name || node.long_name || node.node_id_str,
+      position: node.position ?? null,
+      identified: true,
+      detailPath: mcCandidateDetailPath(node),
+    };
+  }
+  const label =
+    fallbackLabel || candidates[0].short_name || candidates[0].long_name || candidates[0].node_id_str || 'Sender';
+  return { label, position: null, identified: false, detailPath: null };
+}
+
+export function resolveHeardPathSender(message: TextMessage): HeardPathSender | null {
+  const fallbackLabel = message.mc_sender_label?.trim();
+  const proto = message.protocol?.toString().toLowerCase();
+  const isMeshCore = proto === 'meshcore' || proto === '2';
+
+  if (message.sender?.node_id_str) {
+    return {
+      label: message.sender.short_name || message.sender.long_name || message.sender.node_id_str,
+      position: message.sender_position ?? null,
+      identified: true,
+      detailPath: nodeDetailPath({
+        node_id_str: message.sender.node_id_str,
+        protocol: isMeshCore ? 2 : 1,
+      }),
+    };
+  }
+
+  if (message.sender_position) {
+    return {
+      label: message.sender?.short_name || fallbackLabel || message.sender?.node_id_str || 'Sender',
+      position: message.sender_position,
+      identified: true,
+      detailPath: message.sender?.node_id_str
+        ? nodeDetailPath({ node_id_str: message.sender.node_id_str, protocol: isMeshCore ? 2 : 1 })
+        : null,
+    };
+  }
+
+  return senderFromMcCandidates(message.mc_sender_candidates, fallbackLabel);
+}
+
+/** Geo map anchor when sender has coordinates only. */
+export function heardPathSenderForGeoMap(
+  sender: HeardPathSender | null
+): { label: string; position: MapPosition } | null {
+  if (!sender?.position) return null;
+  return { label: sender.label, position: sender.position };
 }
 
 export function mapHeardPathSender(message: TextMessage): { label: string; position: MapPosition } | null {
-  if (message.sender && message.sender_position) {
-    return {
-      label: message.sender.short_name || message.sender.node_id_str,
-      position: message.sender_position,
-    };
-  }
-  if (message.sender_position) {
-    return {
-      label: message.sender?.short_name || message.mc_sender_label || message.sender?.node_id_str || 'Sender',
-      position: message.sender_position,
-    };
-  }
-  return senderFromMcCandidates(message.mc_sender_candidates);
+  return heardPathSenderForGeoMap(resolveHeardPathSender(message));
 }
 
-export function heardPathSenderDisplayLabel(
-  message: TextMessage,
-  sender: { label: string; position: MapPosition } | null
-): string {
+export function heardPathSenderDisplayLabel(message: TextMessage, sender: HeardPathSender | null): string {
   if (sender?.label) return sender.label;
   return message.mc_sender_label?.trim() || message.sender?.short_name || message.sender?.node_id_str || 'Sender';
 }
@@ -95,11 +145,11 @@ function hopToWaypoint(hop: ResolvedHop): TracerouteRouteNode | null {
 }
 
 export function meshCoreHeardLegs(message: TextMessage): {
-  sender: { label: string; position: MapPosition } | null;
+  sender: HeardPathSender | null;
   senderDisplayLabel: string;
   legs: MeshCoreHeardLeg[];
 } {
-  const sender = mapHeardPathSender(message);
+  const sender = resolveHeardPathSender(message);
   const senderDisplayLabel = heardPathSenderDisplayLabel(message, sender);
   const legs: MeshCoreHeardLeg[] = [];
   let colorIndex = 0;
@@ -148,7 +198,8 @@ export function meshCoreHeardToLegs(message: TextMessage): {
   sender: { label: string; position: MapPosition } | null;
   legs: HeardPathLeg[];
 } {
-  const { sender, legs } = meshCoreHeardLegs(message);
+  const { legs } = meshCoreHeardLegs(message);
+  const sender = heardPathSenderForGeoMap(resolveHeardPathSender(message));
   const mapLegs: HeardPathLeg[] = [];
   for (const leg of legs) {
     if (!leg.receiverPosition) continue;

--- a/src/components/messages/heard-path-map-layers.ts
+++ b/src/components/messages/heard-path-map-layers.ts
@@ -1,0 +1,145 @@
+import { buildPartialSegments, midpoint, type LatLng, type PathSegment } from '@/lib/map-path-segments';
+import { createNodeIcon } from '@/components/nodes/map-utils';
+import type { MapPosition } from './HeardPathMap';
+import type { HeardPathLeg } from './HeardPathMap';
+import { HEARD_PATH_LEG_COLORS, HEARD_PATH_SENDER_COLOR } from './heard-path-constants';
+import L from 'leaflet';
+
+export function toLatLng(pos: MapPosition): LatLng {
+  return [pos.latitude, pos.longitude];
+}
+
+export function planLegPathSegments(senderPos: LatLng | null, leg: HeardPathLeg): PathSegment[] {
+  const receiverPos = toLatLng(leg.receiver.position);
+  const hasPositionedHop = leg.waypoints.some((node) => node.position != null);
+
+  if (!senderPos && !hasPositionedHop) {
+    return [];
+  }
+
+  if (leg.pathKnown && hasPositionedHop && senderPos) {
+    return buildPartialSegments({
+      startPos: senderPos,
+      waypoints: leg.waypoints,
+      endPos: receiverPos,
+      truncateAfterLastKnown: false,
+    });
+  }
+
+  return buildPartialSegments({
+    startPos: senderPos,
+    waypoints: leg.waypoints,
+    endPos: receiverPos,
+    truncateAfterLastKnown: true,
+  });
+}
+
+function unknownLabelContent(labels: { node_id_str: string }[]): string {
+  return labels.map((l) => l.node_id_str).join(' · ');
+}
+
+export function addPathSegmentsToMap(map: L.Map, layers: L.Layer[], segments: PathSegment[], color: string): void {
+  segments.forEach((seg) => {
+    const poly = L.polyline(seg.latlngs, {
+      color,
+      weight: 4,
+      dashArray: seg.dashed ? '10, 10' : undefined,
+    }).addTo(map);
+    layers.push(poly);
+
+    if (seg.dashed && seg.unknownLabels.length > 0 && seg.latlngs.length >= 2) {
+      const mid = midpoint(seg.latlngs[0], seg.latlngs[seg.latlngs.length - 1]);
+      const tooltip = L.tooltip({
+        permanent: true,
+        direction: 'center',
+        className: 'traceroute-unknown-label',
+      })
+        .setContent(unknownLabelContent(seg.unknownLabels))
+        .setLatLng(mid);
+      tooltip.addTo(map);
+      layers.push(tooltip);
+    }
+  });
+}
+
+export type DrawHeardPathLayersOptions = {
+  map: L.Map;
+  layers: L.Layer[];
+  bounds: L.LatLngBounds;
+  sender: { label: string; position: MapPosition } | null;
+  legs: HeardPathLeg[];
+};
+
+function drawLegPolylinesAndHopMarkers(
+  map: L.Map,
+  layers: L.Layer[],
+  bounds: L.LatLngBounds,
+  senderPos: LatLng | null,
+  legs: HeardPathLeg[],
+  options: { includeReceiverMarkers: boolean }
+): boolean {
+  let drewPath = false;
+
+  legs.forEach((leg, index) => {
+    const receiverPos = toLatLng(leg.receiver.position);
+    const color = leg.lineColor ?? HEARD_PATH_LEG_COLORS[index % HEARD_PATH_LEG_COLORS.length];
+
+    if (options.includeReceiverMarkers) {
+      const receiverMarker = L.marker(receiverPos, {
+        icon: createNodeIcon(leg.receiver.label, color, false),
+      }).addTo(map);
+      layers.push(receiverMarker);
+      bounds.extend(receiverPos);
+    }
+
+    leg.waypoints.forEach((node) => {
+      if (!node.position) return;
+      const pos = toLatLng(node.position);
+      const label = node.short_name || node.node_id_str;
+      const hopMarker = L.marker(pos, {
+        icon: createNodeIcon(label, color, false),
+      }).addTo(map);
+      layers.push(hopMarker);
+      bounds.extend(pos);
+    });
+
+    const segments = planLegPathSegments(senderPos, leg);
+    if (segments.length > 0) {
+      drewPath = true;
+      addPathSegmentsToMap(map, layers, segments, color);
+      segments.forEach((seg) => {
+        seg.latlngs.forEach((p) => bounds.extend(p));
+      });
+    }
+  });
+
+  return drewPath;
+}
+
+export function drawHeardPathLayers({ map, layers, bounds, sender, legs }: DrawHeardPathLayersOptions): boolean {
+  const senderPos = sender ? toLatLng(sender.position) : null;
+
+  if (senderPos) {
+    const senderMarker = L.marker(senderPos, {
+      icon: createNodeIcon(sender?.label ?? 'S', HEARD_PATH_SENDER_COLOR, false),
+    }).addTo(map);
+    layers.push(senderMarker);
+    bounds.extend(senderPos);
+  }
+
+  return drawLegPolylinesAndHopMarkers(map, layers, bounds, senderPos, legs, { includeReceiverMarkers: true });
+}
+
+export function drawHeardPathPolylinesOnly(
+  map: L.Map,
+  layers: L.Layer[],
+  bounds: L.LatLngBounds,
+  senderPos: LatLng | null,
+  legs: HeardPathLeg[]
+): boolean {
+  return drawLegPolylinesAndHopMarkers(map, layers, bounds, senderPos, legs, { includeReceiverMarkers: false });
+}
+
+export function hasDrawablePathOnMap(senderPos: LatLng | null, legs: HeardPathLeg[]): boolean {
+  return legs.some((leg) => planLegPathSegments(senderPos, leg).length > 0);
+}

--- a/src/lib/map-path-segments.test.ts
+++ b/src/lib/map-path-segments.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from 'vitest';
-import { buildSegments } from './map-path-segments';
+import { buildPartialSegments, buildSegments } from './map-path-segments';
 import type { TracerouteRouteNode } from '@/lib/models';
 
 const start: [number, number] = [55.0, -4.0];
@@ -32,5 +32,54 @@ describe('buildSegments', () => {
     ];
     const segments = buildSegments(start, nodes, end);
     expect(segments.some((s) => !s.dashed)).toBe(true);
+  });
+});
+
+describe('buildPartialSegments', () => {
+  it('starts at first positioned hop when sender is missing', () => {
+    const nodes: TracerouteRouteNode[] = [
+      {
+        meshtastic_node_id: 1,
+        node_id_str: 'hop',
+        short_name: 'H',
+        position: { latitude: 55.05, longitude: -4.05 },
+      },
+    ];
+    const segments = buildPartialSegments({
+      startPos: null,
+      waypoints: nodes,
+      endPos: end,
+    });
+    expect(segments.length).toBeGreaterThan(0);
+  });
+
+  it('omits line to feeder when unknown hops trail last positioned hop', () => {
+    const nodes: TracerouteRouteNode[] = [
+      {
+        meshtastic_node_id: 1,
+        node_id_str: 'known',
+        short_name: 'K',
+        position: { latitude: 55.05, longitude: -4.05 },
+      },
+      {
+        meshtastic_node_id: 2,
+        node_id_str: 'unknown',
+        short_name: 'unknown',
+        position: null,
+      },
+    ];
+    const segments = buildPartialSegments({
+      startPos: start,
+      waypoints: nodes,
+      endPos: end,
+      truncateAfterLastKnown: true,
+    });
+    const reachesFeeder = segments.some(
+      (s) =>
+        s.latlngs.length > 0 &&
+        s.latlngs[s.latlngs.length - 1][0] === end[0] &&
+        s.latlngs[s.latlngs.length - 1][1] === end[1]
+    );
+    expect(reachesFeeder).toBe(false);
   });
 });

--- a/src/lib/map-path-segments.ts
+++ b/src/lib/map-path-segments.ts
@@ -56,3 +56,85 @@ export function buildSegments(
 export function midpoint(a: LatLng, b: LatLng): LatLng {
   return [(a[0] + b[0]) / 2, (a[1] + b[1]) / 2];
 }
+
+function toLatLngFromNode(node: TracerouteRouteNode): LatLng {
+  return [node.position!.latitude, node.position!.longitude];
+}
+
+export type PartialSegmentParams = {
+  startPos: LatLng | null;
+  waypoints: TracerouteRouteNode[];
+  endPos: LatLng | null;
+  truncateAfterLastKnown?: boolean;
+};
+
+/**
+ * Build path segments when start and/or end may be missing and trailing hops may lack positions.
+ * Omits lines past the last positioned intermediate when truncateAfterLastKnown is true.
+ */
+export function buildPartialSegments({
+  startPos,
+  waypoints,
+  endPos,
+  truncateAfterLastKnown = true,
+}: PartialSegmentParams): PathSegment[] {
+  let nodes = waypoints;
+  let end = endPos;
+
+  if (truncateAfterLastKnown && endPos) {
+    let lastPositionedIdx = -1;
+    for (let i = waypoints.length - 1; i >= 0; i -= 1) {
+      if (waypoints[i].position) {
+        lastPositionedIdx = i;
+        break;
+      }
+    }
+    if (lastPositionedIdx >= 0) {
+      const trailingUnknown = waypoints.slice(lastPositionedIdx + 1).some((w) => !w.position);
+      if (trailingUnknown) {
+        end = null;
+        nodes = waypoints.slice(0, lastPositionedIdx + 1);
+      }
+    } else if (!startPos) {
+      return [];
+    }
+  }
+
+  let start = startPos;
+  if (!start) {
+    const firstIdx = nodes.findIndex((w) => w.position);
+    if (firstIdx < 0) {
+      return [];
+    }
+    start = toLatLngFromNode(nodes[firstIdx]);
+    nodes = nodes.slice(firstIdx + 1);
+  }
+
+  if (!start) {
+    return [];
+  }
+
+  if (!end) {
+    const lastPositioned = [...nodes].reverse().find((w) => w.position);
+    if (!lastPositioned?.position) {
+      return [];
+    }
+    const endAnchor = toLatLngFromNode(lastPositioned);
+    const lastIdx = nodes.indexOf(lastPositioned);
+    const chain = nodes.slice(0, lastIdx + 1);
+    return buildSegments(start, chain, endAnchor);
+  }
+
+  const hasPositionedHop = nodes.some((w) => w.position);
+  if (!hasPositionedHop) {
+    return [
+      {
+        latlngs: [start, end],
+        dashed: true,
+        unknownLabels: waypoints.map((node) => ({ node_id_str: node.node_id_str })),
+      },
+    ];
+  }
+
+  return buildSegments(start, nodes, end);
+}

--- a/src/lib/models.ts
+++ b/src/lib/models.ts
@@ -416,8 +416,10 @@ export interface ResolvedHop {
   node_id_str: string | null;
   internal_id: string | null;
   long_name: string | null;
+  short_name?: string | null;
   ambiguous: boolean;
   position?: MapPosition | null;
+  candidates?: McSenderCandidate[];
 }
 
 export interface HeardObserver {


### PR DESCRIPTION
## Summary

- Keep **HeardPathGeoMap** for MeshCore anchors; add optional `pathLegs` overlay via shared `heard-path-map-layers` (partial polylines, dashed unknown hops, truncate after last positioned hop).
- Refactor **HeardPathMap** (Meshtastic) to use the same path layer helper and `buildPartialSegments`.
- **MapPin** / **MapPinOff** on hop badges, sender, feeders; ambiguity banner and candidate tooltips when API returns `candidates`.
- Omit `ambiguous` hops from map waypoints; full chain still in schematic/list.
- **Sender without position:** heard dialog shows identified sender + node link when there is a single `mc_sender_candidate`; map pin icon and geo marker still require coordinates.
- Docs: AGENTS.md component-doc rule, HeardPathMap/HeardPathGeoMap component docs, heard-path-dialog.md.

Depends on [meshflow-api#395](https://github.com/pskillen/meshflow-api/pull/395) for `candidates`, `short_name`, and `path_hash_*` on `heard[]` — deploy API first.

## Testing performed

- [x] `npm test` (364 tests)
- [x] Open MeshCore message heard dialog: verify sender link without position (e.g. GI7ULG), map lines when hop positions exist
- [x] Meshtastic heard dialog still renders paths

Closes meshflow-ui#311