### PR TITLE
fix(auth): recover cleanly from stale JWTs and 401 failures

### DIFF
--- a/config.ts
+++ b/config.ts
@@ -11,11 +11,10 @@ const defaultConfig: AppConfig = {
   apis: {
     meshBot: {
       baseUrl: 'http://localhost:8000',
-      basePath: '/api', // Updated to use the new API base path
+      basePath: '/api/ui',
       timeout: 10000,
       auth: {
-        type: 'token',
-        token: 'd9891a1ed5541ae02392b9829cb68267bf68e06c', // This token should be replaced with a valid JWT token
+        type: 'none',
       },
       headers: {
         Accept: 'application/json',

--- a/deploy/docker/entrypoint.sh
+++ b/deploy/docker/entrypoint.sh
@@ -10,8 +10,7 @@ cat > /usr/share/nginx/html/config.json << EOF
       "basePath": "${MESHBOT_API_BASE_PATH:-/api/ui}",
       "timeout": ${MESHBOT_API_TIMEOUT:-10000},
       "auth": {
-        "type": "token",
-        "token": "${MESHBOT_API_TOKEN:-d9891a1ed5541ae02392b9829cb68267bf68e06c}"
+        "type": "none"
       },
       "headers": {
         "Accept": "application/json"

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -23,7 +23,6 @@ services:
       - MESHBOT_API_URL=http://meshtastic-bot-manager:8000
       - MESHBOT_API_BASE_PATH=/api/ui
       - MESHBOT_API_TIMEOUT=10000
-      - MESHBOT_API_TOKEN=d9891a1ed5541ae02392b9829cb68267bf68e06c
       - MAP_DEFAULT_CENTER_LAT=0
       - MAP_DEFAULT_CENTER_LNG=0
       - MAP_DEFAULT_ZOOM=2

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -26,6 +26,7 @@ import { LoginPage } from '@/pages/auth/LoginPage';
 import { OAuthCallback } from '@/pages/auth/OAuthCallback';
 import { UserPage } from '@/pages/user/UserPage';
 import { ProtectedRoute } from '@/components/auth/ProtectedRoute';
+import { AuthErrorBoundaryWithReset } from '@/components/auth/AuthErrorBoundary';
 import { AppLayout } from '@/components/layouts/AppLayout';
 import MonitorNodes from '@/pages/nodes/monitor';
 import DxMonitoringPage from '@/pages/nodes/DxMonitoringPage';
@@ -50,92 +51,95 @@ function App() {
         <Router>
           <AuthProvider>
             <WebSocketProvider>
-              <Routes>
-                <Route path="/login" element={<LoginPage />} />
-                <Route path="/auth/callback" element={<OAuthCallback />} />
+              <AuthErrorBoundaryWithReset>
+                <Routes>
+                  <Route path="/login" element={<LoginPage />} />
+                  <Route path="/auth/callback" element={<OAuthCallback />} />
+                  <Route path="/oauth/callback" element={<OAuthCallback />} />
 
-                {/* Public observatory (guest or authenticated) — meshflow-ui #298 */}
-                <Route element={<AppLayout />}>
-                  <Route path="/" element={<Dashboard />} />
-                  <Route path="/nodes" element={<NodesList />} />
-                  <Route path="/nodes/:id" element={<NodeDetails />} />
-                  <Route path="/map" element={<Navigate to="/nodes" replace />} />
-                  <Route path="/messages" element={<MessageHistory />} />
-                  <Route path="/meshtastic/dashboard" element={<MeshtasticDashboard />} />
-                  <Route path="/meshcore/dashboard" element={<MeshCoreDashboard />} />
-                  <Route path="/meshcore/path-tracing" element={<MeshCorePassivePath />} />
-                  <Route path="/meshcore/nodes" element={<MeshCoreNodesList />} />
-                  <Route path="/meshcore/messages" element={<MeshCoreMessages />} />
-                  <Route path="/meshcore/map" element={<Navigate to="/meshcore/nodes" replace />} />
-                  <Route path="/traceroutes/history" element={<TracerouteHistory />} />
-                  <Route path="/traceroutes" element={<TraceroutesLanding />} />
-                  <Route path="/traceroutes/heatmap" element={<Navigate to="/traceroutes/map/heat" replace />} />
-                  <Route
-                    path="/traceroutes/topology"
-                    element={<Navigate to="/traceroutes/map/topology/heat" replace />}
-                  />
-                  <Route path="/traceroutes/map/heat" element={<TracerouteHeatmapPage edgeMetric="packets" />} />
-                  <Route path="/traceroutes/map/snr" element={<TracerouteHeatmapPage edgeMetric="snr" />} />
-                  <Route
-                    path="/traceroutes/map/topology/heat"
-                    element={<TracerouteTopologyPage edgeMetric="packets" />}
-                  />
-                  <Route path="/traceroutes/map/topology/snr" element={<TracerouteTopologyPage edgeMetric="snr" />} />
-                  <Route path="/traceroutes/map/coverage" element={<FeederCoveragePage />} />
-                  <Route
-                    path="/traceroutes/map/coverage/constellation/:constellationId"
-                    element={<ConstellationCoveragePage />}
-                  />
-                  <Route path="/traceroutes/map/coverage/constellation" element={<ConstellationCoveragePage />} />
-                  <Route path="/weather" element={<Weather />} />
-                </Route>
+                  {/* Public observatory (guest or authenticated) — meshflow-ui #298 */}
+                  <Route element={<AppLayout />}>
+                    <Route path="/" element={<Dashboard />} />
+                    <Route path="/nodes" element={<NodesList />} />
+                    <Route path="/nodes/:id" element={<NodeDetails />} />
+                    <Route path="/map" element={<Navigate to="/nodes" replace />} />
+                    <Route path="/messages" element={<MessageHistory />} />
+                    <Route path="/meshtastic/dashboard" element={<MeshtasticDashboard />} />
+                    <Route path="/meshcore/dashboard" element={<MeshCoreDashboard />} />
+                    <Route path="/meshcore/path-tracing" element={<MeshCorePassivePath />} />
+                    <Route path="/meshcore/nodes" element={<MeshCoreNodesList />} />
+                    <Route path="/meshcore/messages" element={<MeshCoreMessages />} />
+                    <Route path="/meshcore/map" element={<Navigate to="/meshcore/nodes" replace />} />
+                    <Route path="/traceroutes/history" element={<TracerouteHistory />} />
+                    <Route path="/traceroutes" element={<TraceroutesLanding />} />
+                    <Route path="/traceroutes/heatmap" element={<Navigate to="/traceroutes/map/heat" replace />} />
+                    <Route
+                      path="/traceroutes/topology"
+                      element={<Navigate to="/traceroutes/map/topology/heat" replace />}
+                    />
+                    <Route path="/traceroutes/map/heat" element={<TracerouteHeatmapPage edgeMetric="packets" />} />
+                    <Route path="/traceroutes/map/snr" element={<TracerouteHeatmapPage edgeMetric="snr" />} />
+                    <Route
+                      path="/traceroutes/map/topology/heat"
+                      element={<TracerouteTopologyPage edgeMetric="packets" />}
+                    />
+                    <Route path="/traceroutes/map/topology/snr" element={<TracerouteTopologyPage edgeMetric="snr" />} />
+                    <Route path="/traceroutes/map/coverage" element={<FeederCoveragePage />} />
+                    <Route
+                      path="/traceroutes/map/coverage/constellation/:constellationId"
+                      element={<ConstellationCoveragePage />}
+                    />
+                    <Route path="/traceroutes/map/coverage/constellation" element={<ConstellationCoveragePage />} />
+                    <Route path="/weather" element={<Weather />} />
+                  </Route>
 
-                {/* Authenticated-only */}
-                <Route
-                  element={
-                    <ProtectedRoute>
-                      <AppLayout />
-                    </ProtectedRoute>
-                  }
-                >
-                  <Route path="/nodes/infrastructure" element={<MeshInfrastructure protocol="meshtastic" />} />
-                  <Route path="/meshcore/infrastructure" element={<MeshInfrastructure protocol="meshcore" />} />
+                  {/* Authenticated-only */}
                   <Route
-                    path="/nodes/infrastructure/export"
                     element={
-                      <Suspense fallback={<div>Loading...</div>}>
-                        <InfrastructureExport />
-                      </Suspense>
+                      <ProtectedRoute>
+                        <AppLayout />
+                      </ProtectedRoute>
                     }
-                  />
-                  <Route
-                    path="/nodes/managed-nodes"
-                    element={
-                      <Suspense fallback={<div>Loading managed nodes...</div>}>
-                        <ManagedNodesStatus />
-                      </Suspense>
-                    }
-                  />
-                  <Route path="/nodes/my-nodes" element={<MyNodes />} />
-                  <Route path="/nodes/monitor" element={<MonitorNodes />} />
-                  <Route path="/nodes/dx-monitoring" element={<DxMonitoringPage />} />
-                  <Route path="/nodes/:id/claim" element={<ClaimNode />} />
-                  <Route
-                    path="/meshcore/managed-nodes"
-                    element={
-                      <Suspense fallback={<div>Loading managed nodes...</div>}>
-                        <MeshCoreManagedNodesStatus />
-                      </Suspense>
-                    }
-                  />
-                  <Route path="/user/nodes" element={<NodeSettings />} />
-                  <Route path="/user/settings" element={<SettingsPage />} />
-                  <Route path="/user/api-keys" element={<ApiKeysPage />} />
-                  <Route path="/user" element={<UserPage />} />
-                </Route>
+                  >
+                    <Route path="/nodes/infrastructure" element={<MeshInfrastructure protocol="meshtastic" />} />
+                    <Route path="/meshcore/infrastructure" element={<MeshInfrastructure protocol="meshcore" />} />
+                    <Route
+                      path="/nodes/infrastructure/export"
+                      element={
+                        <Suspense fallback={<div>Loading...</div>}>
+                          <InfrastructureExport />
+                        </Suspense>
+                      }
+                    />
+                    <Route
+                      path="/nodes/managed-nodes"
+                      element={
+                        <Suspense fallback={<div>Loading managed nodes...</div>}>
+                          <ManagedNodesStatus />
+                        </Suspense>
+                      }
+                    />
+                    <Route path="/nodes/my-nodes" element={<MyNodes />} />
+                    <Route path="/nodes/monitor" element={<MonitorNodes />} />
+                    <Route path="/nodes/dx-monitoring" element={<DxMonitoringPage />} />
+                    <Route path="/nodes/:id/claim" element={<ClaimNode />} />
+                    <Route
+                      path="/meshcore/managed-nodes"
+                      element={
+                        <Suspense fallback={<div>Loading managed nodes...</div>}>
+                          <MeshCoreManagedNodesStatus />
+                        </Suspense>
+                      }
+                    />
+                    <Route path="/user/nodes" element={<NodeSettings />} />
+                    <Route path="/user/settings" element={<SettingsPage />} />
+                    <Route path="/user/api-keys" element={<ApiKeysPage />} />
+                    <Route path="/user" element={<UserPage />} />
+                  </Route>
 
-                <Route path="*" element={<Navigate to="/" replace />} />
-              </Routes>
+                  <Route path="*" element={<Navigate to="/" replace />} />
+                </Routes>
+              </AuthErrorBoundaryWithReset>
             </WebSocketProvider>
           </AuthProvider>
         </Router>

--- a/src/components/auth/AuthErrorBoundary.tsx
+++ b/src/components/auth/AuthErrorBoundary.tsx
@@ -1,0 +1,84 @@
+import { Component, ReactNode } from 'react';
+import { Link } from 'react-router-dom';
+import { QueryErrorResetBoundary } from '@tanstack/react-query';
+import { authService } from '@/lib/auth/authService';
+import { Button } from '@/components/ui/button';
+import { ApiError } from '@/lib/types';
+
+function isApiError(error: unknown): error is ApiError {
+  return typeof error === 'object' && error !== null && 'message' in error;
+}
+
+function isUnauthorizedError(error: unknown): boolean {
+  return isApiError(error) && error.status === 401;
+}
+
+interface AuthErrorBoundaryProps {
+  children: ReactNode;
+  onReset?: () => void;
+}
+
+interface AuthErrorBoundaryState {
+  error: unknown;
+}
+
+export class AuthErrorBoundary extends Component<AuthErrorBoundaryProps, AuthErrorBoundaryState> {
+  state: AuthErrorBoundaryState = { error: null };
+
+  static getDerivedStateFromError(error: unknown): AuthErrorBoundaryState {
+    return { error };
+  }
+
+  componentDidCatch(error: unknown) {
+    if (isUnauthorizedError(error)) {
+      authService.handleSessionExpired({
+        message: 'Your session has expired. Please log in again.',
+        reason: 'session_expired',
+      });
+    }
+  }
+
+  private handleRetry = () => {
+    this.setState({ error: null });
+    this.props.onReset?.();
+  };
+
+  render() {
+    const { error } = this.state;
+
+    if (error) {
+      if (isUnauthorizedError(error)) {
+        return (
+          <div className="flex min-h-[50vh] flex-col items-center justify-center gap-4 p-8 text-center">
+            <h2 className="text-xl font-semibold">Your session has expired</h2>
+            <p className="text-muted-foreground">Please sign in again to continue.</p>
+            <Button asChild>
+              <Link to="/login" state={{ reason: 'session_expired' }}>
+                Sign in
+              </Link>
+            </Button>
+          </div>
+        );
+      }
+
+      const message = isApiError(error) ? error.message : 'Something went wrong';
+      return (
+        <div className="flex min-h-[50vh] flex-col items-center justify-center gap-4 p-8 text-center">
+          <h2 className="text-xl font-semibold">Unable to load this page</h2>
+          <p className="text-muted-foreground">{message}</p>
+          <Button onClick={this.handleRetry}>Try again</Button>
+        </div>
+      );
+    }
+
+    return this.props.children;
+  }
+}
+
+export function AuthErrorBoundaryWithReset({ children }: { children: ReactNode }) {
+  return (
+    <QueryErrorResetBoundary>
+      {({ reset }) => <AuthErrorBoundary onReset={reset}>{children}</AuthErrorBoundary>}
+    </QueryErrorResetBoundary>
+  );
+}

--- a/src/components/layouts/AppLayout.tsx
+++ b/src/components/layouts/AppLayout.tsx
@@ -3,6 +3,7 @@ import { AppSidebar } from '@/components/app-sidebar';
 import { SiteHeader } from '@/components/site-header';
 import { SiteFooter } from '@/components/site-footer';
 import { SidebarInset, SidebarProvider } from '@/components/ui/sidebar';
+import { AuthErrorBoundaryWithReset } from '@/components/auth/AuthErrorBoundary';
 
 export function AppLayout() {
   return (
@@ -12,7 +13,9 @@ export function AppLayout() {
         <SiteHeader />
         <div className="flex flex-1 flex-col">
           <div className="@container/main flex flex-1 flex-col gap-2">
-            <Outlet />
+            <AuthErrorBoundaryWithReset>
+              <Outlet />
+            </AuthErrorBoundaryWithReset>
           </div>
           <SiteFooter />
         </div>

--- a/src/components/nav-user.tsx
+++ b/src/components/nav-user.tsx
@@ -1,4 +1,4 @@
-import { LogOutIcon, MoreVerticalIcon, UserCircleIcon, RadioIcon, Settings, Key } from 'lucide-react';
+import { LogOutIcon, MoreVerticalIcon, UserCircleIcon, RadioIcon, Settings, Key, LogInIcon } from 'lucide-react';
 import { Link } from 'react-router-dom';
 
 import { Avatar, AvatarFallback, AvatarImage } from '@/components/ui/avatar';
@@ -17,7 +17,22 @@ import { User } from '@/lib/auth/authService';
 
 export function NavUser({ user }: { user: User | null }) {
   const { isMobile } = useSidebar();
-  const { logout } = useAuth();
+  const { logout, isAuthenticated } = useAuth();
+
+  if (!isAuthenticated) {
+    return (
+      <SidebarMenu>
+        <SidebarMenuItem>
+          <SidebarMenuButton asChild size="lg">
+            <Link to="/login">
+              <LogInIcon className="size-4" />
+              <span>Sign in</span>
+            </Link>
+          </SidebarMenuButton>
+        </SidebarMenuItem>
+      </SidebarMenu>
+    );
+  }
 
   return (
     <SidebarMenu>

--- a/src/lib/api/base.ts
+++ b/src/lib/api/base.ts
@@ -1,12 +1,11 @@
 import axios, { AxiosInstance, AxiosRequestConfig, AxiosResponse } from 'axios';
-import { ApiAuthConfig, ApiConfig, ApiError, NotFoundError, ServerError } from '@/lib/types';
+import { ApiConfig, ApiError, NotFoundError, ServerError } from '@/lib/types';
 import { authService } from '@/lib/auth/authService';
 import { eventService } from '@/lib/events/eventService';
 import { AuthEventType } from '@/lib/auth/authService';
 
 export abstract class BaseApi {
   protected readonly axios: AxiosInstance;
-  private readonly authConfig?: ApiAuthConfig;
   private readonly baseUrl: string;
 
   constructor(config: ApiConfig) {
@@ -26,45 +25,12 @@ export abstract class BaseApi {
       },
     });
 
-    // Store auth config if provided
-    if (config.auth) {
-      this.authConfig = config.auth;
-    }
-
     // Add request interceptor for auth
     this.axios.interceptors.request.use(
       (config) => {
-        // Always check for JWT token first
         const accessToken = authService.getAccessToken();
         if (accessToken) {
           config.headers.Authorization = `Bearer ${accessToken}`;
-          return config;
-        }
-
-        // Fall back to other auth methods if no JWT token
-        if (this.authConfig) {
-          switch (this.authConfig.type) {
-            case 'token':
-              if (this.authConfig.token) {
-                // Updated to use Bearer token for JWT authentication
-                config.headers.Authorization = `Bearer ${this.authConfig.token}`;
-              }
-              break;
-            case 'basic':
-              if (this.authConfig.username && this.authConfig.password) {
-                const credentials = btoa(`${this.authConfig.username}:${this.authConfig.password}`);
-                config.headers.Authorization = `Basic ${credentials}`;
-              }
-              break;
-            case 'apiKey':
-              if (this.authConfig.apiKey && this.authConfig.apiKeyHeader) {
-                config.headers[this.authConfig.apiKeyHeader] = this.authConfig.apiKey;
-              }
-              break;
-            case 'oauth':
-              // OAuth implementation would go here
-              break;
-          }
         }
         return config;
       },

--- a/src/lib/auth/authService.ts
+++ b/src/lib/auth/authService.ts
@@ -293,13 +293,6 @@ export const authService = {
       return null;
     }
 
-    // If we already have user details, return them
-    const storedUser = this.getUserDetails();
-    if (storedUser) {
-      return storedUser;
-    }
-
-    // Otherwise fetch user details from the server
     try {
       return await this.fetchUserDetails(baseUrl);
     } catch (error) {

--- a/src/main.tsx
+++ b/src/main.tsx
@@ -14,7 +14,8 @@ const queryClient = new QueryClient({
       staleTime: 5 * 60 * 1000, // 5 minutes
       refetchOnWindowFocus: false,
       retry: (failureCount, error) => {
-        const status = (error as { response?: { status?: number } })?.response?.status;
+        const status =
+          (error as { status?: number })?.status ?? (error as { response?: { status?: number } })?.response?.status;
 
         // Do not retry on 401 - auth failures should not trigger retries
         if (status === 401) return false;

--- a/src/providers/AuthProvider.tsx
+++ b/src/providers/AuthProvider.tsx
@@ -59,7 +59,7 @@ export function AuthProvider({ children }: AuthProviderProps) {
       const expiresInSec = exp - nowSec;
       const expiresInMs = expiresInSec * 1000;
 
-      if (expiresInMs <= REFRESH_BEFORE_EXPIRY_MS && expiresInMs > 0) {
+      if (expiresInMs <= REFRESH_BEFORE_EXPIRY_MS) {
         try {
           await authService.refreshToken(config.apis.meshBot.baseUrl);
           eventService.emit(AuthEventType.AUTH_TOKEN_REFRESHED);
@@ -79,12 +79,12 @@ export function AuthProvider({ children }: AuthProviderProps) {
   // Sync auth state from authService on mount
   useEffect(() => {
     const checkAuth = async () => {
-      const isAuth = authService.isAuthenticated();
-      setIsAuthenticated(isAuth);
-      setAuthProvider(isAuth ? authService.getAuthProvider() : null);
+      try {
+        const isAuth = authService.isAuthenticated();
+        setIsAuthenticated(isAuth);
+        setAuthProvider(isAuth ? authService.getAuthProvider() : null);
 
-      if (isAuth) {
-        try {
+        if (isAuth) {
           const user = await authService.initializeUser(config.apis.meshBot.baseUrl);
           if (!user) {
             authService.clearTokens();
@@ -93,21 +93,20 @@ export function AuthProvider({ children }: AuthProviderProps) {
             navigate('/login', { state: { reason: 'session_expired' } });
             return;
           }
-        } catch (error) {
-          console.error('Failed to initialize user details:', error);
-          authService.clearTokens();
-          setIsAuthenticated(false);
-          setAuthProvider(null);
-          navigate('/login', { state: { reason: 'session_expired' } });
-          return;
         }
+      } catch (error) {
+        console.error('Failed to initialize user details:', error);
+        authService.clearTokens();
+        setIsAuthenticated(false);
+        setAuthProvider(null);
+        navigate('/login', { state: { reason: 'session_expired' } });
+      } finally {
+        setIsLoading(false);
       }
-
-      setIsLoading(false);
     };
 
     checkAuth();
-  }, [config.apis.meshBot.baseUrl]);
+  }, [config.apis.meshBot.baseUrl, navigate]);
 
   // Register session-expired callback (called by axios interceptor via authService)
   useEffect(() => {
@@ -308,6 +307,7 @@ export function AuthProvider({ children }: AuthProviderProps) {
   // Logout function
   const logout = () => {
     authService.logout();
+    queryClient.clear();
     setIsAuthenticated(false);
     navigate('/login'); // Redirect to login page after logout
   };

--- a/src/providers/AuthProvider.tsx
+++ b/src/providers/AuthProvider.tsx
@@ -112,6 +112,7 @@ export function AuthProvider({ children }: AuthProviderProps) {
   // Register session-expired callback (called by axios interceptor via authService)
   useEffect(() => {
     const unsubscribe = authService.onSessionExpired((params) => {
+      queryClient.clear();
       setIsAuthenticated(false);
       setAuthProvider(null);
       setError(params.message || 'Authentication failed. Please log in again.');
@@ -120,7 +121,7 @@ export function AuthProvider({ children }: AuthProviderProps) {
       });
     });
     return unsubscribe;
-  }, [navigate]);
+  }, [navigate, queryClient]);
 
   // Handle OAuth callback
   useEffect(() => {

--- a/src/test/base-api-auth.test.ts
+++ b/src/test/base-api-auth.test.ts
@@ -1,0 +1,144 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import axios, { AxiosError, InternalAxiosRequestConfig } from 'axios';
+import { BaseApi } from '@/lib/api/base';
+import { authService } from '@/lib/auth/authService';
+import { ApiConfig } from '@/lib/types';
+
+vi.mock('@/lib/auth/authService', () => ({
+  authService: {
+    getAccessToken: vi.fn(),
+    getRefreshToken: vi.fn(),
+    refreshToken: vi.fn(),
+    handleSessionExpired: vi.fn(),
+    onSessionExpired: vi.fn(() => () => {}),
+  },
+  AuthEventType: {
+    AUTH_TOKEN_REFRESHED: 'auth_token_refreshed',
+  },
+}));
+
+vi.mock('@/lib/events/eventService', () => ({
+  eventService: { emit: vi.fn() },
+}));
+
+class TestApi extends BaseApi {
+  ping() {
+    return this.get('/ping');
+  }
+
+  postPing() {
+    return this.post('/ping', {});
+  }
+
+  getAxiosInstance() {
+    return this.axios;
+  }
+}
+
+const apiConfig: ApiConfig = {
+  baseUrl: 'http://localhost:8000',
+  basePath: '/api/ui',
+  timeout: 10000,
+  auth: { type: 'none' },
+};
+
+function installAdapter(
+  instance: ReturnType<TestApi['getAxiosInstance']>,
+  handler: (config: InternalAxiosRequestConfig) => Promise<unknown>
+) {
+  instance.defaults.adapter = async (config) => {
+    try {
+      const result = await handler(config);
+      if (result instanceof Error) {
+        throw result;
+      }
+      return {
+        data: result ?? {},
+        status: 200,
+        statusText: 'OK',
+        headers: {},
+        config,
+      };
+    } catch (error) {
+      if (axios.isAxiosError(error)) {
+        throw error;
+      }
+      throw error;
+    }
+  };
+}
+
+function axios401Error(config: InternalAxiosRequestConfig): AxiosError {
+  return new AxiosError('Unauthorized', 'ERR_BAD_REQUEST', config, undefined, {
+    status: 401,
+    statusText: 'Unauthorized',
+    data: { detail: 'Unauthorized' },
+    headers: {},
+    config,
+  });
+}
+
+describe('BaseApi auth interceptor', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    vi.mocked(authService.getAccessToken).mockReturnValue(null);
+    vi.mocked(authService.getRefreshToken).mockReturnValue(null);
+  });
+
+  it('does not attach Authorization header when no JWT is present', async () => {
+    const api = new TestApi(apiConfig);
+    let capturedAuth: string | undefined;
+
+    installAdapter(api.getAxiosInstance(), async (config) => {
+      capturedAuth = config.headers?.Authorization as string | undefined;
+      return {};
+    });
+
+    await api.ping();
+
+    expect(capturedAuth).toBeUndefined();
+  });
+
+  it('attaches JWT when access token is present', async () => {
+    vi.mocked(authService.getAccessToken).mockReturnValue('jwt-token');
+
+    const api = new TestApi(apiConfig);
+    let capturedAuth: string | undefined;
+
+    installAdapter(api.getAxiosInstance(), async (config) => {
+      capturedAuth = config.headers?.Authorization as string | undefined;
+      return {};
+    });
+
+    await api.ping();
+
+    expect(capturedAuth).toBe('Bearer jwt-token');
+  });
+
+  it('does not expire session for guest GET requests without a token', async () => {
+    const api = new TestApi(apiConfig);
+
+    installAdapter(api.getAxiosInstance(), async (config) => {
+      throw axios401Error(config);
+    });
+
+    await expect(api.ping()).rejects.toMatchObject({ status: 401 });
+    expect(authService.handleSessionExpired).not.toHaveBeenCalled();
+  });
+
+  it('expires session on 401 when an access token is present but refresh is unavailable', async () => {
+    vi.mocked(authService.getAccessToken).mockReturnValue('stale-jwt');
+
+    const api = new TestApi(apiConfig);
+
+    installAdapter(api.getAxiosInstance(), async (config) => {
+      throw axios401Error(config);
+    });
+
+    await expect(api.postPing()).rejects.toMatchObject({ status: 401 });
+    expect(authService.handleSessionExpired).toHaveBeenCalledWith({
+      message: 'Your session has expired. Please log in again.',
+      reason: 'session_expired',
+    });
+  });
+});

--- a/src/test/config.test.ts
+++ b/src/test/config.test.ts
@@ -19,8 +19,7 @@ describe('Config', () => {
         basePath: '/api/ui',
         timeout: 10000,
         auth: {
-          type: 'token',
-          token: 'd9891a1ed5541ae02392b9829cb68267bf68e06c',
+          type: 'none',
         },
         headers: {
           Accept: 'application/json',
@@ -44,8 +43,7 @@ describe('Config', () => {
         baseUrl: 'https://api.example.com',
         timeout: 5000,
         auth: {
-          type: 'token',
-          token: 'new-token',
+          type: 'none',
         },
       },
     },
@@ -131,7 +129,7 @@ describe('Config', () => {
     expect(config.apis.meshBot.baseUrl).toBe('https://api.example.com');
     expect(config.apis.meshBot.basePath).toBe('/api/ui'); // From default
     expect(config.apis.meshBot.timeout).toBe(5000);
-    expect(config.apis.meshBot.auth.token).toBe('new-token');
+    expect(config.apis.meshBot.auth.type).toBe('none');
     expect(config.map.defaultCenter).toEqual([0, 0]); // From default
     expect(config.map.defaultZoom).toBe(5);
     expect(config.refresh.nodesList).toBe(60000);
@@ -158,7 +156,7 @@ describe('Config', () => {
     expect(config.apis.meshBot.baseUrl).toBe('https://api.example.com');
     expect(config.apis.meshBot.basePath).toBe('/api/ui'); // From default
     expect(config.apis.meshBot.timeout).toBe(10000); // From default
-    expect(config.apis.meshBot.auth.token).toBe('d9891a1ed5541ae02392b9829cb68267bf68e06c'); // From default
+    expect(config.apis.meshBot.auth.type).toBe('none'); // From default
     expect(config.map.defaultCenter).toEqual([0, 0]); // From default
     expect(config.map.defaultZoom).toBe(2); // From default
     expect(config.refresh.nodesList).toBe(30000); // From default


### PR DESCRIPTION
## Summary

Fixes auth failure recovery when JWTs are invalidated or stale (#338).

- Remove hardcoded default API token from `config.ts`, Docker entrypoint, and compose — browser requests now use JWT only
- Validate session with the server on boot (no cached-user short-circuit); fix `isLoading` stuck after failed init
- Add `AuthErrorBoundary` so `useSuspenseQuery` 401s show recovery UI instead of a blank page
- Clear React Query cache on session expiry and logout
- Add guest **Sign in** link in sidebar footer (mobile recovery path)
- Register missing `/oauth/callback` route

Closes #338

## Testing performed

- `npm test` — 379 tests pass
- Added `src/test/base-api-auth.test.ts` for JWT-only interceptor and 401 session handling
- Updated `src/test/config.test.ts` for `auth.type: none` defaults